### PR TITLE
XP-479 Start training rounds from 0

### DIFF
--- a/tests/store.py
+++ b/tests/store.py
@@ -82,7 +82,7 @@ given round.
             weights (np.ndarray): weights to store
             round (int): round to which the weights belong
         """
-        writes = self.s3.writes[str(round)]
+        writes = self.s3.writes[str(round + 1)]
         # Under normal conditions, we should write data exactly once
         assert writes == 1, f"got {writes} writes for round {round}, expected 1"
         # If the arrays contains `NaN` we cannot compare them, so we

--- a/tests/store.py
+++ b/tests/store.py
@@ -82,9 +82,9 @@ given round.
             weights (np.ndarray): weights to store
             round (int): round to which the weights belong
         """
-        writes = self.s3.writes[str(round + 1)]
+        writes = self.s3.writes[str(round)]
         # Under normal conditions, we should write data exactly once
-        assert writes == 1, f"got {writes} writes for round {round}, expected 1"
+        assert writes == 0, f"got {writes} writes for round {round}, expected 0"
         # If the arrays contains `NaN` we cannot compare them, so we
         # replace them by zeros to do the comparison
         stored_array = np.nan_to_num(self.s3.fake_store[str(round)])

--- a/tests/store.py
+++ b/tests/store.py
@@ -84,7 +84,7 @@ given round.
         """
         writes = self.s3.writes[str(round)]
         # Under normal conditions, we should write data exactly once
-        assert writes == 0, f"got {writes} writes for round {round}, expected 0"
+        assert writes == 1, f"got {writes} writes for round {round}, expected 1"
         # If the arrays contains `NaN` we cannot compare them, so we
         # replace them by zeros to do the comparison
         stored_array = np.nan_to_num(self.s3.fake_store[str(round)])

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -89,7 +89,7 @@ def test_coordinator_state_standby_round():
     coordinator.on_message(RendezvousRequest(), "participant1")
 
     assert coordinator.state == State.ROUND
-    assert coordinator.current_round == 1
+    assert coordinator.current_round == 0
 
 
 def test_start_training_round():
@@ -156,16 +156,16 @@ def test_end_training_round_update():
     coordinator.on_message(RendezvousRequest(), "participant1")
     coordinator.on_message(RendezvousRequest(), "participant2")
 
-    # check that we are currently in round 1
-    assert coordinator.current_round == 1
+    # check that we are currently in round 0
+    assert coordinator.current_round == 0
 
     coordinator.on_message(EndTrainingRoundRequest(), "participant1")
-    # check we are still in round 1
-    assert coordinator.current_round == 1
+    # check we are still in round 0
+    assert coordinator.current_round == 0
     coordinator.on_message(EndTrainingRoundRequest(), "participant2")
 
     # check that round number was updated
-    assert coordinator.current_round == 2
+    assert coordinator.current_round == 1
 
 
 def test_end_training_round_reinitialize_local_models():

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -410,21 +410,21 @@ def test_full_training_round(
     assert coordinator_service.coordinator.state == State.STANDBY
     assert coordinator_service.coordinator.current_round == 0
 
-    # The 10th participant connect, so the coordinator switches to ROUND>
+    # The 10th participant connects, so the coordinator switches to ROUND
     last_participant = participants[-1]
     response = last_participant.Rendezvous(RendezvousRequest())
     assert response.reply == RendezvousReply.ACCEPT
 
     assert coordinator_service.coordinator.state == State.ROUND
-    assert coordinator_service.coordinator.current_round == 1
+    assert coordinator_service.coordinator.current_round == 0
 
     response = last_participant.Heartbeat(HeartbeatRequest())
-    assert response == HeartbeatResponse(state=State.ROUND, round=1)
+    assert response == HeartbeatResponse(state=State.ROUND, round=0)
 
-    # The initial 9 participants send another heatbeat request.
+    # The initial 9 participants send another heartbeat request.
     for participant in participants[:-1]:
         response = participant.Heartbeat(HeartbeatRequest(state=State.STANDBY, round=0))
-    assert response == HeartbeatResponse(state=State.ROUND, round=1)
+    assert response == HeartbeatResponse(state=State.ROUND, round=0)
 
     # The participants start training
     for participant in participants:
@@ -435,7 +435,7 @@ def test_full_training_round(
             epoch_base=coordinator_service.coordinator.epoch_base,
         )
 
-    # The first 9th participants end training
+    # The first 9 participants end training
     for participant in participants[:-1]:
         response = participant.EndTrainingRound(
             EndTrainingRoundRequest(weights=weights_proto, number_samples=1)
@@ -476,9 +476,9 @@ def test_start_participant(mock_coordinator_service):
         coord = mock_coordinator_service.coordinator
         assert coord.state == State.FINISHED
 
-        # coordinator set to 2 round for good measure, but the resulting
+        # coordinator set to 2 rounds for good measure, but the resulting
         # aggregated weights are the same as a single round
-        assert coord.current_round == 2
+        assert coord.current_round == 1
 
         # expect weight aggregated by summation - see mock_coordinator_service
         np.testing.assert_equal(coord.weights, [np.arange(start=10, stop=29, step=2)])

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -449,7 +449,7 @@ def test_full_training_round(
     response = last_participant.EndTrainingRound(EndTrainingRoundRequest())
     assert response == EndTrainingRoundResponse()
     # Make sure we wrote the results for the given round
-    coordinator_service.store.assert_wrote(1, coordinator_service.coordinator.weights)
+    coordinator_service.store.assert_wrote(0, coordinator_service.coordinator.weights)
 
 
 @pytest.mark.integration

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -45,8 +45,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
           the important messages the coordinator can receive are
           :class:`~.coordinator_pb2.StartTrainingRoundRequest` and
           :class:`~.coordinator_pb2.EndTrainingRoundRequest`.  Since
-          participants are selected for rounds or not, they can be
-          advertised either ROUND or STANDBY accordingly.
+          participants may or may not be selected for rounds, they can be
+          advertised accordingly with ROUND or STANDBY respectively.
+          Round numbers start from 0.
 
         - ``FINISHED``: The training session has ended and
           participants should disconnect from the coordinator.
@@ -57,7 +58,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
     The flow of the Coordinator:
 
         1. The coordinator is started and waits for enough participants to join. `STANDBY`.
-        2. Once enough participants are connected the coordinator starts the rounds. `ROUND N`.
+        2. Once enough participants are connected the coordinator starts the rounds. `ROUND`.
         3. Repeat step 2. for the given number of rounds
         4. The training session is over and the coordinator is ready to shutdown. `FINISHED`.
 
@@ -68,10 +69,10 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     Args:
 
-        num_rounds: The number of rounds of the training session
+        num_rounds: The number of rounds of the training session.
 
         minimum_participants_in_round: The minimum number of
-            participants that participate in a round
+            participants that participate in a round.
 
         fraction_of_participants: The fraction of total connected
             participants to be selected in a single round. Defaults to
@@ -90,6 +91,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         controller: Controls how the Participants are selected at the
             start of each round. Defaults to
             :class:`~.RandomController`.
+
     """
 
     DEFAULT_AGGREGATOR: Aggregator = FederatedAveragingAgg()
