### PR TITLE
PB-383 write aggregated weights after each round

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from concurrent import futures
 import threading
-from unittest import mock
 
 import grpc
 import pytest
@@ -16,7 +15,6 @@ from xain_fl.fl.coordinator.controller import IdController
 from xain_fl.helloproto.numproto_server import NumProtoServer
 
 from .port_forwarding import ConnectionManager
-from .store import FakeS3Store
 
 
 @pytest.fixture
@@ -42,10 +40,7 @@ def coordinator_service():
     """
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    store = FakeS3Store()
-    coordinator = Coordinator(
-        store=store, minimum_participants_in_round=10, fraction_of_participants=1.0
-    )
+    coordinator = Coordinator(minimum_participants_in_round=10, fraction_of_participants=1.0)
     coordinator_grpc = CoordinatorGrpc(coordinator)
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
     server.add_insecure_port("localhost:50051")
@@ -64,29 +59,26 @@ def mock_coordinator_service():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     agg = ModelSumAggregator()
     ctrl = IdController()
-    with mock.patch("xain_fl.coordinator.store.AbstractStore") as mock_obj:
-        mock_store = mock_obj.return_value
-        coordinator = Coordinator(
-            store=mock_store,
-            num_rounds=2,
-            minimum_participants_in_round=1,
-            fraction_of_participants=1.0,
-            aggregator=agg,
-            controller=ctrl,
-        )
-        coordinator_grpc = CoordinatorGrpc(coordinator)
-        coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
-        server.add_insecure_port("localhost:50051")
-        server.start()
-        terminate_event = threading.Event()
-        monitor_thread = threading.Thread(
-            target=monitor_heartbeats, args=(coordinator, terminate_event)
-        )
-        monitor_thread.start()
-        yield coordinator_grpc
-        terminate_event.set()
-        monitor_thread.join()
-        server.stop(0)
+    coordinator = Coordinator(
+        num_rounds=2,
+        minimum_participants_in_round=1,
+        fraction_of_participants=1.0,
+        aggregator=agg,
+        controller=ctrl,
+    )
+    coordinator_grpc = CoordinatorGrpc(coordinator)
+    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(coordinator_grpc, server)
+    server.add_insecure_port("localhost:50051")
+    server.start()
+    terminate_event = threading.Event()
+    monitor_thread = threading.Thread(
+        target=monitor_heartbeats, args=(coordinator, terminate_event)
+    )
+    monitor_thread.start()
+    yield coordinator_grpc
+    terminate_event.set()
+    monitor_thread.join()
+    server.stop(0)
 
 
 @pytest.fixture

--- a/tests/store.py
+++ b/tests/store.py
@@ -11,7 +11,7 @@ from xain_fl.config import StorageConfig
 from xain_fl.coordinator.store import S3Store
 
 
-class FakeS3Resource:
+class MockS3Resource:
     """Mock of the `xain-fl.coordinator.Store.s3` attribute.
 
     This class offers the same API than `boto3.S3.Client.bucket` but
@@ -62,7 +62,7 @@ class FakeS3Resource:
         self.reads[key] += 1
 
 
-class FakeS3Store(S3Store):
+class MockS3Store(S3Store):
     """A partial mock of the ``xain-fl.coordinator.store.S3Store`` class
     that does not perform any IO. Instead, data is stored in memory.
 
@@ -79,7 +79,7 @@ class FakeS3Store(S3Store):
             secret_access_key="secret_access_key",
             bucket="bucket",
         )
-        self.s3 = FakeS3Resource()
+        self.s3 = MockS3Resource()
 
     def assert_wrote(self, round: int, weights: np.ndarray):
         """Check that the given weights have been written to the store for the

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -37,7 +37,7 @@ from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
 from xain_fl.coordinator.participants import ParticipantContext, Participants
 
-from .store import FakeS3Store
+from .store import MockS3Store
 
 
 @pytest.mark.integration
