### PR TITLE
XP-422 ai metrics

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
-    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.1.0",
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.2.0",
 ]
 
 docs_require = ["Sphinx==2.2.1", "m2r==0.2.1", "sphinxcontrib-mermaid==0.3.1"]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ install_requires = [
     "grpcio==1.23",  # Apache License 2.0
     "numproto==0.3",  # Apache License 2.0
     "structlog==19.2.0",  # Apache License 2.0
-    "xain-proto==0.1.0",  # Apache License 2.0
+    # TODO: change xain-proto requirement to "xain-proto==0.2.0" once it is released
+    "xain-proto @ git+https://github.com/xainag/xain-proto.git@0e52b2fd1ceabbcccd443b05e2438a9ce0c65178#egg=xain_proto-0.2.0&subdirectory=python",  # Apache License 2.0
 ]
 
 dev_require = [

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -137,9 +137,9 @@ def test_heartbeat_denied(participant_stub, coordinator_service):  # pylint: dis
         assert reply.status_code == grpc.StatusCode.PERMISSION_DENIED
 
 
-@mock.patch("threading.Event.is_set", side_effect=[False, True])
-@mock.patch("time.sleep", return_value=None)
-@mock.patch("xain_fl.coordinator.coordinator.Coordinator.remove_participant")
+@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True])
+@mock.patch("xain_fl.coordinator.heartbeat.time.sleep", return_value=None)
+@mock.patch("xain_fl.coordinator.heartbeat.Coordinator.remove_participant")
 def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
     """[summary]
 
@@ -164,8 +164,8 @@ def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
     mock_participants_remove.assert_called_once_with("participant_1")
 
 
-@mock.patch("threading.Event.is_set", side_effect=[False, True])
-@mock.patch("time.sleep", return_value=None)
+@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True])
+@mock.patch("xain_fl.coordinator.heartbeat.time.sleep", return_value=None)
 def test_monitor_heartbeats_remove_participant(_mock_sleep, _mock_event):
     """[summary]
 
@@ -189,9 +189,11 @@ def test_monitor_heartbeats_remove_participant(_mock_sleep, _mock_event):
     assert participants.len() == 0
 
 
-@mock.patch("threading.Event.is_set", side_effect=[False, False, True])
-@mock.patch("time.sleep", return_value=None)
-@mock.patch("xain_proto.fl.coordinator_pb2.HeartbeatRequest")
+@mock.patch(
+    "xain_sdk.participant_state_machine.threading.Event.is_set", side_effect=[False, False, True]
+)
+@mock.patch("xain_sdk.participant_state_machine.time.sleep", return_value=None)
+@mock.patch("xain_sdk.participant_state_machine.HeartbeatRequest")
 def test_message_loop(mock_heartbeat_request, _mock_sleep, _mock_event):
     """[summary]
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -15,6 +15,10 @@ from xain_proto.fl import (
     hellonumproto_pb2_grpc,
 )
 
+from xain_fl.coordinator.coordinator import Coordinator
+from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
+from xain_fl.coordinator.heartbeat import monitor_heartbeats
+from xain_fl.coordinator.participants import Participants
 from xain_sdk.participant_state_machine import (
     StateRecord,
     end_training,
@@ -22,11 +26,6 @@ from xain_sdk.participant_state_machine import (
     rendezvous,
     start_training,
 )
-
-from xain_fl.coordinator.coordinator import Coordinator
-from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
-from xain_fl.coordinator.heartbeat import monitor_heartbeats
-from xain_fl.coordinator.participants import Participants
 
 
 @pytest.mark.integration
@@ -304,7 +303,7 @@ def test_end_training(coordinator_service):
 
     # simulate trained local model data
     test_weights, number_samples = [np.arange(20, 30), np.arange(30, 40)], 2
-    test_metrics = {"metric": [np.arange(10, 20), np.arange(5, 10)]}
+    test_metrics = {"metric": np.arange(10, 20)}
 
     with grpc.insecure_channel("localhost:50051") as channel:
         # we first need to rendezvous before we can send any other request

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -297,20 +297,13 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         # TODO: Ideally we want to know for which round the participant is
         # submitting the updates and raise an exception if it is the wrong
         # round.
-        weights_proto, number_samples, metrics_proto = (
-            message.weights,
-            message.number_samples,
-            message.metrics,
-        )
 
         # record the request data
         weight_update: Tuple[List[ndarray], int] = (
-            [proto_to_ndarray(pnda) for pnda in weights_proto],
-            number_samples,
+            [proto_to_ndarray(pnda) for pnda in message.weights],
+            message.number_samples,
         )
-        metrics: Dict[str, List[ndarray]] = {
-            k: [proto_to_ndarray(v) for v in mv.metrics] for k, mv in metrics_proto.items()
-        }
+        metrics: Dict[str, ndarray] = {k: proto_to_ndarray(v) for k, v in message.metrics.items()}
         self.round.add_updates(participant_id, weight_update, metrics)
 
         # The round is over. Run the aggregation

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -26,7 +26,7 @@ class Round:
         self,
         participant_id: str,
         weight_update: Tuple[List[ndarray], int],
-        metrics: Dict[str, List[ndarray]],
+        metrics: Dict[str, ndarray],
     ) -> None:
         """Valid a participant's update for the round.
 


### PR DESCRIPTION
### References

- [XP-422](https://xainag.atlassian.net/browse/XP-422)

### Summary

- update the coordinator state machine to use the new ai metrics object
- fix mocking destinations for the tests

### Are there any open tasks/blockers for the ticket?

- note that these changes are interdependent with the merge requests of [xain-sdk](https://github.com/xainag/xain-sdk/pull/28) and [xain-proto](https://github.com/xainag/xain-proto/pull/3) and need to be merged simultaneously to avoid breaking stuff

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
