### PR TITLE
PB-351 Store participant metrics

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -10,7 +10,7 @@ port = 50051
 
 # (Optional)
 [server.grpc_options]
-# More information about all available gRPC options can be find here: 
+# More information about all available gRPC options can be found here: 
 # https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga813f94f9ac3174571dd712c96cdbbdc1
 
 # Example

--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -39,3 +39,7 @@ secret_access_key = "minio123"
 # The log level can be one of "notset", "debug", "info", "warning",
 # "error" and "critical". It defaults to "info".
 level = "debug"
+
+[metrics]
+# The hostname to connect ot InfluxDB.
+host = "influxdb"

--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -49,6 +49,8 @@ level = "info"
 
 # (Optional)
 [metrics]
+# (Optional) If `true`, store metrics in InfluxDB, otherwise not.
+enable = false
 # (Optional) The hostname to connect to InfluxDB.
 host = "localhost"
 # (Optional) The port of InfluxDB.

--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -1,45 +1,61 @@
+# An example configfiguration file. 
+# The values that are used for the optional keys correspond to their default values.
+
+# (Optional)
 [server]
-# Address to listen on for incoming gRPC connections
+# (Optional) Address to listen on for incoming gRPC connections
 host = "localhost"
-# Port to listen on for incoming gRPC connections
+# (Optional) Port to listen on for incoming gRPC connections
 port = 50051
 
+# (Optional)
 [server.grpc_options]
 # More information about all available gRPC options can be find here: 
 # https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga813f94f9ac3174571dd712c96cdbbdc1
 
+# Example
 # Maximum message length that the channel can receive. -1 means unlimited. 
-"grpc.max_receive_message_length" = -1
-# Maximum message length that the channel can send. -1 means unlimited. 
-"grpc.max_send_message_length" = -1
+# "grpc.max_receive_message_length" = -1
 
+# (Required)
 [ai]
-# Number of global rounds the model is going to be trained for. This
+# (Required) Number of global rounds the model is going to be trained for. This
 # must be a positive integer.
 rounds = 2
-# Number of local epochs per round
+# (Required) Number of local epochs per round
 epochs = 1
-# Minimum number of participants to be selected for a round.
+# (Optional) Minimum number of participants to be selected for a round.
 min_participants = 1
-# Fraction of total clients that participate in a training round. This
+# (Optional) Fraction of total clients that participate in a training round. This
 # must be a float between 0 and 1.
 fraction_participants = 1.0
 
+# (Required)
 [storage]
-# URL to the storage service to use
+# (Required) URL to the storage service to use
 endpoint = "http://minio-dev:9000"
-# Name of the bucket for storing the aggregated models
+# (Required) Name of the bucket for storing the aggregated models
 bucket = "xain-fl-aggregated-weights"
-# AWS access key ID to use to authenticate to the storage service
+# (Required) AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
-# AWS secret access to use to authenticate to the storage service
+# (Required) AWS secret access to use to authenticate to the storage service
 secret_access_key = "minio123"
 
+# (Optional)
 [logging]
-# The log level can be one of "notset", "debug", "info", "warning",
-# "error" and "critical". It defaults to "info".
-level = "debug"
+# (Optional) The log level can be one of "notset", "debug", "info", "warning",
+# "error" and "critical".
+level = "info"
 
+# (Optional)
 [metrics]
-# The hostname to connect ot InfluxDB.
-host = "influxdb"
+# (Optional) The hostname to connect to InfluxDB.
+host = "localhost"
+# (Optional) The port of InfluxDB.
+port = 8086
+# (Optional) The name of the InfluxDB user.
+user = "root"
+# (Optional) The password of the InfluxDB user.
+password = "root"
+# (Optional) The name of the database.
+db_name = "metrics"

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -7,7 +7,7 @@ host = "0.0.0.0"
 port = 50051
 
 [server.grpc_options]
-# More information about all available gRPC options can be find here: 
+# More information about all available gRPC options can be found here: 
 # https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga813f94f9ac3174571dd712c96cdbbdc1
 
 # Maximum message length that the channel can receive. -1 means unlimited. 

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -44,5 +44,5 @@ level = "info"
 
 
 [metrics]
-# The hostname to connect ot InfluxDB.
+# The hostname to connect to InfluxDB.
 host = "influxdb"

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -44,5 +44,6 @@ level = "info"
 
 
 [metrics]
+enable = true
 # The hostname to connect to InfluxDB.
 host = "influxdb"

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -41,3 +41,8 @@ secret_access_key = "minio123"
 # The log level can be one of "notset", "debug", "info", "warning",
 # "error" and "critical". It defaults to "info".
 level = "info"
+
+
+[metrics]
+# The hostname to connect ot InfluxDB.
+host = "influxdb"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -61,6 +61,8 @@ services:
   influxdb:
     image: influxdb:1.7 # current stable version, v2 is in Beta
     hostname: influxdb
+    environment:
+      INFLUXDB_DB: metrics
     volumes:
       - influxdb-data:/var/lib/influxdb
     networks:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ install_requires = [
     "toml==0.10.0",  # MIT
     "schema~=0.7",  # MIT
     "idna==2.8",  # BSD
+    "influxdb==5.2.3",  # MIT
 ]
 
 dev_require = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,7 +141,7 @@ def test_load_valid_config(config_sample):
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
 
