### PR TITLE
PB-104: Fix exception in monitor_hearbeats()

### DIFF
--- a/xain_fl/coordinator/heartbeat.py
+++ b/xain_fl/coordinator/heartbeat.py
@@ -29,17 +29,25 @@ def monitor_heartbeats(coordinator: Coordinator, terminate_event: threading.Even
     """
 
     logger.info("Heartbeat monitor starting...")
+
     while not terminate_event.is_set():
         participants_to_remove: List[str] = []
 
+        now = time.time()
         for participant in coordinator.participants.participants.values():
-            if participant.heartbeat_expires < time.time():
+            if participant.heartbeat_expires < now:
                 participants_to_remove.append(participant.participant_id)
 
         for participant_id in participants_to_remove:
             coordinator.remove_participant(participant_id)
 
-        next_expiration: float = coordinator.participants.next_expiration() - time.time()
+        next_expiration: float = coordinator.participants.next_expiration() - now
 
         logger.debug("Monitoring heartbeats", next_expiration=next_expiration)
-        time.sleep(next_expiration)
+
+        # It is better not to use time.sleep() here because if there
+        # is no participant,
+        # coordinator.participants.next_expiration() can be quite big
+        # and we end up sleeping for a long time, even if
+        # terminate_event gets set in the meantime.
+        terminate_event.wait(timeout=next_expiration)


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/PB-104

### Summary:

This adds a test reproducing the following exception, and provides a
fix for it:

```
Exception in thread Thread-1:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/app/xain_fl/coordinator/heartbeat.py", line 45, in monitor_heartbeats
    time.sleep(next_expiration)
ValueError: sleep length must be non-negative
```

Detailed explanation:

There is a timing issue in the `monitor_hearbeats()` function, that is
more likely to occur when we have many participants. Here is a
simplified and commented version of the code that explains the issue in
more details:


```python
class Participants:
    def next_expiration(self) -> float:
        return min([p.heartbeat_expires for p in self.participants.values()])

def monitor_hearbeats():
    while True:

        # Here we can have a participant P such that:
        # P.heartbeat_expires > time.time(), but by a very short margin.
        #
        # Thus, P is not removed from the set of participants
        #
        for participant in coordinator.participants.participants.values():
            if participant.heartbeat_expires < time.time():
                coordinator.remove_participant(participant.participant_id)

        # When we arrive here, P is the next participant to expire, so
        # Participants.next_expiration() returns P.heartbeat_expires.
        # Except now, we have P.heartbeat_expires < time.time(). Note
        # that this is more likely to occur if P is at the beginning
        # of the self.coordinator.participants list, and there are
        # many participants, because then, the loop above takes a long
        # time to execute.
        #
        # Thus, next_expiration is negative
        #
        next_expiration: float = coordinator.participants.next_expiration() - time.time()

        # This now fails
        time.sleep(next_expiration)
```

One solution is to only call `time.time()` once in the `while` loop
body. Then, all the durations will be relative to a fixed offset.

Another solution would be simply not to sleep if `next_iterations`
is negative but the fix mentioned ealier seems cleaner.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