@@ -90,9 +90,7 @@ def test_participant_rendezvous_later(participant_stub):
     """
 
     # populate participants
-    coordinator = Coordinator(
-        store=FakeS3Store(), minimum_participants_in_round=10, fraction_of_participants=1.0
-    )
+    coordinator = Coordinator(minimum_participants_in_round=10, fraction_of_participants=1.0)
     required_participants = 10
     for i in range(required_participants):
         coordinator.participants.add(str(i))
@@ -416,11 +414,12 @@ def test_end_training_round_denied(  # pylint: disable=unused-argument
 
 
 @pytest.mark.integration
-def test_full_training_round(
-    participant_stubs, coordinator_service
-):  # pylint: disable=unused-argument
+def test_full_training_round(participant_stubs, coordinator_service):
     """Run a complete training round with multiple participants.
     """
+    # Use a MockS3Store so that we can also test the storage logic
+    coordinator_service.coordinator.store = MockS3Store()
+
     # Initialize the coordinator with dummy weights, otherwise, the
     # aggregated weights at the end of the round are an empty array.
     dummy_weights = np.ndarray([1, 2, 3, 4])

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -27,15 +27,14 @@ def main():
     set_log_level(config.logging.level.upper())
 
     coordinator = Coordinator(
+        store=S3Store(config.storage),
         num_rounds=config.ai.rounds,
         epochs=config.ai.epochs,
         minimum_participants_in_round=config.ai.min_participants,
         fraction_of_participants=config.ai.fraction_participants,
     )
 
-    store = S3Store(config.storage)
-
-    serve(coordinator=coordinator, store=store, server_config=config.server)
+    serve(coordinator=coordinator, server_config=config.server)
 
 
 main()

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -20,6 +20,7 @@ from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
+from xain_fl.coordinator.store import AbstractStore, DummyStore
 from xain_fl.fl.coordinator.aggregate import Aggregator, WeightedAverageAggregator
 from xain_fl.fl.coordinator.controller import Controller, RandomController
 from xain_fl.logger import StructLogger, get_logger
@@ -95,6 +96,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        store: AbstractStore = DummyStore(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,
         fraction_of_participants: float = 1.0,
@@ -104,6 +106,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         aggregator: Aggregator = WeightedAverageAggregator(),
         controller: Controller = RandomController(),
     ) -> None:
+        self.store: AbstractStore = store
         self.minimum_participants_in_round: int = minimum_participants_in_round
         self.fraction_of_participants: float = fraction_of_participants
         self.participants: Participants = Participants()
@@ -360,6 +363,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             self.weights = self.aggregator.aggregate(
                 mult_model_weights=mult_model_weights, aggregation_data=aggregation_data
             )
+            self.store.write_weights(self.current_round, self.weights)
 
             # update the round or finish the training session
             if self.current_round >= self.num_rounds - 1:

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -20,7 +20,7 @@ from xain_proto.numproto import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
-from xain_fl.coordinator.store import AbstractStore, DummyStore
+from xain_fl.coordinator.store import AbstractStore, NullObjectStore
 from xain_fl.fl.coordinator.aggregate import Aggregator, WeightedAverageAggregator
 from xain_fl.fl.coordinator.controller import Controller, RandomController
 from xain_fl.logger import StructLogger, get_logger
@@ -96,7 +96,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        store: AbstractStore = DummyStore(),
+        store: AbstractStore = NullObjectStore(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,
         fraction_of_participants: float = 1.0,

--- a/xain_fl/coordinator/coordinator_grpc.py
+++ b/xain_fl/coordinator/coordinator_grpc.py
@@ -10,12 +10,10 @@ from xain_proto.fl.coordinator_pb2 import (
     RendezvousResponse,
     StartTrainingRoundRequest,
     StartTrainingRoundResponse,
-    State,
 )
 from xain_proto.fl.coordinator_pb2_grpc import CoordinatorServicer
 
 from xain_fl.coordinator.coordinator import Coordinator
-from xain_fl.coordinator.store import AbstractStore
 from xain_fl.tools.exceptions import (
     DuplicatedUpdateError,
     InvalidRequestError,
@@ -34,15 +32,10 @@ class CoordinatorGrpc(CoordinatorServicer):
     Args:
 
         coordinator: The Coordinator state machine.
-
-        store: The Store in which the coordinator fetches trained
-            models from the participants and to which it saves
-            aggregated models.
     """
 
