### PR TITLE
PB-381: make the log level configurable

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -34,3 +34,8 @@ bucket = "xain-fl-aggregated-weights"
 access_key_id = "minio"
 # AWS secret access to use to authenticate to the storage service
 secret_access_key = "minio123"
+
+[logging]
+# The log level can be one of "notset", "debug", "info", "warning",
+# "error" and "critical". It defaults to "info".
+level = "debug"

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -36,3 +36,8 @@ bucket = "xain-fl-aggregated-weights"
 access_key_id = "minio"
 # AWS secret access to use to authenticate to the storage service
 secret_access_key = "minio123"
+
+[logging]
+# The log level can be one of "notset", "debug", "info", "warning",
+# "error" and "critical". It defaults to "info".
+level = "info"

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -6,7 +6,7 @@ import sys
 from xain_fl.config import Config, InvalidConfig, get_cmd_parameters
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.store import S3Store
-from xain_fl.logger import StructLogger, get_logger, initialize_logging
+from xain_fl.logger import StructLogger, get_logger, initialize_logging, set_log_level
 from xain_fl.serve import serve
 
 logger: StructLogger = get_logger(__name__)
@@ -23,6 +23,8 @@ def main():
     except InvalidConfig as err:
         logger.error("Invalid config", error=str(err))
         sys.exit(1)
+
+    set_log_level(config.logging.level.upper())
 
     coordinator = Coordinator(
         num_rounds=config.ai.rounds,

--- a/xain_fl/config/__init__.py
+++ b/xain_fl/config/__init__.py
@@ -3,12 +3,20 @@ various configuration options exposed by the CLI and the toml config
 file."""
 
 from xain_fl.config.cli import get_cmd_parameters
-from xain_fl.config.schema import AiConfig, Config, InvalidConfig, ServerConfig, StorageConfig
+from xain_fl.config.schema import (
+    AiConfig,
+    Config,
+    InvalidConfig,
+    LoggingConfig,
+    ServerConfig,
+    StorageConfig,
+)
 
 __all__ = [
     "get_cmd_parameters",
     "Config",
     "AiConfig",
+    "LoggingConfig",
     "StorageConfig",
     "ServerConfig",
     "InvalidConfig",

--- a/xain_fl/logger.py
+++ b/xain_fl/logger.py
@@ -1,7 +1,7 @@
 """XAIN FL structured logger"""
 
 import logging
-from typing import Any
+from typing import Any, Optional, Union
 
 import structlog
 
@@ -41,6 +41,20 @@ def configure_structlog():
     )
 
 
+def set_log_level(level: Union[str, int]):
+    """Set the log level on the root logger. Since by default, the root
+    logger log level is inherited by all the loggers, this is like
+    setting a default log level.
+
+    Args:
+
+        level: the log level, as documented in the `Python standard
+            library <https://docs.python.org/3/library/logging.html#levels>`_
+    """
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+
 def initialize_logging():
     """Set up logging
 
@@ -50,12 +64,14 @@ def initialize_logging():
 
 
 def get_logger(
-    name: str, level: int = logging.INFO
+    name: str, level: Optional[int] = None
 ) -> structlog._config.BoundLoggerLazyProxy:  # pylint: disable=protected-access
     """Wrap python logger with default configuration of structlog.
+
     Args:
-        name (str): Identification name. For module name pass name=__name__.
-        level (int): Threshold for this logger. Defaults to logging.INFO.
+        name: Identification name. For module name pass ``name=__name__``.
+        level: Threshold for this logger.
+
     Returns:
         Wrapped python logger with default configuration of structlog.
     """
@@ -66,6 +82,8 @@ def get_logger(
     handler.setFormatter(formatter)
     logger = logging.getLogger(name)
     logger.addHandler(handler)
-    logger.setLevel(level)
+
+    if level is not None:
+        logger.setLevel(level)
 
     return structlog.wrap_logger(logger)


### PR DESCRIPTION
**This is based on https://github.com/xainag/xain-fl/pull/242**

-----

### References

https://xainag.atlassian.net/browse/PB-381

### Summary

Add a new `[logging]` section to the configuration file. For now, this
section only provides a `level` key which can be one of the log levels
supported by default by the Python standard library: notset, debug,
info, warning, error, critical.

In the future, this `[logging]` section could be used to provide more
knobs for logging customatization: enabling colors for the terminal
handler, specifying a path for logging into a file, etc.

References:

xainag.atlassian.net/browse/PB-381

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
