### PR TITLE
Xp 373 add sdk as dependency in fl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,13 @@ dev_require = [
     "twine==2.0.0",  # Apache License 2.0
     "wheel==0.33.6",  # MIT
     "typing-extensions==3.7.4.1",  # PSF
-    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.1.0",
 ]
 
 tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.1.0",
 ]
 
 docs_require = ["Sphinx==2.2.1", "m2r==0.2.1", "sphinxcontrib-mermaid==0.3.1"]

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ dev_require = [
     "twine==2.0.0",  # Apache License 2.0
     "wheel==0.33.6",  # MIT
     "typing-extensions==3.7.4.1",  # PSF
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.1.0",
 ]
 
 tests_require = [


### PR DESCRIPTION
### References

[XP-373](https://xainag.atlassian.net/browse/XP-373)

### Summary

Add link to SDK repo inside `setup.py` and reactivates the tests that were disabled both by the comments and by the `@pytest.mark.skip` decorator.

 I had to refactor a bit `test_end_training` test. The refactor addresses two things:
1. renaming variables to make them more readable
2. i changed `np.testing.assert_allclose` to `np.testing.assert_equal` because it was failing with a numpy error. 
**My guess** is that since this test has been skipped for a while, the fact that in the meantime we changed numpy version affected this test. So had this test not been skipped when the numpy version was changed, it would have been picked up back then (just a guess on the reason now it was failing, not a blame). The slight change i made to the test applies a condition that is more restrictive, so i think it's conceptually better than before. Hope it's OK with the reviewers!

### Are there any open tasks/blockers for the ticket?

This should unblock a bunch of tickets, but no blockers for this one.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
