### PR TITLE
PB-382: cleanup storage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from xain_fl.fl.coordinator.controller import IdController
 from xain_fl.helloproto.numproto_server import NumProtoServer
 
 from .port_forwarding import ConnectionManager
-from .store import TestStore
+from .store import FakeS3Store
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def coordinator_service():
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     coordinator = Coordinator(minimum_participants_in_round=10, fraction_of_participants=1.0)
-    store = TestStore()
+    store = FakeS3Store()
     coordinator_grpc = CoordinatorGrpc(coordinator, store)
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
     server.add_insecure_port("localhost:50051")
@@ -69,7 +69,7 @@ def mock_coordinator_service():
         aggregator=agg,
         controller=ctrl,
     )
-    with mock.patch("xain_fl.coordinator.coordinator_grpc.Store") as mock_obj:
+    with mock.patch("xain_fl.coordinator.coordinator_grpc.AbstractStore") as mock_obj:
         mock_store = mock_obj.return_value
         coordinator_grpc = CoordinatorGrpc(coordinator, mock_store)
         coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)

--- a/tests/store.py
+++ b/tests/store.py
@@ -8,7 +8,7 @@ import typing
 import numpy as np
 
 from xain_fl.config import StorageConfig
-from xain_fl.coordinator.store import Store
+from xain_fl.coordinator.store import S3Store
 
 
 class FakeS3Resource:
@@ -62,9 +62,10 @@ class FakeS3Resource:
         self.reads[key] += 1
 
 
-class TestStore(Store):
-    """A partial mock of the `xain-fl.coordinator.store.Store` class that
-    does not perform any IO. Instead, data is stored in memory.
+class FakeS3Store(S3Store):
+    """A partial mock of the ``xain-fl.coordinator.store.S3Store`` class
+    that does not perform any IO. Instead, data is stored in memory.
+
     """
 
     # We DO NOT want to call the parent class __init__, since it tries

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -36,7 +36,7 @@ from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
 from xain_fl.coordinator.participants import Participants
 
-from .store import TestStore
+from .store import FakeS3Store
 
 
 @pytest.mark.integration
@@ -95,7 +95,7 @@ def test_participant_rendezvous_later(participant_stub):
         coordinator.participants.add(str(i))
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    store = TestStore()
+    store = FakeS3Store()
     add_CoordinatorServicer_to_server(CoordinatorGrpc(coordinator, store), server)
     server.add_insecure_port("localhost:50051")
     server.start()

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -5,7 +5,7 @@ import sys
 
 from xain_fl.config import Config, InvalidConfig, get_cmd_parameters
 from xain_fl.coordinator.coordinator import Coordinator
-from xain_fl.coordinator.store import Store
+from xain_fl.coordinator.store import S3Store
 from xain_fl.logger import StructLogger, get_logger, initialize_logging
 from xain_fl.serve import serve
 
@@ -31,7 +31,7 @@ def main():
         fraction_of_participants=config.ai.fraction_participants,
     )
 
-    store = Store(config.storage)
+    store = S3Store(config.storage)
 
     serve(coordinator=coordinator, store=store, server_config=config.server)
 

--- a/xain_fl/coordinator/coordinator_grpc.py
+++ b/xain_fl/coordinator/coordinator_grpc.py
@@ -15,7 +15,7 @@ from xain_proto.fl.coordinator_pb2 import (
 from xain_proto.fl.coordinator_pb2_grpc import CoordinatorServicer
 
 from xain_fl.coordinator.coordinator import Coordinator
-from xain_fl.coordinator.store import Store
+from xain_fl.coordinator.store import AbstractStore
 from xain_fl.tools.exceptions import (
     DuplicatedUpdateError,
     InvalidRequestError,
@@ -40,9 +40,9 @@ class CoordinatorGrpc(CoordinatorServicer):
             aggregated models.
     """
 
-    def __init__(self, coordinator: Coordinator, store: Store):
+    def __init__(self, coordinator: Coordinator, store: AbstractStore):
         self.coordinator: Coordinator = coordinator
-        self.store: Store = store
+        self.store: AbstractStore = store
 
     def Rendezvous(
         self, request: RendezvousRequest, context: grpc.ServicerContext

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -1,4 +1,8 @@
-# pylint: disable=missing-docstring
+"""This module provides classes for weights storage. It currently only
+works with services that provide the AWS S3 APIs.
+
+"""
+import abc
 from io import BytesIO
 import pickle
 
@@ -8,7 +12,46 @@ from numpy import ndarray
 from xain_fl.config import StorageConfig
 
 
-class Store:
+class AbstractStore(abc.ABC):
+
+    """An abstract class that defines the API a store must implement.
+
+    """
+
+    @abc.abstractmethod
+    def write_weights(self, round: int, weights: ndarray) -> None:
+        """Store the given `weights`, corresponding to the given `round`.
+
+        Args:
+
+            round: round number the weights correspond to
+            weights: weights to store
+
+        """
+
+    @abc.abstractmethod
+    def read_weights(self, participant_id: str, round: int) -> ndarray:
+        """Read the weights computed by the given participant for the given
+        round.
+
+        Args:
+
+            participant_id: ID of the participant's weights
+            round: round number the weights correspond to
+
+        """
+
+
+class S3Store(AbstractStore):
+    """A store for services that offer the AWS S3 API.
+
+    Args:
+
+        config: the storage configuration (endpoint URL, credentials,
+            etc.)
+
+    """
+
     def __init__(self, config: StorageConfig):
         self.config = config
         # pylint: disable=invalid-name
@@ -22,10 +65,31 @@ class Store:
         )
 
     def write_weights(self, round: int, weights: ndarray):
+        """Store the given `weights`, corresponding to the given `round`.
+
+        Args:
+
+            round: round number the weights correspond to
+            weights: weights to store
+
+        """
         bucket = self.s3.Bucket(self.config.bucket)
         bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
 
-    def read_weights(self, round: int) -> ndarray:
+    def read_weights(self, _participant_id: str, round: int) -> ndarray:
+        """Download the weights computed by the given participant for the given
+        round, from an S3 bucket.
+
+        Args:
+
+            _participant_id: ID of the participant's weights
+            round: round number the weights correspond to
+
+        Return:
+
+            The weights read from the S3 bucket
+
+        """
         bucket = self.s3.Bucket(self.config.bucket)
         data = BytesIO()
         bucket.download_fileobj(str(round), data)

--- a/xain_fl/serve.py
+++ b/xain_fl/serve.py
@@ -12,13 +12,13 @@ from xain_fl.coordinator import _ONE_DAY_IN_SECONDS
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
-from xain_fl.coordinator.store import Store
+from xain_fl.coordinator.store import AbstractStore
 from xain_fl.logger import StructLogger, get_logger
 
 logger: StructLogger = get_logger(__name__)
 
 
-def serve(coordinator: Coordinator, store: Store, server_config: ServerConfig) -> None:
+def serve(coordinator: Coordinator, store: AbstractStore, server_config: ServerConfig) -> None:
     """Main method to start the gRPC service.
 
     This methods just creates the :class:`xain_fl.coordinator.coordinator.Coordinator`,


### PR DESCRIPTION
### Summary:

- introduce an abstract class that defines the storage API
- document the `xain_fl.coordinator.store` module
- rename `tests.store.TestStore` into `tests.store.FakeS3Store`

### References:

https://xainag.atlassian.net/browse/PB-382

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
