### PR TITLE
DO-57 Provision InfluxDB for storing coordinator/participant metrics

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -58,6 +58,16 @@ services:
     ports:
       - "6379:6379"
 
+  influxdb:
+    image: influxdb:1.7 # current stable version, v2 is in Beta
+    hostname: influxdb
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+    networks:
+      - xain-fl-dev
+    ports:
+      - "8086:8086"
+
   xain-fl-dev:
     build:
       context: .
@@ -76,6 +86,7 @@ services:
 volumes:
   minio-data:
   redis-data:
+  influxdb-data:
 
 networks:
   xain-fl-dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,16 @@ services:
     expose:
       - "6379"
 
+  influxdb:
+    image: influxdb:1.7 # current stable version, v2 is in Beta
+    hostname: influxdb
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+    networks:
+      - xain-fl
+    expose:
+      - "8086"
+
   xain-fl:
     build:
       context: .
@@ -42,6 +52,7 @@ services:
 volumes:
   minio-data:
   redis-data:
+  influxdb-data:
 
 networks:
   xain-fl:


### PR DESCRIPTION
### References

[PB-172](https://xainag.atlassian.net/browse/PB-172) -> [DO-57](https://xainag.atlassian.net/browse/DO-57)

### Summary

Updates `docker-compose-dev.yml` and `docker-compose.yml` for provisioning InfluxDB.
InfluxDB will be used as Time-Series Database for the Coordinator to store historical data over metrics from itself and registered participants.

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
