### PR TITLE
XP-505: cleanup docstrings in xain_fl.coordinator

### DIFF
--- a/xain_fl/coordinator/coordinator_grpc.py
+++ b/xain_fl/coordinator/coordinator_grpc.py
@@ -32,12 +32,12 @@ class CoordinatorGrpc(CoordinatorServicer):
     :class:`xain_fl.coordinator.coordinator.Coordinator`.
 
     Args:
-        coordinator (:class:`xain_fl.coordinator.coordinator.Coordinator`): The Coordinator
-         state machine.
 
-        store (:class:`xain_fl.coordinator.store.Store`): The Store in
-            which the coordinator fetches trained models from the
-            participants and to which it saves aggregated models.
+        coordinator: The Coordinator state machine.
+
+        store: The Store in which the coordinator fetches trained
+            models from the participants and to which it saves
+            aggregated models.
     """
 
     def __init__(self, coordinator: Coordinator, store: Store):
@@ -54,16 +54,21 @@ class CoordinatorGrpc(CoordinatorServicer):
         all the participants it tells the participant to try again later.
 
         Args:
-            request (:class:`~.coordinator_pb2.RendezvousRequest`): The participant's request.
-            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+            request: The participant's request.
+            context: The context associated with the gRPC request.
 
         Returns:
-            :class:`~.coordinator_pb2.RendezvousResponse`: The response to the
-            participant's request. The response is an enum containing either:
 
-                ACCEPT: If the :class:`xain_fl.coordinator.coordinator.Coordinator`
-                    does not have enough participants.
-                LATER: If the :class:`xain_fl.coordinator.coordinator.Coordinator`
+            The response to the participant's request. The response is
+            an enum containing either:
+
+                - `ACCEPT`: If the
+                  :class:`xain_fl.coordinator.coordinator.Coordinator`
+                  does not have enough participants.
+
+                - `LATER`: If the
+                    :class:`xain_fl.coordinator.coordinator.Coordinator`
                     already has enough participants.
         """
         return self.coordinator.on_message(request, context.peer())
@@ -77,19 +82,20 @@ class CoordinatorGrpc(CoordinatorServicer):
         :class:`Coordinator` can detect failures.
 
         Args:
-            request (:class:`~.coordinator_pb2.HeartbeatRequest`): The
-                participant's request. The participant's request contains the
-                current :class:`~.coordinator_pb2.State` and round number the
+
+            request: The participant's request. The participant's
+                request contains the current
+                :class:`~.coordinator_pb2.State` and round number the
                 participant is on.
-            context (:class:`~grpc.ServicerContext`): The context associated
-                with the gRPC request.
+
+            context: The context associated with the gRPC request.
 
         Returns:
-            :class:`~.coordinator_pb2.HeartbeatResponse`: The response to the
-            participant's request. The response contains both the
-            :class:`~.coordinator_pb2.State` and the current round the
-            coordinator is on. If a training session has not started yet the
-            round number defaults to 0.
+
+            The response to the participant's request. The response
+            contains both the :class:`~.coordinator_pb2.State` and the
+            current round the coordinator is on. If a training session
+            has not started yet the round number defaults to 0.
         """
         try:
             return self.coordinator.on_message(request, context.peer())
@@ -110,14 +116,15 @@ class CoordinatorGrpc(CoordinatorServicer):
         training for the round.
 
         Args:
-            request (:class:`~.coordinator_pb2.StartTrainingRoundRequest`): The participant's
-                request.
-            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+            request: The participant's request.
+            context: The context associated with the gRPC request.
 
         Returns:
-            :class:`~.coordinator_pb2.StartTrainingRoundResponse`: The response to the
-            participant's request. The response contains the global model weights.
-            """
+
+            The response to the participant's request. The response
+            contains the global model weights.
+        """
         try:
             return self.coordinator.on_message(request, context.peer())
         except UnknownParticipantError as error:
@@ -139,17 +146,20 @@ class CoordinatorGrpc(CoordinatorServicer):
         the updated weights.
 
         Args:
-            request (:class:`~.coordinator_pb2.EndTrainingRoundRequest`): The
-                participant's request. The request contains the updated weights as
-                a result of the training as well as any metrics helpful for the
+
+            request: The participant's request. The request contains
+                the updated weights as a result of the training as
+                well as any metrics helpful for the
                 :class:`xain_fl.coordinator.coordinator.Coordinator`.
-            context (:class:`~grpc.ServicerContext`): The context associated with the gRPC request.
+
+            context: The context associated with the gRPC request.
 
         Returns:
-            :class:`~.coordinator_pb2.EndTrainingRoundResponse`: The response to the
-            participant's request. The response is just an acknowledgment that
-            the :class:`xain_fl.coordinator.coordinator.Coordinator` successfully received
-            the updated weights.
+
+            The response to the participant's request. The response is
+            just an acknowledgment that the
+            :class:`xain_fl.coordinator.coordinator.Coordinator`
+            successfully received the updated weights.
         """
         try:
             response = self.coordinator.on_message(request, context.peer())

