### PR TITLE
XP-456: fix coordinator command

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ set -o nounset
 # set -o xtrace
 
 if [ $# -eq 0 ]; then
-    exec coordinator -f ${CONFIG_FILE}
+    exec coordinator --config ${CONFIG_FILE}
 else
     exec coordinator "$@"
 fi


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/XP-456

### Summary

Fix the `coordinator` command in the docker "release" image.



---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
