### PR TITLE
XP-308: store aggregated weights in S3 buckets

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -30,20 +30,20 @@ jobs:
 
       - name: black
         run: |
-          black --line-length 100 --check setup.py xain_fl
+          black --line-length 100 --check setup.py xain_fl tests
 
       - name: isort
         run: |
-          isort --check-only --indent=4 -rc setup.py xain_fl
+          isort --check-only --indent=4 -rc setup.py xain_fl tests
 
       - name: pylint
         run: |
-          pylint --rcfile=.pylintrc xain_fl
+          pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
         continue-on-error: true
         run: |
-          mypy xain_fl
+          mypy xain_fl tests
 
       - name: Sphinx check
         env:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,20 +30,20 @@ jobs:
 
       - name: black
         run: |
-          black --line-length 100 --check setup.py xain_fl
+          black --line-length 100 --check setup.py xain_fl tests
 
       - name: isort
         run: |
-          isort --check-only --indent=4 -rc setup.py xain_fl
+          isort --check-only --indent=4 -rc setup.py xain_fl tests
 
       - name: pylint
         run: |
-          pylint --rcfile=.pylintrc xain_fl
+          pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
         continue-on-error: true
         run: |
-          mypy xain_fl
+          mypy xain_fl tests
 
       - name: Sphinx check
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV PORT="50051"
 ENV PATH="/home/${USER}/.local/bin:${PATH}"
 
 RUN addgroup -S ${USER} && adduser -S ${USER} -G ${USER}
-RUN apk update && apk add python3-dev build-base
+RUN apk update && apk add python3-dev build-base git
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ COPY setup.py .
 COPY xain_fl xain_fl/
 COPY README.md .
 
-RUN pip install .
+RUN pip install -v .
 
 # Remove everything, including dot files
 RUN rm -rf ..?* .[!.]* *

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,12 @@
 FROM python:3.6-alpine
 
-RUN apk update && apk add python3-dev build-base
+RUN apk update && apk add python3-dev build-base git
 
 WORKDIR /app
 COPY setup.py .
 COPY xain_fl xain_fl/
 COPY README.md .
 