-    def __init__(self, coordinator: Coordinator, store: AbstractStore):
+    def __init__(self, coordinator: Coordinator):
         self.coordinator: Coordinator = coordinator
-        self.store: AbstractStore = store
 
     def Rendezvous(
         self, request: RendezvousRequest, context: grpc.ServicerContext
@@ -162,7 +155,7 @@ class CoordinatorGrpc(CoordinatorServicer):
             successfully received the updated weights.
         """
         try:
-            response = self.coordinator.on_message(request, context.peer())
+            return self.coordinator.on_message(request, context.peer())
         except DuplicatedUpdateError as error:
             context.set_details(str(error))
             context.set_code(grpc.StatusCode.ALREADY_EXISTS)
@@ -171,7 +164,3 @@ class CoordinatorGrpc(CoordinatorServicer):
             context.set_details(str(error))
             context.set_code(grpc.StatusCode.PERMISSION_DENIED)
             return EndTrainingRoundResponse()
-
-        if self.coordinator.state == State.FINISHED:
-            self.store.write_weights(self.coordinator.current_round, self.coordinator.weights)
-        return response

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -42,6 +42,30 @@ class AbstractStore(abc.ABC):
         """
 
 
+class DummyStore(AbstractStore):
+    """A store that does nothing"""
+
+    def write_weights(self, _round: int, _weights: ndarray) -> None:
+        """A dummy method that has no effect.
+
+        Args:
+
+            _round: round number the weights correspond to. Not used.
+            _weights: weights to store. Not used.
+
+        """
+
+    def read_weights(self, _participant_id: str, _round: int) -> ndarray:
+        """A dummy method that has no effect.
+
+        Args:
+
+            _participant_id: ID of the participant's weights
+            _round: round number the weights correspond to
+
+        """
+
+
 class S3Store(AbstractStore):
     """A store for services that offer the AWS S3 API.
 

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -42,7 +42,7 @@ class AbstractStore(abc.ABC):
         """
 
 
-class DummyStore(AbstractStore):
+class NullObjectStore(AbstractStore):
     """A store that does nothing"""
 
     def write_weights(self, _round: int, _weights: ndarray) -> None:

--- a/xain_fl/serve.py
+++ b/xain_fl/serve.py
@@ -12,13 +12,12 @@ from xain_fl.coordinator import _ONE_DAY_IN_SECONDS
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
-from xain_fl.coordinator.store import AbstractStore
 from xain_fl.logger import StructLogger, get_logger
 
 logger: StructLogger = get_logger(__name__)
 
 
-def serve(coordinator: Coordinator, store: AbstractStore, server_config: ServerConfig) -> None:
+def serve(coordinator: Coordinator, server_config: ServerConfig) -> None:
     """Main method to start the gRPC service.
 
     This methods just creates the :class:`xain_fl.coordinator.coordinator.Coordinator`,
@@ -32,9 +31,7 @@ def serve(coordinator: Coordinator, store: AbstractStore, server_config: ServerC
     server = grpc.server(
         futures.ThreadPoolExecutor(max_workers=10), options=server_config.grpc_options
     )
-    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(
-        CoordinatorGrpc(coordinator, store), server
-    )
+    coordinator_pb2_grpc.add_CoordinatorServicer_to_server(CoordinatorGrpc(coordinator), server)
     server.add_insecure_port(f"{server_config.host}:{server_config.port}")
     server.start()
     monitor_thread.start()


### PR DESCRIPTION
This is based on #245, which should be merged first.

### References

https://xainag.atlassian.net/browse/PB-383

### Summary

We now store the weights at the end of *each* round instead of the end
of the final round.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
