### PR TITLE
XP-498: more generic shebangs

### DIFF
--- a/scripts/create_git_hooks.sh
+++ b/scripts/create_git_hooks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit immediately if a command exits with a non-zero status.
 set -e
@@ -11,10 +11,10 @@ cd $DIR/../
 
 if [ -f "$PRE_PUSH_HOOK" ]; then
     echo "$PRE_PUSH_HOOK exist"
-else 
+else
     echo "#!/bin/sh" >> $PRE_PUSH_HOOK
     echo "./scripts/test.sh" >> $PRE_PUSH_HOOK
-    
+
     chmod +x $PRE_PUSH_HOOK
 
     echo "$PRE_PUSH_HOOK created"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit immediately if a command exits with a non-zero status
 set -e

--- a/scripts/rm_caches.sh
+++ b/scripts/rm_caches.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -e  # Exit immediately if a command exits with a non-zero status
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/../

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/XP-498

### Summary

On some platforms, /bin/bash does not exist. Using /usr/bin/env let
users choose which `bash` should be used to run the scripts.

See also:

- https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability
- https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
