### PR TITLE
PB-104: make the tests fast again

### DIFF
--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -148,17 +148,17 @@ def test_heartbeat_denied(participant_stub, coordinator_service):  # pylint: dis
 
 
 @mock.patch("xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True])
-@mock.patch("xain_fl.coordinator.heartbeat.time.sleep", return_value=None)
+@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None)
 @mock.patch("xain_fl.coordinator.heartbeat.Coordinator.remove_participant")
-def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
-    """[summary]
-
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
+def test_monitor_heartbeats(mock_participants_remove, _mock_event_wait, _mock_event_is_set):
+    """Test that when there is a participant with an expired heartbeat,
+    ``Coordinator.remove_participant`` is called exactly once.
 
     Args:
-        mock_participants_remove ([type]): [description]
-        _mock_sleep ([type]): [description]
-        _mock_event ([type]): [description]
+        mock_participants_remove: mock of ``Coordinator.remove_participant()``
+        _mock_evet_wait: mock of ``threading.Event.wait`` that does not block
+        _mock_event_is_set: mock of ``threading.Event.is_set``
+
     """
 
     participants = Participants()
@@ -175,15 +175,16 @@ def test_monitor_heartbeats(mock_participants_remove, _mock_sleep, _mock_event):
 
 
 @mock.patch("xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True])
-@mock.patch("xain_fl.coordinator.heartbeat.time.sleep", return_value=None)
-def test_monitor_heartbeats_remove_participant(_mock_sleep, _mock_event):
-    """[summary]
-
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
+@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None)
+def test_monitor_heartbeats_remove_participant(_mock_event_wait, _mock_event_is_set):
+    """Test that when the coordinator has exactly one participant with an
+    expired heartbeat, it is removed correctly.
 
     Args:
-        _mock_sleep ([type]): [description]
-        _mock_event ([type]): [description]
+
+        _mock_evet_wait: mock of ``threading.Event.wait`` that does not block
+        _mock_event_is_set: mock of ``threading.Event.is_set``
+
     """
 
     participants = Participants()

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -182,7 +182,7 @@ def test_monitor_heartbeats_remove_participant(_mock_event_wait, _mock_event_is_
 
     Args:
 
-        _mock_evet_wait: mock of ``threading.Event.wait`` that does not block
+        _mock_event_wait: mock of ``threading.Event.wait`` that does not block
         _mock_event_is_set: mock of ``threading.Event.is_set``
 
     """

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -156,7 +156,7 @@ def test_monitor_heartbeats(mock_participants_remove, _mock_event_wait, _mock_ev
 
     Args:
         mock_participants_remove: mock of ``Coordinator.remove_participant()``
-        _mock_evet_wait: mock of ``threading.Event.wait`` that does not block
+        _mock_event_wait: mock of ``threading.Event.wait`` that does not block
         _mock_event_is_set: mock of ``threading.Event.is_set``
 
     """


### PR DESCRIPTION
### Summary:

In https://github.com/xainag/xain-fl/pull/248, we replaced the call to
`time.sleep()` in `monitor_hearbeats()` by a call to
`threading.Event.wait()` to optimize for cases where the termination
event is set while we're sleeping. But, that made tests with mocks of
`time.sleep()` slower. This commit fixes that by mocking
`threading.Event.wait()` instead of `time.sleep()` in these tests.

### References:

https://github.com/xainag/xain-fl/pull/248
https://xainag.atlassian.net/browse/PB-104

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