-RUN pip install -e .[dev]
+RUN pip install -v -e .[dev]
 
 CMD ["python3", "setup.py", "--fullname"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,6 @@ COPY setup.py .
 COPY xain_fl xain_fl/
 COPY README.md .
 
-RUN pip install -v -e .[dev]
+RUN pip install -v -e .
 
 CMD ["python3", "setup.py", "--fullname"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -10,7 +10,8 @@ services:
     environment:
       MINIO_ACCESS_KEY: minio
       MINIO_SECRET_KEY: minio123
-    command: server /data
+    command:
+        server /data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
@@ -47,10 +48,13 @@ services:
       "
 
   xain-fl-dev:
+    environment:
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: coordinator -f test_array.npy
+    command: sh -c "coordinator -f test_array.npy --storage-endpoint http://minio-dev:9000 --storage-key-id $${MINIO_ACCESS_KEY} --storage-secret-access-key $${MINIO_SECRET_KEY} --storage-bucket xain-fl-aggregated-weights"
     volumes:
       #  don't use the local egg-info, if one exists
       - /app/xain_fl.egg-info

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -6,5 +6,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/../
 
 set -x
-isort --indent=4 -rc setup.py xain_fl
-black --line-length 100 setup.py xain_fl
+isort --indent=4 -rc setup.py xain_fl tests
+black --line-length 100 setup.py xain_fl tests

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,16 +5,16 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/../
 
 # sort import
-isort --check-only --indent=4 -rc setup.py xain_fl && echo "===> isort says: well done <===" &&
+isort --check-only --indent=4 -rc setup.py xain_fl tests && echo "===> isort says: well done <===" &&
 
 # format code
-black --line-length 100 --check setup.py xain_fl && echo "===> black says: well done <===" &&
+black --line-length 100 --check setup.py xain_fl tests && echo "===> black says: well done <===" &&
 
 # lint
-pylint --rcfile=.pylintrc xain_fl && echo "===> pylint says: well done <===" &&
+pylint --rcfile=.pylintrc xain_fl tests && echo "===> pylint says: well done <===" &&
 
 # type checks
-mypy xain_fl && echo "===> mypy says: well done <===" &&
+mypy xain_fl tests && echo "===> mypy says: well done <===" &&
 
 # documentation checks
 (cd docs/ && SPHINXOPTS="-W" make docs) && echo "===> sphinx-build says: well done <===" &&

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ install_requires = [
     "structlog==19.2.0",  # Apache License 2.0
     # TODO: change xain-proto requirement to "xain-proto==0.2.0" once it is released
     "xain-proto @ git+https://github.com/xainag/xain-proto.git@0e52b2fd1ceabbcccd443b05e2438a9ce0c65178#egg=xain_proto-0.2.0&subdirectory=python",  # Apache License 2.0
+    "boto3==1.10.48",  # Apache License 2.0
 ]
 
 dev_require = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@ from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.helloproto.numproto_server import NumProtoServer
 
+from .port_forwarding import ConnectionManager
+from .store import TestStore
+
 
 @pytest.fixture
 def greeter_server():
@@ -35,7 +38,8 @@ def coordinator_service():
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     coordinator = Coordinator(minimum_participants_in_round=10, fraction_of_participants=1.0)
-    coordinator_grpc = CoordinatorGrpc(coordinator)
+    store = TestStore()
+    coordinator_grpc = CoordinatorGrpc(coordinator, store)
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
     server.add_insecure_port("localhost:50051")
     server.start()
@@ -59,3 +63,41 @@ def participant_stub():
     yield stub
 
     channel.close()
+
+
+def port_generator():
+    """A generator that yields incrementing port numbers.
+
+    """
+    port = 50052
+    while True:
+        yield port
+        port += 1
+
+
+@pytest.fixture
+def participant_stubs():
+    """Generator that yields functions instantiate participant stubs.
+    Each participant creates a new TCP connection, so that they get a
+    different participant ID.
+
+    """
+
+    ports = port_generator()
+    connections = ConnectionManager()
+    channels = []
+
+    def generate_participant_stubs():
+        for port in ports:
+            connections.start("localhost", port, "localhost", 50051)
+            channel = grpc.insecure_channel(f"localhost:{port}")
+            channels.append(channel)
+            stub = coordinator_pb2_grpc.CoordinatorStub(channel)
+            yield stub
+
+    yield generate_participant_stubs()
+
+    for channel in channels:
+        channel.close()
+
+    connections.stop_all()

--- a/tests/port_forwarding.py
+++ b/tests/port_forwarding.py
@@ -165,6 +165,7 @@ class ConnectionManager:
         terminate_event = Event()
         thread = Thread(
             target=forward,
+            name=f"{host}:{port}<->{target_host}:{target_port}",
             args=(host, port, target_host, target_port, terminate_event),
             daemon=True,
         )
@@ -195,5 +196,10 @@ class ConnectionManager:
             threads.append(thread)
         for thread in threads:
             thread.join(timeout=1)
-            assert not thread.isAlive()
+            # FIXME: sometimes some threads don't terminate in CI, so
+            # we're dumping the stacktraces for all the current
+            # threads for debugging purpose.
+            if thread.isAlive():
+                faulthandler.dump_traceback()
+                raise Exception(f"Thread {thread.name} is still alive")
         self.forwarders = {}

--- a/tests/port_forwarding.py
+++ b/tests/port_forwarding.py
@@ -1,0 +1,199 @@
+"""
+This module provides logic to perform port forwarding. We use this to
+artificially open new TCP connections when creating gRPC clients.
+"""
+from errno import EBADF, ECONNRESET, ENOTCONN
+import faulthandler
+import socket
+from threading import Event, Thread
+
+# Buffer size for reading from a connection
+BUFFER_SIZE = 4096
+
+
+def transfer_worker(src, dst, terminate_event):
+    """A worker that reads data from the `src` socket and forwards it to
+    the `dst` socket.
+
+    Args:
+
+        src (socket.socket): source socket
+        dst (socket.socket): destination socket
+        terminate_event (Event): event used to tell the caller that
+            the `src` socket is closed
+
+    """
+    while True:
+        try:
+            # Block until there's data to read OR the connection
+            # closes.
+            data = src.recv(BUFFER_SIZE)
+        except OSError as exc:
+            if exc.errno in [ECONNRESET, EBADF, ENOTCONN]:
+                terminate_event.set()
+                return
+            raise
+
+        # The socket is closed
+        if not data:
+            terminate_event.set()
+            return
+
+        try:
+            dst.send(data)
+        except OSError as exc:
+            if exc.errno in [ECONNRESET, EBADF, ENOTCONN]:
+                terminate_event.set()
+                return
+            raise
+
+
+def forward(host, port, target_host, target_port, terminate_event):
+    """Set up a TCP socket listening on host:port. Once a connection is
+    established, open a connection to target_host:target_port and
+    forward data both way.
+
+    # Example
+
+    ```python
+    >>> forward("localhost", 8080, "localhost", 80)
+    ```
+
+    has the same effect than:
+
+    ```shell
+    socat tcp-listen:8080,reuseaddr,fork tcp:localhost:80
+    ```
+
+    Args:
+
+        host (str): hostname or ip address for listening
+        port (str): port number for listening
+        target_host (str): hostname of ip address to establish a
+            connection with
+        target_port (str): port number to establish a connection to
+            connection with
+        terminate_event (Event): when this event is set, this function:
+            - closes the sockets it opened
+            - waits for the two `transfer_worker()` threads to finish
+            - returns
+    """
+    # Set up a server socket that will wait for incoming connections
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    # Make the socket non-blocking so that `accept()` doesn't block
+    # forever, and we can periodically check whether the
+    # `terminate_event` is set.
+    server.settimeout(0.1)
+    server.bind((host, port))
+    # Allow only one connection
+    server.listen(1)
+
+    # Block until the first client connects or we're told to terminate
+    while True:
+        try:
+            client_conn, _ = server.accept()
+        except socket.timeout:
+            # Check whether we should terminate
+            if terminate_event.is_set():
+                server.close()
+                return
+        else:
+            break
+
+    # Once the client is connected, open a connection with the target
+    target_conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    target_conn.connect((target_host, target_port))
+
+    # Start transfering data both way
+    tx_thread = Thread(
+        target=transfer_worker,
+        name=f"{target_host}:{target_port}->{host}:{port}",
+        args=(target_conn, client_conn, terminate_event),
+        daemon=True,
+    )
+    rx_thread = Thread(
+        target=transfer_worker,
+        name=f"{host}:{port}->{target_host}:{target_port}",
+        args=(client_conn, target_conn, terminate_event),
+        daemon=True,
+    )
+    tx_thread.start()
+    rx_thread.start()
+
+    # Wait until we're told to terminate (this event can be fired for
+    # the `transfer_worker()` threads, or by the caller.
+    _ = terminate_event.wait()
+
+    # Close all the sockets
+    for sock in [target_conn, client_conn, server]:
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except OSError as exc:
+            if exc.errno not in [ECONNRESET, EBADF, ENOTCONN]:
+                raise
+        sock.close()
+
+    # Wait for the transfer workers to terminate
+    tx_thread.join(timeout=0.2)
+    assert not tx_thread.isAlive()
+    rx_thread.join(timeout=0.2)
+    assert not rx_thread.isAlive()
+
+
+class ConnectionManager:
+    """
+    Manage multiple forwarding workers.
+    """
+
+    def __init__(self):
+        self.forwarders = {}
+
+    def start(self, host, port, target_host, target_port):
+        """Start a new forwarding worker.
+
+        Args:
+
+            host (str): hostname or ip address for listening
+            port (str): port number for listening
+            target_host (str): hostname of ip address to establish a
+                connection with
+            target_port (str): port number to establish a connection
+                to connection with
+
+        """
+        terminate_event = Event()
+        thread = Thread(
+            target=forward,
+            args=(host, port, target_host, target_port, terminate_event),
+            daemon=True,
+        )
+        thread.start()
+        self.forwarders[(host, port)] = (terminate_event, thread)
+
+    def stop(self, host, port):
+        """Stop the forwarding worker listening on the given host and port
+
+        Args:
+            host (str): hostname or ip address the worker is listening
+                on
+            port (str): port number the worker is listening on
+
+        """
+        terminate_event, thread = self.forwarders.pop((host, port))
+        terminate_event.set()
+        thread.join(timeout=5)
+
+    def stop_all(self):
+        """
+        Stop all the forwarding workers
+        """
+        threads = []
+        for (host, port) in self.forwarders:
+            terminate_event, thread = self.forwarders[(host, port)]
+            terminate_event.set()
+            threads.append(thread)
+        for thread in threads:
+            thread.join(timeout=1)
+            assert not thread.isAlive()
+        self.forwarders = {}

--- a/tests/store.py
+++ b/tests/store.py
@@ -1,0 +1,101 @@
+"""This module provide a subclass of
+`xain_fl.coordinator.store.Store` that stores data in memory.
+"""
+from collections import defaultdict
+import pickle
+import typing
+
+import numpy as np
+
+from xain_fl.coordinator.store import Store, StoreConfig
+
+
+class FakeS3Resource:
+    """Mock of the `xain-fl.coordinator.Store.s3` attribute.
+
+    This class offers the same API than `boto3.S3.Client.bucket` but
+    writes data in memory and keeps track of the reads and writes.
+    """
+
+    def __init__(self):
+        # fake store where data gets written to
+        self.fake_store = {}
+        # count the writes for each key in the store
+        self.writes = defaultdict(lambda: 0)
+        # count the reads for each key in the store
+        self.reads = defaultdict(lambda: 0)
+
+    # The names come from the `boto3` API we're mocking
+    # pylint: disable=invalid-name
+    def Bucket(self, _name: str):
+        """Mock of the `boto3.S3.Client.Bucket` method.
+
+        Args:
+            _name (str): name of the bucket (un-used)
+        """
+        return self
+
+    # The names come from the `boto3` API we're mocking
+    # pylint: disable=invalid-name
+    def put_object(self, Body: bytes, Key: str):
+        """Mock of the `boto3.S3.Client.put_object` method.
+
+        Args:
+            Body (bytes): data to write to the bucket
+            Key (str): key under which the data should be stored
+        """
+        # We store the data non-serialized, to make it easier to
+        # check it.
+        self.fake_store[Key] = pickle.loads(Body)
+        self.writes[Key] += 1
+
+    def download_fileobj(self, key: str, buf: typing.IO):
+        """Mock of the `boto3.S3.Client.download_fileobj` method.
+
+        Args:
+            key (str): key under which the data to retrieve is stored
+            buf (bytes of file-like object): buffer for writing the data
+        """
+        data = pickle.dumps(self.fake_store[key])
+        buf.write(data)
+        self.reads[key] += 1
+
+
+class TestStore(Store):
+    """A partial mock of the `xain-fl.coordinator.store.Store` class that
+    does not perform any IO. Instead, data is stored in memory.
+    """
+
+    # We DO NOT want to call the parent class __init__, since it tries
+    # to initialize a connection to a non-existent external resource
+    #
+    # pylint: disable=super-init-not-called
+    def __init__(self):
+        self.config = StoreConfig("endpoint_url", "access_key_id", "secret_access_key", "bucket")
+        self.s3 = FakeS3Resource()
+
+    def assert_wrote(self, round: int, weights: np.ndarray):
+        """Check that the given weights have been written to the store for the
+given round.
+
+        Args:
+            weights (np.ndarray): weights to store
+            round (int): round to which the weights belong
+        """
+        writes = self.s3.writes[str(round)]
+        # Under normal conditions, we should write data exactly once
+        assert writes == 1, f"got {writes} writes for round {round}, expected 1"
+        # If the arrays contains `NaN` we cannot compare them, so we
+        # replace them by zeros to do the comparison
+        stored_array = np.nan_to_num(self.s3.fake_store[str(round)])
+        expected_array = np.nan_to_num(weights)
+        assert np.array_equal(stored_array, expected_array)
+
+    def assert_didnt_write(self, round: int):
+        """Check that the weights for the given round have NOT been written to the store.
+
+        Args:
+            round (int): round to which the weights belong
+
+        """
+        assert self.s3.writes[str(round)] == 0

--- a/xain_fl/cli.py
+++ b/xain_fl/cli.py
@@ -8,6 +8,7 @@ import argparse
 import numpy as np
 
 from xain_fl.coordinator.coordinator import Coordinator
+from xain_fl.coordinator.store import Store, StoreConfig
 from xain_fl.serve import serve
 
 
@@ -178,6 +179,30 @@ def get_cmd_parameters():
             A float between 0 and 1",
     )
 
+    parser.add_argument(
+        "--storage-endpoint", required=True, type=str, help="URL to the storage service to use",
+    )
+
+    parser.add_argument(
+        "--storage-bucket",
+        required=True,
+        type=str,
+        help="Name of the bucket for storing the aggregated models",
+    )
+
+    parser.add_argument(
+        "--storage-key-id",
+        required=True,
+        type=str,
+        help="AWS access key ID to use to authenticate to the storage service",
+    )
+
+    parser.add_argument(
+        "--storage-secret-access-key",
+        required=True,
+        type=str,
+        help="AWS secret access to use to authenticate to the storage service",
+    )
     return parser.parse_args()
 
 
@@ -197,7 +222,15 @@ def main():
         fraction_of_participants=parameters.fraction,
     )
 