--- a/xain_fl/coordinator/heartbeat.py
+++ b/xain_fl/coordinator/heartbeat.py
@@ -16,14 +16,16 @@ def monitor_heartbeats(coordinator: Coordinator, terminate_event: threading.Even
     If a heartbeat expires the participant is removed from the :class:`~.Participants`.
 
     Note:
+
         This is meant to be run inside a thread and expects an
         :class:`~threading.Event`, to know when it should terminate.
 
     Args:
-        coordinator (:class:`xain_fl.coordinator.coordinator.Coordinator`): The coordinator
-            to monitor for heartbeats.
-        terminate_event (:class:`~threading.Event`): A threading event to signal
-            that this method should terminate.
+
+        coordinator: The coordinator to monitor for heartbeats.
+
+        terminate_event: A threading event to signal that this method
+            should terminate.
     """
 
     logger.info("Heartbeat monitor starting...")

--- a/xain_fl/coordinator/participants.py
+++ b/xain_fl/coordinator/participants.py
@@ -12,10 +12,11 @@ class ParticipantContext:  # pylint: disable=too-few-public-methods
     and the time when the next heartbeat_expires.
 
     In the future we may store more information like in what state a participant is in e.g.
-    IDLE, RUNNING, ...
+    `IDLE`, `RUNNING`, ...
 
-    Attributes:
-        participant_id (:obj:`str`): The id of the participant. Typically a
+    Args:
+
+        participant_id: The id of the participant. Typically a
             host:port or public key when using SSL.
     """
 
@@ -38,7 +39,8 @@ class Participants:
         """Adds a new participant to the list of participants.
 
         Args:
-            participant_id (:obj:`str`): The id of the participant to add.
+
+            participant_id: The id of the participant to add.
         """
 
         with self._lock:
@@ -47,10 +49,12 @@ class Participants:
     def remove(self, participant_id: str) -> None:
         """Removes a participant from the list of participants.
 
-        This will be typically used after a participant is disconnected from the coordinator.
+        This will be typically used after a participant is
+        disconnected from the coordinator.
 
         Args:
-            participant_id (:obj:`str`): The id of the participant to remove.
+
+            participant_id: The id of the participant to remove.
         """
 
         with self._lock:
@@ -64,7 +68,8 @@ class Participants:
         the next check.
 
         Returns:
-            :obj:`float`: The next heartbeat to expire.
+
+            The next heartbeat to expire.
         """
 
         with self._lock:
@@ -77,7 +82,8 @@ class Participants:
         """Get the number of participants.
 
         Returns:
-            :obj:`int`: The number of participants in the list.
+
+            The number of participants in the list.
         """
 
         with self._lock:
@@ -87,7 +93,8 @@ class Participants:
         """Get the ids of the participants.
 
         Returns:
-            :obj:`list` of :obj:`str`: The list of participant ids.
+
+            The list of participant ids.
         """
 
         with self._lock:
@@ -100,7 +107,8 @@ class Participants:
         every time a participant sends a heartbeat.
 
         Args:
-            participant_id (:obj:`str`): The id of the participant to update the expire time.
+
+            participant_id: The id of the participant to update the expire time.
         """
 
         with self._lock:

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -13,9 +13,10 @@ class Round:
     participants during a round and does some sanity checks like preventing the
     same participant to submit multiple updates during a single round.
 
-    Attributes:
-        participant_ids(:obj:`list` of :obj:`str`): The list of IDs of the participants
-            selected to participate in this round.
+    Args:
+
+        participant_ids: The list of IDs of the participants selected
+            to participate in this round.
     """
 
     def __init__(self, participant_ids: List[str]) -> None:
@@ -31,13 +32,16 @@ class Round:
         """Valid a participant's update for the round.
 
         Args:
-            participant_id (:obj:`str`): The id of the participant making the request.
-            weight_update (:obj:`tuple` of :obj:`list` of :class:`~numpy.ndarray`):
-                A tuple containing a list of updated weights.
-            metrics (:obj:`dict`): A dictionary containing metrics with the name and the value
-                as list of ndarrays.
+
+            participant_id: The id of the participant making the request.
+
+            weight_update: A tuple containing a list of updated weights.
+
+            metrics: A dictionary containing metrics with the name and
+                the value as list of ndarrays.
 
         Raises:
+
             DuplicatedUpdateError: If the participant already submitted his update this round.
         """
 
@@ -56,8 +60,9 @@ class Round:
         If all participants submitted their updates the round is considered finished.
 
         Returns:
-            :obj:`bool`:: :obj:`True` if all participants submitted their
-            updates this round. :obj:`False` otherwise.
+
+            `True` if all participants submitted their updates this
+            round. `False` otherwise.
         """
         return len(self.updates) == len(self.participant_ids)
 
@@ -66,7 +71,7 @@ class Round:
         This list will usually be used by the aggregation function.
 
         Returns:
-            :obj:`list` of :obj:`tuple`: The list of weight updates from all
-            participants.
+
+            The list of weight updates from all participants.
         """
         return [v["weight_update"] for k, v in self.updates.items()]


### PR DESCRIPTION
This is a follow-up of https://github.com/xainag/xain-fl/pull/224


### References


Reference: https://xainag.atlassian.net/browse/XP-505


### Summary

Let the types be resolved when the doc is generated instead of making them explicit in the docstrings

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