-    assert config.metrics.enable == False
+    assert config.metrics.enable is False
     assert config.metrics.host == "localhost"
     assert config.metrics.port == 8086
     assert config.metrics.user == "root"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,9 +29,15 @@ def server_sample():
 @pytest.fixture
 def metrics_sample():
     """
-    Return a valid "server" section
+    Return a valid "metrics" section
     """
-    return {}
+    return {
+        "host": "localhost",
+        "port": 8086,
+        "user": "root",
+        "password": "root",
+        "db_name": "metrics",
+    }
 
 
 @pytest.fixture
@@ -133,6 +139,12 @@ def test_load_valid_config(config_sample):
     assert config.storage.bucket == "aggregated_weights"
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
+
+    assert config.metrics.host == "localhost"
+    assert config.metrics.port == 8086
+    assert config.metrics.user == "root"
+    assert config.metrics.password == "root"
+    assert config.metrics.db_name == "metrics"
 
 
 def test_server_config_ip_address(config_sample, server_sample):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,14 @@ def server_sample():
 
 
 @pytest.fixture
+def metrics_sample():
+    """
+    Return a valid "server" section
+    """
+    return {}
+
+
+@pytest.fixture
 def ai_sample():
     """
     Return a valid "ai" section
@@ -63,7 +71,7 @@ def logging_sample():
 
 
 @pytest.fixture
-def config_sample(server_sample, ai_sample, storage_sample, logging_sample):
+def config_sample(server_sample, ai_sample, storage_sample, logging_sample, metrics_sample):
     """
     Return a valid config
     """
@@ -72,6 +80,7 @@ def config_sample(server_sample, ai_sample, storage_sample, logging_sample):
         "server": server_sample,
         "storage": storage_sample,
         "logging": logging_sample,
+        "metrics": metrics_sample,
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,20 +27,6 @@ def server_sample():
 
 
 @pytest.fixture
-def metrics_sample():
-    """
-    Return a valid "metrics" section
-    """
-    return {
-        "host": "localhost",
-        "port": 8086,
-        "user": "root",
-        "password": "root",
-        "db_name": "metrics",
-    }
-
-
-@pytest.fixture
 def ai_sample():
     """
     Return a valid "ai" section
@@ -69,10 +55,25 @@ def storage_sample():
 @pytest.fixture
 def logging_sample():
     """
-    Return a valid "ai" section
+    Return a valid "logging" section
     """
     return {
         "level": "debug",
+    }
+
+
+@pytest.fixture
+def metrics_sample():
+    """
+    Return a valid "metrics" section
+    """
+    return {
+        "enable": False,
+        "host": "localhost",
+        "port": 8086,
+        "user": "root",
+        "password": "root",
+        "db_name": "metrics",
     }
 
 
@@ -140,6 +141,7 @@ def test_load_valid_config(config_sample):
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
 
+    assert config.metrics.enable == False
     assert config.metrics.host == "localhost"
     assert config.metrics.port == 8086
     assert config.metrics.user == "root"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,7 +78,9 @@ def metrics_sample():
 
 
 @pytest.fixture
-def config_sample(server_sample, ai_sample, storage_sample, logging_sample, metrics_sample):
+def config_sample(
+    server_sample, ai_sample, storage_sample, logging_sample, metrics_sample
+):
     """
     Return a valid config
     """

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -71,6 +71,6 @@ def test_write_metrics_exception_handling(metrics_sample):
     """Check that raised exceptions of the write_points method are caught in the write_metrics
     method.
     """
