### PR TITLE
PB-380: split get_logger()

### DIFF
--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -6,7 +6,7 @@ import sys
 from xain_fl.config import Config, InvalidConfig, get_cmd_parameters
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.store import Store
-from xain_fl.logger import StructLogger, get_logger
+from xain_fl.logger import StructLogger, get_logger, initialize_logging
 from xain_fl.serve import serve
 
 logger: StructLogger = get_logger(__name__)
@@ -15,6 +15,7 @@ logger: StructLogger = get_logger(__name__)
 def main():
     """Start a coordinator instance
     """
+    initialize_logging()
 
     args = get_cmd_parameters()
     try:

--- a/xain_fl/logger.py
+++ b/xain_fl/logger.py
@@ -8,15 +8,10 @@ import structlog
 StructLogger = structlog._config.BoundLoggerLazyProxy  # pylint: disable=protected-access
 
 
-def get_logger(
-    name: str, level: int = logging.INFO
-) -> structlog._config.BoundLoggerLazyProxy:  # pylint: disable=protected-access
-    """Wrap python logger with default configuration of structlog.
-    Args:
-        name (str): Identification name. For module name pass name=__name__.
-        level (int): Threshold for this logger. Defaults to logging.INFO.
-    Returns:
-        Wrapped python logger with default configuration of structlog.
+def configure_aimetrics_logger():
+    """Configure a logger named "aimetrics" with a configurable log
+    level.
+
     """
     AIMETRICS = 25  # pylint: disable=invalid-name
     structlog.stdlib.AIMETRICS = AIMETRICS
@@ -31,6 +26,10 @@ def get_logger(
         aimetrics
     )
     structlog.stdlib.BoundLogger.aimetrics = aimetrics
+
+
+def configure_structlog():
+    """Set the structlog configuration"""
     structlog.configure(
         processors=[
             structlog.stdlib.add_log_level,
@@ -40,6 +39,26 @@ def get_logger(
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )
+
+
+def initialize_logging():
+    """Set up logging
+
+    """
+    configure_aimetrics_logger()
+    configure_structlog()
+
+
+def get_logger(
+    name: str, level: int = logging.INFO
+) -> structlog._config.BoundLoggerLazyProxy:  # pylint: disable=protected-access
+    """Wrap python logger with default configuration of structlog.
+    Args:
+        name (str): Identification name. For module name pass name=__name__.
+        level (int): Threshold for this logger. Defaults to logging.INFO.
+    Returns:
+        Wrapped python logger with default configuration of structlog.
+    """
     formatter = structlog.stdlib.ProcessorFormatter(
         processor=structlog.processors.JSONRenderer(indent=2, sort_keys=True)
     )


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/PB-380

### Summary

`get_logger()` does not just create a logger and wrap it into
structlog. It actually also creates an "aimetrics" logger and
reconfigures structlog. This commit split `get_logger()` so that it
only creates a logger.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
