### PR TITLE
PB-122: handle sigint properly

### DIFF
--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -38,4 +38,5 @@ def main():
     serve(coordinator=coordinator, store=store, server_config=config.server)
 
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/PB-122

### Summary

Guard the call to `main()` at the end of `__main__.py`. Otherwise
we're starting the coordinator twice by calling the `coordinator`
command: once when `__main__.py` is imported, and once when the
entrypoint (`__main.py__::main`) is called.

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