-    metric_store = MetricsStore(MetricsConfig(host="", port=1, user="", password="", db_name=""))
+    metric_store = MetricsStore(MetricsConfig(enable=True, host="", port=1, user="", password="", db_name=""))
 
     assert not metric_store.write_metrics("participant_id", metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -71,6 +71,8 @@ def test_write_metrics_exception_handling(metrics_sample):
     """Check that raised exceptions of the write_points method are caught in the write_metrics
     method.
     """
-    metric_store = MetricsStore(MetricsConfig(enable=True, host="", port=1, user="", password="", db_name=""))
+    metric_store = MetricsStore(
+        MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
+    )
 
     assert not metric_store.write_metrics("participant_id", metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -32,7 +32,7 @@ def test_null_object_metrics_store_always_return_true(metrics_sample):
 
 
 def test_transform_data(metrics_sample):
-    """Test that a metric object is correctly transformed into influx data point structure."""
+    """Check that a metric object is correctly transformed into the influx data point structure."""
     actual_data_points = transform_metrics_to_influx_data_points("participant_id", metrics_sample)
     expected_data_points = [
         {
@@ -68,7 +68,7 @@ def test_transform_data(metrics_sample):
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
 def test_write_metrics_exception_handling(metrics_sample):
-    """Test that raised exceptions of the write_points method are caught."""
+    """Check that raised exceptions of the write_points method are caught in the write_metrics method."""
     metric_store = MetricsStore(MetricsConfig(host="", port=1, user="", password="", db_name=""))
 
     assert metric_store.write_metrics("participant_id", metrics_sample) == False

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -1,0 +1,74 @@
+"""XAIN FL tests for metric store"""
+
+from unittest import mock
+
+from influxdb import InfluxDBClient
+import numpy as np
+import pytest
+
+from xain_fl.config import MetricsConfig
+from xain_fl.coordinator.metrics_store import (
+    MetricsStore,
+    NullObjectMetricsStore,
+    transform_metrics_to_influx_data_points,
+)
+
+
+@pytest.fixture()
+def metrics_sample():
+    """Return a valid metric object."""
+    return {
+        "metric_1": np.array([0.2, 0.44]),
+        "metric_2": np.array([0.99, 0.55]),
+    }
+
+
+def test_null_object_metrics_store_always_return_true(metrics_sample):
+    """Check that the null object metric store always retruns true."""
+
+    no_metric_store = NullObjectMetricsStore()
+
+    assert no_metric_store.write_metrics("participant_id", metrics_sample) == True
+
+
+def test_transform_data(metrics_sample):
+    """Test that a metric object is correctly transformed into influx data point structure."""
+    actual_data_points = transform_metrics_to_influx_data_points("participant_id", metrics_sample)
+    expected_data_points = [
+        {
+            "measurement": "participant.ai.metric_1",
+            "tags": {"id": "participant_id"},
+            "fields": {"metric_1": "0.20000000"},
+        },
+        {
+            "measurement": "participant.ai.metric_1",
+            "tags": {"id": "participant_id"},
+            "fields": {"metric_1": "0.44000000"},
+        },
+        {
+            "measurement": "participant.ai.metric_2",
+            "tags": {"id": "participant_id"},
+            "fields": {"metric_2": "0.99000000"},
+        },
+        {
+            "measurement": "participant.ai.metric_2",
+            "tags": {"id": "participant_id"},
+            "fields": {"metric_2": "0.55000000"},
+        },
+    ]
+
+    for (actual_dp, expected_dp) in zip(actual_data_points, expected_data_points):
+        assert actual_dp["measurement"] == expected_dp["measurement"]
+        assert actual_dp["tags"] == expected_dp["tags"]
+        assert actual_dp["fields"] == expected_dp["fields"]
+
+    assert actual_data_points[0]["time"] == actual_data_points[2]["time"]
+    assert actual_data_points[1]["time"] == actual_data_points[3]["time"]
+
+
+@mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
+def test_write_metrics_exception_handling(metrics_sample):
+    """Test that raised exceptions of the write_points method are caught."""
+    metric_store = MetricsStore(MetricsConfig(host="", port=1, user="", password="", db_name=""))
+
+    assert metric_store.write_metrics("participant_id", metrics_sample) == False

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -1,5 +1,5 @@
 """XAIN FL tests for metric store"""
-
+# pylint: disable=redefined-outer-name
 from unittest import mock
 
 from influxdb import InfluxDBClient
@@ -28,7 +28,7 @@ def test_null_object_metrics_store_always_return_true(metrics_sample):
 
     no_metric_store = NullObjectMetricsStore()
 
-    assert no_metric_store.write_metrics("participant_id", metrics_sample) == True
+    assert no_metric_store.write_metrics("participant_id", metrics_sample)
 
 
 def test_transform_data(metrics_sample):
@@ -68,7 +68,9 @@ def test_transform_data(metrics_sample):
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
 def test_write_metrics_exception_handling(metrics_sample):
-    """Check that raised exceptions of the write_points method are caught in the write_metrics method."""
+    """Check that raised exceptions of the write_points method are caught in the write_metrics
+    method.
+    """
     metric_store = MetricsStore(MetricsConfig(host="", port=1, user="", password="", db_name=""))
 
-    assert metric_store.write_metrics("participant_id", metrics_sample) == False
+    assert not metric_store.write_metrics("participant_id", metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -9,6 +9,7 @@ import pytest
 from xain_fl.config import MetricsConfig
 from xain_fl.coordinator.metrics_store import (
     MetricsStore,
+    MetricsStoreError,
     NullObjectMetricsStore,
     transform_metrics_to_influx_data_points,
 )
@@ -76,5 +77,5 @@ def test_write_metrics_exception_handling(metrics_sample):
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
-
-    assert not metric_store.write_metrics("participant_id", metrics_sample)
+    with pytest.raises(MetricsStoreError):
+        metric_store.write_metrics("participant_id", metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -33,7 +33,9 @@ def test_null_object_metrics_store_always_return_true(metrics_sample):
 
 def test_transform_data(metrics_sample):
     """Check that a metric object is correctly transformed into the influx data point structure."""
-    actual_data_points = transform_metrics_to_influx_data_points("participant_id", metrics_sample)
+    actual_data_points = transform_metrics_to_influx_data_points(
+        "participant_id", metrics_sample
+    )
     expected_data_points = [
         {
             "measurement": "participant.ai.metric_1",

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -5,6 +5,7 @@ import sys
 
 from xain_fl.config import Config, InvalidConfig, get_cmd_parameters
 from xain_fl.coordinator.coordinator import Coordinator
+from xain_fl.coordinator.metrics_store import MetricsStore
 from xain_fl.coordinator.store import S3Store
 from xain_fl.logger import StructLogger, get_logger, initialize_logging, set_log_level
 from xain_fl.serve import serve
@@ -32,6 +33,7 @@ def main():
         epochs=config.ai.epochs,
         minimum_participants_in_round=config.ai.min_participants,
         fraction_of_participants=config.ai.fraction_participants,
+        metrics_store=MetricsStore(config.metrics),
     )
 
     serve(coordinator=coordinator, server_config=config.server)

--- a/xain_fl/config/__init__.py
+++ b/xain_fl/config/__init__.py
@@ -8,6 +8,7 @@ from xain_fl.config.schema import (
     Config,
     InvalidConfig,
     LoggingConfig,
+    MetricsConfig,
     ServerConfig,
     StorageConfig,
 )
@@ -19,5 +20,6 @@ __all__ = [
     "LoggingConfig",
     "StorageConfig",
     "ServerConfig",
+    "MetricsConfig",
     "InvalidConfig",
 ]

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -317,6 +317,12 @@ class Config:
         server: the configuration corresponding to the `[server]`
             section of the toml config file
 
+        logging: the configuration corresponding to the `[logging]`
+            section of the toml config file
+
+        metrics: the configuration corresponding to the `[metrics]`
+            section of the toml config file
+
     :Example:
 
     Here is a valid configuration:

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -286,7 +286,7 @@ CONFIG_SCHEMA = Schema(
         "ai": AI_SCHEMA,
         "storage": STORAGE_SCHEMA,
         Optional("logging", default=LOGGING_SCHEMA.validate({})): LOGGING_SCHEMA,
-        "metrics": METRICS_SCHEMA
+        Optional("metrics"): METRICS_SCHEMA,
     }
 )
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -267,7 +267,11 @@ LOGGING_SCHEMA = Schema(
 
 METRICS_SCHEMA = Schema(
     {
-        "host": And(str, hostname_or_ip_address, error=error("metrics.host", "a valid hostname or ip address")),
+        "host": And(
+            str,
+            hostname_or_ip_address,
+            error=error("metrics.host", "a valid hostname or ip address"),
+        ),
         "port": Use(int, error=error("metrics.port", "a valid port number")),
         "user": Use(str, error=error("metrics.user", "a valid user")),
         "password": Use(str, error=error("metrics.password", "a valid password")),
@@ -327,6 +331,9 @@ StorageConfig.__doc__ = (
 
 LoggingConfig = create_class_from_schema("LoggingConfig", LOGGING_SCHEMA)
 LoggingConfig.__doc__ = "Logging related configuration: log level, colors, etc."
+
+MetricsConfig = create_class_from_schema("MetricsConfig", METRICS_SCHEMA)
+MetricsConfig.__doc__ = "Storage related configuration: storage endpoints and credentials, etc."
 
 T = TypeVar("T", bound="Config")
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -24,7 +24,6 @@ configuration.
 
 from collections import namedtuple
 import ipaddress
-import os
 from typing import Any, Mapping, NamedTuple, Type, TypeVar
 import urllib
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -208,9 +208,8 @@ def existing_file(
 SERVER_SCHEMA = Schema(
     {
         Optional("host", default="localhost"): hostname_or_ip_address("server.host"),
-        Optional("port", default=50051): Use(
-            int, error=error("server.port", "a valid port number")
-        ),
+        Optional("port", default=50051): non_negative_integer("server.port")
+        ,
         Optional("grpc_options", default=dict): Use(
             lambda opt: list(opt.items()),
             error=error("server.grpc_options", "valid gRPC options"),
@@ -273,8 +272,8 @@ METRICS_SCHEMA = Schema(
             error=error("metrics.host", "a valid hostname or ip address"),
         ),
         Optional("port", default=8086): non_negative_integer("metrics.port"),
-        Optional("user", default="admin"): Use(str, error=error("metrics.user", "a valid user")),
-        Optional("password", default="admin"): Use(
+        Optional("user", default="root"): Use(str, error=error("metrics.user", "a valid user")),
+        Optional("password", default="root"): Use(
             str, error=error("metrics.password", "a valid password")
         ),
         Optional("db_name", default="metrics"): Use(
@@ -337,7 +336,7 @@ LoggingConfig = create_class_from_schema("LoggingConfig", LOGGING_SCHEMA)
 LoggingConfig.__doc__ = "Logging related configuration: log level, colors, etc."
 
 MetricsConfig = create_class_from_schema("MetricsConfig", METRICS_SCHEMA)
-MetricsConfig.__doc__ = "Storage related configuration: storage endpoints and credentials, etc."
+MetricsConfig.__doc__ = "Metrics related configuration: InfluxDB host, InfluxDB port, etc."
 
 T = TypeVar("T", bound="Config")
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -275,7 +275,7 @@ METRICS_SCHEMA = Schema(
         "port": Use(int, error=error("metrics.port", "a valid port number")),
         "user": Use(str, error=error("metrics.user", "a valid user")),
         "password": Use(str, error=error("metrics.password", "a valid password")),
-        "db_name": Use(str, error=error("metrics.db_name", "a data base name")),
+        "db_name": Use(str, error=error("metrics.db_name", "a database name")),
     }
 )
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -213,19 +213,25 @@ STORAGE_SCHEMA = Schema(
     }
 )
 
-LOGGING_SCHEMA = Schema({Optional("level", default="info"): log_level("logging.level"),})
+LOGGING_SCHEMA = Schema(
+    {Optional("level", default="info"): log_level("logging.level"),}
+)
 
 
 METRICS_SCHEMA = Schema(
     {
-        Optional("enable", default=False): Use(bool, error=error("metrics.enable", "a boolean")),
+        Optional("enable", default=False): Use(
+            bool, error=error("metrics.enable", "a boolean")
+        ),
         Optional("host", default="localhost"): And(
             str,
             hostname_or_ip_address,
             error=error("metrics.host", "a valid hostname or ip address"),
         ),
         Optional("port", default=8086): non_negative_integer("metrics.port"),
-        Optional("user", default="root"): Use(str, error=error("metrics.user", "a valid user")),
+        Optional("user", default="root"): Use(
+            str, error=error("metrics.user", "a valid user")
+        ),
         Optional("password", default="root"): Use(
             str, error=error("metrics.password", "a valid password")
         ),
@@ -289,7 +295,9 @@ LoggingConfig = create_class_from_schema("LoggingConfig", LOGGING_SCHEMA)
 LoggingConfig.__doc__ = "Logging related configuration: log level, colors, etc."
 
 MetricsConfig = create_class_from_schema("MetricsConfig", METRICS_SCHEMA)
-MetricsConfig.__doc__ = "Metrics related configuration: InfluxDB host, InfluxDB port, etc."
+MetricsConfig.__doc__ = (
+    "Metrics related configuration: InfluxDB host, InfluxDB port, etc."
+)
 
 T = TypeVar("T", bound="Config")
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -433,7 +433,7 @@ class Config:
        assert config.storage.access_key_id == "my-key"
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         ai: NamedTuple,
         storage: NamedTuple,

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -267,15 +267,19 @@ LOGGING_SCHEMA = Schema(
 
 METRICS_SCHEMA = Schema(
     {
-        "host": And(
+        Optional("host", default="localhost"): And(
             str,
             hostname_or_ip_address,
             error=error("metrics.host", "a valid hostname or ip address"),
         ),
-        "port": Use(int, error=error("metrics.port", "a valid port number")),
-        "user": Use(str, error=error("metrics.user", "a valid user")),
-        "password": Use(str, error=error("metrics.password", "a valid password")),
-        "db_name": Use(str, error=error("metrics.db_name", "a database name")),
+        Optional("port", default=8086): non_negative_integer("metrics.port"),
+        Optional("user", default="admin"): Use(str, error=error("metrics.user", "a valid user")),
+        Optional("password", default="admin"): Use(
+            str, error=error("metrics.password", "a valid password")
+        ),
+        Optional("db_name", default="metrics"): Use(
+            str, error=error("metrics.db_name", "a database name")
+        ),
     }
 )
 
@@ -286,7 +290,7 @@ CONFIG_SCHEMA = Schema(
         "ai": AI_SCHEMA,
         "storage": STORAGE_SCHEMA,
         Optional("logging", default=LOGGING_SCHEMA.validate({})): LOGGING_SCHEMA,
-        Optional("metrics"): METRICS_SCHEMA,
+        Optional("metrics", default=METRICS_SCHEMA.validate({})): METRICS_SCHEMA,
     }
 )
 
@@ -435,11 +439,13 @@ class Config:
         storage: NamedTuple,
         server: NamedTuple,
         logging: NamedTuple,
+        metrics: NamedTuple,
     ):
         self.ai = ai
         self.storage = storage
         self.server = server
         self.logging = logging
+        self.metrics = metrics
 
     @classmethod
     def from_unchecked_dict(cls: Type[T], dictionary: Mapping[str, Any]) -> T:
@@ -471,6 +477,7 @@ class Config:
             StorageConfig(**dictionary["storage"]),
             ServerConfig(**dictionary["server"]),
             LoggingConfig(**dictionary["logging"]),
+            MetricsConfig(**dictionary["metrics"]),
         )
 
     @classmethod

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -208,8 +208,7 @@ def existing_file(
 SERVER_SCHEMA = Schema(
     {
         Optional("host", default="localhost"): hostname_or_ip_address("server.host"),
-        Optional("port", default=50051): non_negative_integer("server.port")
-        ,
+        Optional("port", default=50051): non_negative_integer("server.port"),
         Optional("grpc_options", default=dict): Use(
             lambda opt: list(opt.items()),
             error=error("server.grpc_options", "valid gRPC options"),

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -264,12 +264,25 @@ LOGGING_SCHEMA = Schema(
     {Optional("level", default="info"): log_level("logging.level"),}
 )
 
+
+METRICS_SCHEMA = Schema(
+    {
+        "host": And(str, hostname_or_ip_address, error=error("metrics.host", "a valid hostname or ip address")),
+        "port": Use(int, error=error("metrics.port", "a valid port number")),
+        "user": Use(str, error=error("metrics.user", "a valid user")),
+        "password": Use(str, error=error("metrics.password", "a valid password")),
+        "db_name": Use(str, error=error("metrics.db_name", "a data base name")),
+    }
+)
+
+
 CONFIG_SCHEMA = Schema(
     {
         Optional("server", default=SERVER_SCHEMA.validate({})): SERVER_SCHEMA,
         "ai": AI_SCHEMA,
         "storage": STORAGE_SCHEMA,
         Optional("logging", default=LOGGING_SCHEMA.validate({})): LOGGING_SCHEMA,
+        "metrics": METRICS_SCHEMA
     }
 )
 

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -19,10 +19,7 @@ from xain_proto.fl.coordinator_pb2 import (
 )
 from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
-from xain_fl.coordinator.metrics_store import (
-    AbstractMetricsStore,
-    NullObjectMetricsStore,
-)
+from xain_fl.coordinator.metrics_store import AbstractMetricsStore, NullObjectMetricsStore
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
 from xain_fl.coordinator.store import AbstractStore, NullObjectStore

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -21,6 +21,7 @@ from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator.metrics_store import (
     AbstractMetricsStore,
+    MetricsStoreError,
     NullObjectMetricsStore,
 )
 from xain_fl.coordinator.participants import Participants
@@ -352,7 +353,12 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             metrics=metrics,
         )
 
-        self.metrics_store.write_metrics(participant_id, metrics)
+        try:
+            self.metrics_store.write_metrics(participant_id, metrics)
+        except MetricsStoreError as err:
+            logger.warn(
+                "Can not write metrics", participant_id=participant_id, error=repr(err)
+            )
 
         # The round is over. Run the aggregation
         if self.round.is_finished():

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -19,7 +19,7 @@ from xain_proto.fl.coordinator_pb2 import (
 )
 from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
-from xain_fl.coordinator.metrics_store import ABCMetricsStore, MetricsStore, NoMetricsStore
+from xain_fl.coordinator.metrics_store import ABCMetricsStore, NoMetricsStore
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
 from xain_fl.coordinator.store import AbstractStore, NullObjectStore

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -19,7 +19,7 @@ from xain_proto.fl.coordinator_pb2 import (
 )
 from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
-from xain_fl.coordinator.metrics_store import AbstractMetricsStore, DummyMetricsStore
+from xain_fl.coordinator.metrics_store import AbstractMetricsStore, NullObjectMetricsStore
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
 from xain_fl.coordinator.store import AbstractStore, NullObjectStore
@@ -94,6 +94,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
         store: AbstractStore = NullObjectStore(),
+        metrics_store: AbstractMetricsStore = NullObjectMetricsStore(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,
         fraction_of_participants: float = 1.0,
@@ -102,7 +103,6 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         epoch_base: int = 0,
         aggregator: Aggregator = WeightedAverageAggregator(),
         controller: Controller = RandomController(),
-        metrics_store: AbstractMetricsStore = DummyMetricsStore(),
     ) -> None:
         self.store: AbstractStore = store
         self.minimum_participants_in_round: int = minimum_participants_in_round

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -19,7 +19,10 @@ from xain_proto.fl.coordinator_pb2 import (
 )
 from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
-from xain_fl.coordinator.metrics_store import AbstractMetricsStore, NullObjectMetricsStore
+from xain_fl.coordinator.metrics_store import (
+    AbstractMetricsStore,
+    NullObjectMetricsStore,
+)
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
 from xain_fl.coordinator.store import AbstractStore, NullObjectStore

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -8,16 +8,13 @@ from influxdb import InfluxDBClient
 from numpy import array2string, ndarray
 
 from xain_fl.config import MetricsConfig
-from xain_fl.logger import StructLogger, get_logger
-
-logger: StructLogger = get_logger(__name__)
 
 
 class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         """Write the participant metrics on behalf of the participant with the given participant_id
         into a metric store.
 
@@ -37,7 +34,7 @@ class NullObjectMetricsStore(
 ):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         """A method that has no effect.
 
         Args:

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -45,8 +45,9 @@ class NullObjectMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-p
 
         Returns:
 
-            True, on success, otherwise False.
+            Always True.
         """
+        return True
 
 
 class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -13,7 +13,7 @@ def current_time():
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-class ABCMetricsStore(ABC): # pylint: disable=too-few-public-methods
+class ABCMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
@@ -27,12 +27,12 @@ class ABCMetricsStore(ABC): # pylint: disable=too-few-public-methods
         """
 
 
-class NoMetricsStore(ABCMetricsStore): # pylint: disable=too-few-public-methods
+class NoMetricsStore(ABCMetricsStore):  # pylint: disable=too-few-public-methods
     def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         pass
 
 
-class MetricsStore(ABCMetricsStore): # pylint: disable=too-few-public-methods
+class MetricsStore(ABCMetricsStore):  # pylint: disable=too-few-public-methods
     def __init__(self, config: MetricsConfig):
         self.config = config
         # pylint: disable=invalid-name

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -32,7 +32,9 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
         """
 
 
-class NullObjectMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
+class NullObjectMetricsStore(
+    AbstractMetricsStore
+):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
     def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
@@ -79,7 +81,9 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
         # FIXME: We will change the data format of the metrics message in a separate ticket.
         # The goal is, that coordinator doesn't need to transform the metrics anymore.
-        influx_data_points = transform_metrics_to_influx_data_points(participant_id, metrics)
+        influx_data_points = transform_metrics_to_influx_data_points(
+            participant_id, metrics
+        )
 
         try:
             return self.influx_client.write_points(influx_data_points)
@@ -116,7 +120,10 @@ def transform_metrics_to_influx_data_points(
                 "time": next_epoch_time,
                 "fields": {
                     metric_name: array2string(
-                        epoch_data_point, precision=8, suppress_small=True, floatmode="fixed"
+                        epoch_data_point,
+                        precision=8,
+                        suppress_small=True,
+                        floatmode="fixed",
                     )
                 },
             }

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -48,8 +48,10 @@ class NullObjectMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-p
             True, on success, otherwise False.
         """
 
+
 class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
     """A metric store that uses InfluxDB to store the metrics."""
+
     def __init__(self, config: MetricsConfig):
         self.config = config
         self.influx_client = InfluxDBClient(

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -79,7 +79,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             True, on success, otherwise False.
         """
 
-        # FIXME: We will change the data format of the metrics message in a separate ticket 
+        # FIXME: We will change the data format of the metrics message in a separate ticket
         # (PB-390). The goal is, that coordinator doesn't need to transform the metrics anymore.
         influx_data_points = transform_metrics_to_influx_data_points(
             participant_id, metrics
@@ -90,6 +90,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
         except Exception as err:  # pylint: disable=broad-except
             logger.warn("Can not write metrics", error=str(err))
             return False
+
 
 # Check if ths function can be removed after PB-390 is done.
 def transform_metrics_to_influx_data_points(
@@ -107,7 +108,7 @@ def transform_metrics_to_influx_data_points(
 
     # Currently the metrics message does not contain any timestamps.
     # We set a timestamp for each epoch data point with an interval of 1 sec for the case,
-    # that the participant send metrics for more than 1 epoch per round. 
+    # that the participant send metrics for more than 1 epoch per round.
     # If we just use the same timestamp, all data points will group on a horizontal line.
     first_epoch_time = datetime.now()
     data_points: List = []

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 from abc import ABC, abstractmethod
-from typing import Dict, List
+from datetime import datetime
+from typing import Dict
 
 from influxdb import InfluxDBClient
 from numpy import ndarray
@@ -12,21 +13,26 @@ def current_time():
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-class ABCMetricsStore(ABC):
-    """An abstract participant for federated learning."""
+class ABCMetricsStore(ABC): # pylint: disable=too-few-public-methods
+    """An abstract metric store."""
 
     @abstractmethod
     def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         """
+        Args:
+
+        participant_ids: The list of IDs of the participants selected
+            to participate in this round.
+        metrics :
         """
 
 
-class NoMetricsStore(ABCMetricsStore):
+class NoMetricsStore(ABCMetricsStore): # pylint: disable=too-few-public-methods
     def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         pass
 
 
-class MetricsStore(ABCMetricsStore):
+class MetricsStore(ABCMetricsStore): # pylint: disable=too-few-public-methods
     def __init__(self, config: MetricsConfig):
         self.config = config
         # pylint: disable=invalid-name
@@ -38,7 +44,7 @@ class MetricsStore(ABCMetricsStore):
             self.config.db_name,
         )
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]):
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
         metrics = {
             "measurement": "participant",
             "tags": {"host": participant_id},

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -4,9 +4,13 @@ from datetime import datetime
 from typing import Dict
 
 from influxdb import InfluxDBClient
+from influxdb.client import InfluxDBClientError
 from numpy import ndarray
 
 from xain_fl.config import MetricsConfig
+from xain_fl.logger import StructLogger, get_logger
+
+logger: StructLogger = get_logger(__name__)
 
 
 def current_time():
@@ -58,4 +62,8 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             # "fields": {"state": state},
         }
 
-        return self.influx_client.write_points([metrics])
+        try:
+            return self.influx_client.write_points([metrics])
+        except InfluxDBClientError as err:
+            logger.warn("Invalid config", error=str(err))
+            return False

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -1,0 +1,49 @@
+# pylint: disable=missing-docstring
+from abc import ABC, abstractmethod
+from typing import Dict, List
+
+from influxdb import InfluxDBClient
+from numpy import ndarray
+
+from xain_fl.config import MetricsConfig
+
+
+def current_time():
+    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ABCMetricsStore(ABC):
+    """An abstract participant for federated learning."""
+
+    @abstractmethod
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+        """
+        """
+
+
+class NoMetricsStore(ABCMetricsStore):
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+        pass
+
+
+class MetricsStore(ABCMetricsStore):
+    def __init__(self, config: MetricsConfig):
+        self.config = config
+        # pylint: disable=invalid-name
+        self.influx_client = InfluxDBClient(
+            self.config.host,
+            self.config.port,
+            self.config.user,
+            self.config.password,
+            self.config.db_name,
+        )
+
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]):
+        metrics = {
+            "measurement": "participant",
+            "tags": {"host": participant_id},
+            "time": current_time(),
+            # "fields": {"state": state},
+        }
+
+        return self.influx_client.write_points([metrics])

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -13,10 +13,6 @@ from xain_fl.logger import StructLogger, get_logger
 logger: StructLogger = get_logger(__name__)
 
 
-def current_time_in_sec():
-    return timegm(datetime.utcnow().utctimetuple())
-
-
 class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
@@ -66,16 +62,20 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             return False
 
 
+def current_time_in_sec():
+    return timegm(datetime.utcnow().utctimetuple())
+
+
 def format_date(total_seconds):
     return datetime.fromtimestamp(total_seconds).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def transform_metrics_to_influx_data_points(participant_id: str, metrics: Dict[str, ndarray]):
-    start_first_epoch_in_sec = current_time_in_sec()
+    first_epoch_in_sec = current_time_in_sec()
     data_points: List = []
 
     for name, epoch_data_points in metrics.items():
-        next_epoch_time_in_sec = timedelta(seconds=start_first_epoch_in_sec)
+        next_epoch_time_in_sec = timedelta(seconds=first_epoch_in_sec)
 
         for epoch_data_point in epoch_data_points:
             data_point = {

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -79,8 +79,8 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             True, on success, otherwise False.
         """
 
-        # FIXME: We will change the data format of the metrics message in a separate ticket.
-        # The goal is, that coordinator doesn't need to transform the metrics anymore.
+        # FIXME: We will change the data format of the metrics message in a separate ticket 
+        # (PB-390). The goal is, that coordinator doesn't need to transform the metrics anymore.
         influx_data_points = transform_metrics_to_influx_data_points(
             participant_id, metrics
         )
@@ -91,13 +91,13 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             logger.warn("Can not write metrics", error=str(err))
             return False
 
-
+# Check if ths function can be removed after PB-390 is done.
 def transform_metrics_to_influx_data_points(
     participant_id: str, metrics: Dict[str, ndarray]
 ) -> List[dict]:
     """Transform the metrics of a participant into InfluxDB data points.
 
-    Arguments:
+    Args:
         participant_id: The ID of the participant.
         metrics: The metrics of the participant with the given participant_id.
 
@@ -106,7 +106,9 @@ def transform_metrics_to_influx_data_points(
     """
 
     # Currently the metrics message does not contain any timestamps.
-    # We set a timestamp for each epoch data point with an interval of 1 sec.
+    # We set a timestamp for each epoch data point with an interval of 1 sec for the case,
+    # that the participant send metrics for more than 1 epoch per round. 
+    # If we just use the same timestamp, all data points will group on a horizontal line.
     first_epoch_time = datetime.now()
     data_points: List = []
 

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -13,26 +13,32 @@ def current_time():
     return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-class ABCMetricsStore(ABC):  # pylint: disable=too-few-public-methods
+class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
-        """
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+        """ 
         Args:
 
-        participant_ids: The list of IDs of the participants selected
-            to participate in this round.
-        metrics :
+            participant_ids: The list of IDs of the participants selected
+                to participate in this round.
+            metrics: The metrics of the participant with the given participant_id. 
+
+        Returns: 
+        
+            True, on success, otherwise False.
         """
 
 
-class NoMetricsStore(ABCMetricsStore):  # pylint: disable=too-few-public-methods
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+class DummyMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
+    """A metric store that does nothing."""
+
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
         pass
 
 
-class MetricsStore(ABCMetricsStore):  # pylint: disable=too-few-public-methods
+class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
     def __init__(self, config: MetricsConfig):
         self.config = config
         # pylint: disable=invalid-name
@@ -44,10 +50,10 @@ class MetricsStore(ABCMetricsStore):  # pylint: disable=too-few-public-methods
             self.config.db_name,
         )
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
         metrics = {
             "measurement": "participant",
-            "tags": {"host": participant_id},
+            "tags": {"id": participant_id},
             "time": current_time(),
             # "fields": {"state": state},
         }

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -32,11 +32,11 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
         """
 
 
-class DummyMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
+class NullObjectMetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
     def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
-        """A dummy method that has no effect.
+        """A method that has no effect.
 
         Args:
 

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -1,6 +1,6 @@
 """XAIN FL Rounds"""
 
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from numpy import ndarray
 

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -4,7 +4,6 @@ from typing import Dict, List, Tuple
 
 from numpy import ndarray
 
-from xain_fl.coordinator.metrics_store import ABCMetricsStore
 from xain_fl.tools.exceptions import DuplicatedUpdateError
 
 
@@ -19,10 +18,9 @@ class Round:
             to participate in this round.
     """
 
-    def __init__(self, participant_ids: List[str], metrics_store: ABCMetricsStore) -> None:
+    def __init__(self, participant_ids: List[str]) -> None:
         self.participant_ids = participant_ids
         self.updates: Dict[str, Dict] = {}
-        self.metrics_store = metrics_store
 
     def add_updates(
         self,
@@ -57,8 +55,6 @@ class Round:
             "aggregation_data": aggregation_data,
             "metrics": metrics,
         }
-
-        self.metrics_store.write_metrics(participant_id, metrics)
 
     def is_finished(self) -> bool:
         """Check if all the required participants submitted their updates this round.

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -1,9 +1,10 @@
 """XAIN FL Rounds"""
 
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from numpy import ndarray
 
+from xain_fl.coordinator.metrics_store import ABCMetricsStore
 from xain_fl.tools.exceptions import DuplicatedUpdateError
 
 
@@ -18,9 +19,10 @@ class Round:
             to participate in this round.
     """
 
-    def __init__(self, participant_ids: List[str]) -> None:
+    def __init__(self, participant_ids: List[str], metrics_store: ABCMetricsStore) -> None:
         self.participant_ids = participant_ids
         self.updates: Dict[str, Dict] = {}
+        self.metrics_store = metrics_store
 
     def add_updates(
         self,
@@ -55,6 +57,8 @@ class Round:
             "aggregation_data": aggregation_data,
             "metrics": metrics,
         }
+
+        self.metrics_store.write_metrics(participant_id, metrics)
 
     def is_finished(self) -> bool:
         """Check if all the required participants submitted their updates this round.


### PR DESCRIPTION
### References

[PB-351 Implement metric proxying/re-routing on coordinator for metrics shipped by participant](https://xainag.atlassian.net/browse/PB-351)

### Summary

* store participant metrics on InfluxDB
* InfluxDBClient is configurable via the config.toml
* feature is enabled in `docker-compose-dev` only

### Are there any open tasks/blockers for the ticket?

* Adjust the metrics messages to meet the needs of InfluxDB.(PB-390)

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