-    serve(coordinator=coordinator, host=parameters.host, port=parameters.port)
+    store_config = StoreConfig(
+        parameters.storage_endpoint,
+        parameters.storage_key_id,
+        parameters.storage_secret_access_key,
+        parameters.storage_bucket,
+    )
+    store = Store(store_config)
+
+    serve(coordinator=coordinator, store=store, host=parameters.host, port=parameters.port)
 
 
 if __name__ == "__main__":

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -280,7 +280,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         weights_proto = [ndarray_to_proto(nda) for nda in self.weights]
 
         return coordinator_pb2.StartTrainingReply(
-            weights=weights_proto, epochs=self.epochs, epoch_base=self.epoch_base
+            weights=weights_proto, epochs=self.epochs, epoch_base=self.epoch_base,
         )
 
     def _handle_end_training(

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -1,0 +1,43 @@
+# pylint: disable=missing-docstring
+from io import BytesIO
+import pickle
+
+import boto3
+from numpy import ndarray
+
+
+# pylint: disable=too-few-public-methods
+class StoreConfig:
+    def __init__(
+        self, endpoint_url: str, access_key_id: str, secret_access_key: str, bucket: str,
+    ):
+        self.endpoint_url = endpoint_url
+        self.access_key_id = access_key_id
+        self.secret_access_key = secret_access_key
+        self.bucket = bucket
+
+
+class Store:
+    def __init__(self, config: StoreConfig):
+        self.config = config
+        # pylint: disable=invalid-name
+        self.s3 = boto3.resource(
+            "s3",
+            endpoint_url=self.config.endpoint_url,
+            aws_access_key_id=self.config.access_key_id,
+            aws_secret_access_key=self.config.secret_access_key,
+            # FIXME: not sure what this should be for now
+            region_name="dummy",
+        )
+
+    def write_weights(self, round: int, weights: ndarray):
+        bucket = self.s3.Bucket(self.config.bucket)
+        bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
+
+    def read_weights(self, round: int) -> ndarray:
+        bucket = self.s3.Bucket(self.config.bucket)
+        data = BytesIO()
+        bucket.download_fileobj(str(round), data)
+        # FIXME: not sure whether getvalue() copies the data. If so we
+        # should probably prefer getbuffer() instead.
+        return pickle.loads(data.getvalue())

--- a/xain_fl/serve.py
+++ b/xain_fl/serve.py
@@ -11,12 +11,13 @@ from xain_fl.coordinator import _ONE_DAY_IN_SECONDS
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
+from xain_fl.coordinator.store import Store
 from xain_fl.logger import StructLogger, get_logger
 
 logger: StructLogger = get_logger(__name__)
 
 
-def serve(coordinator: Coordinator, host: str = "[::]", port: int = 50051) -> None:
+def serve(coordinator: Coordinator, store: Store, host: str = "[::]", port: int = 50051) -> None:
     """Main method to start the gRPC service.
 
     This methods just creates the :class:`xain_fl.coordinator.coordinator.Coordinator`,
@@ -28,7 +29,9 @@ def serve(coordinator: Coordinator, host: str = "[::]", port: int = 50051) -> No
     )
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(CoordinatorGrpc(coordinator), server)
+    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(
+        CoordinatorGrpc(coordinator, store), server
+    )
     server.add_insecure_port(f"{host}:{port}")
     server.start()
     monitor_thread.start()


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/XP-40
https://xainag.atlassian.net/browse/XP-308
https://xainag.atlassian.net/browse/XP-309
https://xainag.atlassian.net/browse/XP-311

## `xain-fl` changes

This commits adds a new module `xain-fl.coordinator.store`, which
contains a `Store()` class that can read from and write to S3
buckets. At the end of each round, the aggregated weights are uploaded
to an S3 bucket. Note that as a first step, the aggregated weights are
still sent to the participants via gRPC.

##### Implementation notes:

We're trying to not have IO related code in the Coordinator class, so
the Store instance is held by the CoordinatorGrpc instead of
Coordinator. However, since the Coordinator is currently generating
the grpc messages, which are inherently coupled to the IO logic. This
means that if at some point the messages need to contain information
related to storage, we'll end up with storage logic in the
Coordinator, and things might become pretty messy. Thus, we should
already start thinking about refactoring xain-fl.coordinator such that
the state machine is completely decoupled for the IO logic.

## Tests changes

In order to test the store, we needed to go through a valid round, since weights are only stored at the end of a round after the weights have been aggregated. This was initially not possible because in the unit tests, all the participant stubs used the same TCP connection, so they were all identified by the coordinator as the same participant. To work around this, we implemented a simple TCP port forwarding mechanism so that we can create a new TCP connection for each stub.

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
