### PR TITLE
DO-49 default buckets minio

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -33,7 +33,7 @@ services:
         echo Waiting for minio service to start...;
         while ! nc -z minio-dev 9000;
         do
-          sleep 1;
+          sleep 5;
         done;
         echo Connected!;
         mc config host add dev-minio http://minio-dev:9000 $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY};

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -19,6 +19,33 @@ services:
     ports:
       - "9000:9000"
 
+  initial-buckets:
+    image: minio/mc
+    depends_on:
+      - minio-dev
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    networks:
+      - xain-fl-dev
+    entrypoint: >
+      /bin/sh -c "
+        echo Waiting for minio service to start...;
+        while ! nc -z minio-dev 9000;
+        do
+          sleep 1;
+        done;
+        echo Connected!;
+        mc config host add dev-minio http://minio-dev:9000 $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY};
+        /usr/bin/mc mb -p dev-minio/xain-fl-temporary-weights;
+        /usr/bin/mc mb -p dev-minio/xain-fl-aggregated-weights;
+        /usr/bin/mc policy set upload dev-minio/xain-fl-temporary-weights;
+        /usr/bin/mc policy set download dev-minio/xain-fl-temporary-weights;
+        /usr/bin/mc policy set upload dev-minio/xain-fl-aggregated-weights;
+        /usr/bin/mc policy set download dev-minio/xain-fl-aggregated-weights;
+        exit 0;
+      "
+
   xain-fl-dev:
     build:
       context: .

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -43,7 +43,7 @@ services:
         /usr/bin/mc policy set download dev-minio/xain-fl-temporary-weights;
         /usr/bin/mc policy set upload dev-minio/xain-fl-aggregated-weights;
         /usr/bin/mc policy set download dev-minio/xain-fl-aggregated-weights;
-        exit 0;
+        /usr/bin/mc admin trace -v -e dev-minio;
       "
 
   xain-fl-dev:


### PR DESCRIPTION
### References

[DO-49](https://xainag.atlassian.net/browse/DO-49)

### Summary

This PR provisions two initial buckets for minio in the dev environment. One for temporary weights from participants, and one for storage of aggregated models

### Are there any open tasks/blockers for the ticket?

No. [With the research done](https://github.com/minio/mc/issues/2497) by @Robert-Steiner  it was confirmed that a timing issue is present thus the timeout was increased to 5 secs 


---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
