### PR TITLE
XP-333 Replace numproto with xain-proto

### DIFF
--- a/docs/network_architecture.rst
+++ b/docs/network_architecture.rst
@@ -99,8 +99,8 @@ models after they finished their training task.
 In order to remain agnostic to the machine learning framework *Participants*
 and *Coordinator* exchange models in the form of numpy arrays. How models are
 converted from a particular machine learning framework model into numpy arrays
-are outside the scope of this document. We do provide the `Numproto
-<https://github.com/xainag/numproto>`_ python package that performs
+are outside the scope of this document. We do provide the `xain-proto
+<https://github.com/xainag/xain-proto>`_ python package that performs
 serialization and deserialization of numpy arrays into and from protobuf.
 
 
@@ -350,15 +350,15 @@ where the request and response data are given as the following protobuf messages
    message StartTrainingRoundRequest {}
 
    message StartTrainingRoundResponse {
-       repeated numproto.protobuf.NDArray weights = 1;
+       repeated xain_proto.numproto.NDArray weights = 1;
        int32 epochs = 2;
        int32 epoch_base = 3;
    }
 
    message EndTrainingRoundRequest {
-       repeated numproto.protobuf.NDArray weights = 1;
+       repeated xain_proto.numproto.NDArray weights = 1;
        int32 number_samples = 2;
-       map<string, numproto.protobuf.NDArray> metrics = 3;
+       map<string, xain_proto.numproto.NDArray> metrics = 3;
    }
 
    message EndTrainingRoundResponse {}
@@ -366,8 +366,9 @@ where the request and response data are given as the following protobuf messages
 
 Note that while most of the Python data types to be exchanged can be
 "protobuf-erized" (and back), :code:`ndarray` requires more work. Fortunately we
-have the `numproto <https://github.com/xainag/numproto>`_ project to help with
-this conversion.
+have the 
+`xain_proto/numproto <https://github.com/xainag/xain-proto/tree/master/python/xain_proto/numproto>`_
+project to help with this conversion.
 
 Training Round Communication
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,9 @@ with open(readme_file_path, "r") as fp:
 
 
 # License comments according to `pip-licenses`
-
 install_requires = [
     "numpy==1.15",  # BSD
     "grpcio==1.23",  # Apache License 2.0
-    "numproto==0.3",  # Apache License 2.0
     "structlog==19.2.0",  # Apache License 2.0
     # TODO: change xain-proto requirement to "xain-proto==0.2.0" once it is released
     "xain-proto @ git+https://github.com/xainag/xain-proto.git@c78e86584c205fb56b5c1f03f052e0b623dcd25d#egg=xain_proto-0.1.0&subdirectory=python",  # Apache License 2.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open(readme_file_path, "r") as fp:
 
 
 # License comments according to `pip-licenses`
+
 install_requires = [
     "numpy==1.15",  # BSD
     "grpcio==1.23",  # Apache License 2.0

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
     "grpcio==1.23",  # Apache License 2.0
     "structlog==19.2.0",  # Apache License 2.0
     # TODO: change xain-proto requirement to "xain-proto==0.2.0" once it is released
-    "xain-proto @ git+https://github.com/xainag/xain-proto.git@c78e86584c205fb56b5c1f03f052e0b623dcd25d#egg=xain_proto-0.1.0&subdirectory=python",  # Apache License 2.0
+    "xain-proto @ git+https://github.com/xainag/xain-proto.git@37fc05566da91d263c37d203c0ba70804960be9b#egg=xain_proto-0.1.0&subdirectory=python",  # Apache License 2.0
     "boto3==1.10.48",  # Apache License 2.0
 ]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,1 @@
 """XAIN FL tests"""
-
-import os
-
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,5 @@
 """XAIN FL tests for coordinator"""
 
-from numproto import proto_to_ndarray
 import numpy as np
 import pytest
 from xain_proto.fl.coordinator_pb2 import (
@@ -12,6 +11,7 @@ from xain_proto.fl.coordinator_pb2 import (
     StartTrainingRoundRequest,
     State,
 )
+from xain_proto.numproto import proto_to_ndarray
 
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.tools.exceptions import (

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -5,7 +5,6 @@ import threading
 from unittest import mock
 
 import grpc
-from numproto import ndarray_to_proto, proto_to_ndarray
 import numpy as np
 import pytest
 from xain_proto.fl.coordinator_pb2 import (
@@ -22,6 +21,7 @@ from xain_proto.fl.coordinator_pb2 import (
 from xain_proto.fl.coordinator_pb2_grpc import add_CoordinatorServicer_to_server
 from xain_proto.fl.hellonumproto_pb2 import NumProtoRequest
 from xain_proto.fl.hellonumproto_pb2_grpc import NumProtoServerStub
+from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 from xain_sdk.participant_state_machine import (
     StateRecord,
     end_training_round,

--- a/xain_fl/__init__.py
+++ b/xain_fl/__init__.py
@@ -1,5 +1,1 @@
 """XAIN FL init"""
-
-import os
-
-os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -3,7 +3,6 @@
 from typing import Dict, List, Optional, Tuple
 
 from google.protobuf.internal.python_message import GeneratedProtocolMessageType
-from numproto import ndarray_to_proto, proto_to_ndarray
 from numpy import ndarray
 from xain_proto.fl.coordinator_pb2 import (
     EndTrainingRoundRequest,
@@ -17,6 +16,7 @@ from xain_proto.fl.coordinator_pb2 import (
     StartTrainingRoundResponse,
     State,
 )
+from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round

--- a/xain_fl/helloproto/numproto_client.py
+++ b/xain_fl/helloproto/numproto_client.py
@@ -1,9 +1,9 @@
 """XAIN FL numproto client"""
 
 import grpc
-from numproto import ndarray_to_proto, proto_to_ndarray
 import numpy as np
 from xain_proto.fl import hellonumproto_pb2, hellonumproto_pb2_grpc
+from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.logger import StructLogger, get_logger
 

--- a/xain_fl/helloproto/numproto_server.py
+++ b/xain_fl/helloproto/numproto_server.py
@@ -4,8 +4,8 @@ from concurrent import futures
 import time
 
 import grpc
-from numproto import ndarray_to_proto, proto_to_ndarray
 from xain_proto.fl import hellonumproto_pb2, hellonumproto_pb2_grpc
+from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator import _ONE_DAY_IN_SECONDS
 from xain_fl.logger import StructLogger, get_logger


### PR DESCRIPTION
### References

[XP-333-Protocol Buffer - Couldn't build proto file at starting of participant](https://xainag.atlassian.net/browse/XP-333)

### Summary

* Replaced `numproto` with `xain-proto`

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
