### PR TITLE
DO-59 Provision Redis 5.x for persisting states for the Coordinator

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.7"
 services:
 
   minio-dev:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -47,6 +47,17 @@ services:
         /usr/bin/mc admin trace -v -e dev-minio;
       "
 
+  redis:
+    image: redis:5 # current stable version, v6 out between March 2020 and May 2020
+    hostname: redis
+    entrypoint: /usr/local/bin/redis-server --appendonly yes --appendfsync everysec # using combination of RDB and AOF for persistence: https://redis.io/topics/persistence
+    volumes:
+      - redis-data:/data
+    networks:
+      - xain-fl-dev
+    ports:
+      - "6379:6379"
+
   xain-fl-dev:
     build:
       context: .
@@ -64,6 +75,7 @@ services:
 
 volumes:
   minio-data:
+  redis-data:
 
 networks:
   xain-fl-dev:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: "3.7"
+version: "3"
 services:
 
   minio-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,9 @@ services:
     volumes:
       - redis-data:/data
     networks:
-      - xain-fl-dev
-    ports:
-      - "6379:6379"
+      - xain-fl
+    expose:
+      - "6379"
 
   xain-fl:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,17 @@ services:
     expose:
       - "9000"
 
+  redis:
+    image: redis:5 # current stable version, v6 out between March 2020 and May 2020
+    hostname: redis
+    entrypoint: /usr/local/bin/redis-server --appendonly yes --appendfsync everysec # using combination of RDB and AOF for persistence: https://redis.io/topics/persistence
+    volumes:
+      - redis-data:/data
+    networks:
+      - xain-fl-dev
+    ports:
+      - "6379:6379"
+
   xain-fl:
     build:
       context: .
@@ -30,6 +41,7 @@ services:
 
 volumes:
   minio-data:
+  redis-data:
 
 networks:
   xain-fl:


### PR DESCRIPTION
### References

[PB-353](https://xainag.atlassian.net/browse/PB-353) -> [DO-59](https://xainag.atlassian.net/browse/DO-59)

### Summary

Updates `docker-compose-dev.yml` and `docker-compose.yml` for provisioning Redis 5.x.
Redis will be used as in-memory key-value storage for the Coordinator to persist its state externally.

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
