### PR TITLE
XP-119 Fix gRPC testing setup so that it can run on macOS

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,4 +56,6 @@ def participant_stub():
     channel = grpc.insecure_channel("localhost:50051")
     stub = coordinator_pb2_grpc.CoordinatorStub(channel)
 
-    return stub
+    yield stub
+
+    channel.close()

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -30,17 +30,6 @@ from xain_fl.coordinator.heartbeat import monitor_heartbeats
 from xain_fl.coordinator.participants import Participants
 
 
-# TODO: it should be fixed with: https://xainag.atlassian.net/browse/XP-119
-# Some grpc tests fail on macos.
-# `pytestmark` when defined on a module will mark all tests in that module.
-# For more information check
-# http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
-if sys.platform == "darwin":
-    pytestmark = pytest.mark.xfail(  # pylint: disable=invalid-name
-        reason="some grpc tests fail on macos"
-    )
-
-
 @pytest.mark.integration
 def test_greeter_server(greeter_server):  # pylint: disable=unused-argument
     """[summary]

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -1,7 +1,6 @@
 """XAIN FL tests for gRPC coordinator"""
 
 from concurrent import futures
-import sys
 import threading
 from unittest import mock
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -70,7 +70,6 @@ def test_participant_rendezvous_accept(  # pylint: disable=unused-argument
     assert reply.response == coordinator_pb2.RendezvousResponse.ACCEPT
 
 
-# TODO(XP-119): Fix test so it also runs correctly on macos
 @pytest.mark.integration
 def test_participant_rendezvous_later(participant_stub):
     """[summary]


### PR DESCRIPTION
### References

[XP-119 Fix gRPC testing setup so that it can run on macos](https://xainag.atlassian.net/browse/XP-119)

### Summary

* close channel after each test

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
