### PR TITLE
XP-505: docstrings cleanup

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinxcontrib.mermaid",
     "sphinx.ext.todo",
+    "sphinx_autodoc_typehints",
 ]
 
 source_suffix = {".rst": "restructuredtext", ".md": "markdown"}

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,12 @@ tests_require = [
     "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.1.0",
 ]
 
-docs_require = ["Sphinx==2.2.1", "m2r==0.2.1", "sphinxcontrib-mermaid==0.3.1"]
+docs_require = [
+    "Sphinx==2.2.1",
+    "m2r==0.2.1",
+    "sphinxcontrib-mermaid==0.3.1",
+    "sphinx-autodoc-typehints==1.10.3",  # MIT
+]
 
 setup(
     name="xain_fl",


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/XP-505

### Summary

This fixes two issues:

- make the docstrings more readable by having symbols types automatically inferred by sphinx
- have working links to symbols types in the generated documentation

I will split this task in multiple pull request to minimize the risk of conflicts, since this affects the entire codebase.

Optional: Next Step

Clean up other modules
---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