@@ -365,7 +367,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             self.weights = self.aggregator.aggregate(self.round.get_weight_updates())
 
             # update the round or finish the training session
-            if self.current_round == self.num_rounds:
+            if self.current_round >= self.num_rounds - 1:
                 logger.debug("Last round over", round=self.current_round)
                 self.state = State.FINISHED
             else:

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -257,9 +257,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             if self.participants.len() == self.minimum_connected_participants:
                 self.select_participant_ids_and_init_round()
 
-                # TODO: We may need to make this update thread safe
                 self.state = State.ROUND
-                self.current_round = 1 if self.current_round == 0 else self.current_round
         else:
             reply = RendezvousReply.LATER
             logger.info(


### PR DESCRIPTION
### References

[XP-404](https://xainag.atlassian.net/browse/XP-404) (specifically [XP-479](https://xainag.atlassian.net/browse/XP-479))

### Summary

This lays the groundwork for supporting weights initialisation in the Participant. Currently, the Coordinator is responsible for providing the initial weights to its participants for training, but it would be more desirable for this to be generated by the participants themselves.

For this, we adopt a new convention of enumerating rounds from **0** where the 0th round is usually intended to be for initialisation purposes but (for sake of simplicity and uniformity) is conceptually no different from any other round i.e. it still follows the same `StartTrainingRound`-`EndTrainingRound` communication:

- In `StartTrainingRound`, empty weights are distributed to participants.
- In `EndTrainingRound`, each participant uploads its share of initialised weights.

Thus the global initial weights for round 1 are the result of aggregating the shares from round 0.

Note that as a result of this change,

- `0 <= current_round < num_rounds`

### Are there any open tasks/blockers for the ticket?

- see also the related ticket [XP-381](https://xainag.atlassian.net/browse/XP-381)

<!-- ### Optional: Next Step -->

<!-- (If there are any open tasks/blockers, what is the next step) -->

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
