### PR TITLE
XP-510 allow zero epochs

### DIFF
--- a/xain_fl/cli.py
+++ b/xain_fl/cli.py
@@ -57,7 +57,7 @@ def type_num_epochs(value):
 
     ivalue = int(value)
 
-    if ivalue <= 0:
+    if ivalue < 0:
         raise argparse.ArgumentTypeError("%s is an invalid positive int value" % value)
 
     if ivalue > 10_000:


### PR DESCRIPTION
### References

- [XP-510](https://xainag.atlassian.net/browse/XP-510)

### Summary

- allow for zero epochs when running the coordinator from the cli

### Are there any open tasks/blockers for the ticket?

- none

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
