### PR TITLE
DO-58: cache xain-fl dependencies in Docker

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,22 @@ FROM python:3.6-alpine
 RUN apk update && apk add python3-dev build-base git
 
 WORKDIR /app
+# Some dependencies require a very long compilation: protobuf, numpy,
+# grpcio. To avoid having to re-install these packages every time, we
+# pre-install them so that they are cached.
+#
+# However, we cannot just pre-install a few packages, because we don't
+# know exactly which version `pip` will pick for them. Instead, we
+# give `pip` all the package's dependencies, and let it resolve and
+# install them.
 COPY setup.py .
+RUN mkdir xain_fl && \
+    printf '__version__ = "0"\n__short_version__ = "0"' > xain_fl/__version__.py && \
+    touch README.md && \
+    python setup.py egg_info && \
+    cat *.egg-info/requires.txt | grep -v '^\[' | uniq | pip install -r /dev/stdin
+
+RUN rm -rf xain_fl
 COPY xain_fl xain_fl/
 COPY README.md .
 


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/DO-58

### Summary

Some dependencies require a very long compilation: protobuf, numpy,
grpcio. To avoid having to re-install these packages every time, we
pre-install them so that they are cached.

However, we cannot just pre-install a few packages, because we don't
know exactly which version `pip` will pick for them. Instead, we
give `pip` all the package's dependencies, and let it resolve and
install them.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
