### PR TITLE
PB-269: enable reading participants weights from S3

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -1,4 +1,4 @@
-# An example configfiguration file. 
+# An example configfiguration file.
 # The values that are used for the optional keys correspond to their default values.
 
 # (Optional)
@@ -10,11 +10,11 @@ port = 50051
 
 # (Optional)
 [server.grpc_options]
-# More information about all available gRPC options can be found here: 
+# More information about all available gRPC options can be found here:
 # https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga813f94f9ac3174571dd712c96cdbbdc1
 
 # Example
-# Maximum message length that the channel can receive. -1 means unlimited. 
+# Maximum message length that the channel can receive. -1 means unlimited.
 # "grpc.max_receive_message_length" = -1
 
 # (Required)
@@ -35,7 +35,9 @@ fraction_participants = 1.0
 # (Required) URL to the storage service to use
 endpoint = "http://minio-dev:9000"
 # (Required) Name of the bucket for storing the aggregated models
-bucket = "xain-fl-aggregated-weights"
+aggregated_weights_bucket = "xain-fl-aggregated-weights"
+# (Required) Name of the bucket for retrieving the participants models
+participants_bucket = "xain-fl-participants-weights"
 # (Required) AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # (Required) AWS secret access to use to authenticate to the storage service

--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -34,10 +34,10 @@ fraction_participants = 1.0
 [storage]
 # (Required) URL to the storage service to use
 endpoint = "http://minio-dev:9000"
-# (Required) Name of the bucket for storing the aggregated models
-aggregated_weights_bucket = "xain-fl-aggregated-weights"
-# (Required) Name of the bucket for retrieving the participants models
-participants_bucket = "xain-fl-participants-weights"
+# (Required) Name of the bucket for storing the global model weights
+global_weights_bucket = "xain-fl-aggregated-weights"
+# (Required) Name of the bucket for retrieving the local model weights
+local_weights_bucket = "xain-fl-participants-weights"
 # (Required) AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # (Required) AWS secret access to use to authenticate to the storage service

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -7,12 +7,12 @@ host = "0.0.0.0"
 port = 50051
 
 [server.grpc_options]
-# More information about all available gRPC options can be found here: 
+# More information about all available gRPC options can be found here:
 # https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html#ga813f94f9ac3174571dd712c96cdbbdc1
 
-# Maximum message length that the channel can receive. -1 means unlimited. 
+# Maximum message length that the channel can receive. -1 means unlimited.
 "grpc.max_receive_message_length" = -1
-# Maximum message length that the channel can send. -1 means unlimited. 
+# Maximum message length that the channel can send. -1 means unlimited.
 "grpc.max_send_message_length" = -1
 
 [ai]
@@ -31,7 +31,9 @@ fraction_participants = 1.0
 # URL to the storage service to use
 endpoint = "http://minio-dev:9000"
 # Name of the bucket for storing the aggregated models
-bucket = "xain-fl-aggregated-weights"
+aggregated_weights_bucket = "xain-fl-aggregated-weights"
+# Name of the bucket for retrieving the participants models
+participants_bucket = "xain-fl-participants-weights"
 # AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # AWS secret access to use to authenticate to the storage service

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -30,10 +30,10 @@ fraction_participants = 1.0
 [storage]
 # URL to the storage service to use
 endpoint = "http://minio-dev:9000"
-# Name of the bucket for storing the aggregated models
-aggregated_weights_bucket = "xain-fl-aggregated-weights"
-# Name of the bucket for retrieving the participants models
-participants_bucket = "xain-fl-participants-weights"
+# Name of the bucket for storing the global model weights
+global_weights_bucket = "xain-fl-aggregated-weights"
+# Name of the bucket for retrieving the local model weights
+local_weights_bucket = "xain-fl-participants-weights"
 # AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # AWS secret access to use to authenticate to the storage service

--- a/tests/store.py
+++ b/tests/store.py
@@ -62,7 +62,7 @@ class MockS3Resource:
         self.reads[key] += 1
 
 
-class MockS3Store(S3GlobalWeightsWriter):
+class MockS3Writer(S3GlobalWeightsWriter):
     """A partial mock of the
     ``xain-fl.coordinator.store.S3GlobalWeightsWriter`` class that
     does not perform any IO. Instead, data is stored in memory.
@@ -78,8 +78,8 @@ class MockS3Store(S3GlobalWeightsWriter):
             endpoint="endpoint",
             access_key_id="access_key_id",
             secret_access_key="secret_access_key",
-            aggregated_weights_bucket="bucket",
-            participants_bucket="bucket",
+            global_weights_bucket="bucket",
+            local_weights_bucket="bucket",
         )
         self.s3 = MockS3Resource()
 

--- a/tests/store.py
+++ b/tests/store.py
@@ -8,7 +8,7 @@ import typing
 import numpy as np
 
 from xain_fl.config import StorageConfig
-from xain_fl.coordinator.store import AggregatedWeightsS3Store
+from xain_fl.coordinator.store import S3GlobalWeightsWriter
 
 
 class MockS3Resource:
@@ -62,9 +62,9 @@ class MockS3Resource:
         self.reads[key] += 1
 
 
-class MockS3Store(AggregatedWeightsS3Store):
+class MockS3Store(S3GlobalWeightsWriter):
     """A partial mock of the
-    ``xain-fl.coordinator.store.AggregatedWeightsS3Store`` class that
+    ``xain-fl.coordinator.store.S3GlobalWeightsWriter`` class that
     does not perform any IO. Instead, data is stored in memory.
 
     """

--- a/tests/store.py
+++ b/tests/store.py
@@ -8,7 +8,7 @@ import typing
 import numpy as np
 
 from xain_fl.config import StorageConfig
-from xain_fl.coordinator.store import S3Store
+from xain_fl.coordinator.store import AggregatedWeightsS3Store
 
 
 class MockS3Resource:
@@ -62,9 +62,10 @@ class MockS3Resource:
         self.reads[key] += 1
 
 
-class MockS3Store(S3Store):
-    """A partial mock of the ``xain-fl.coordinator.store.S3Store`` class
-    that does not perform any IO. Instead, data is stored in memory.
+class MockS3Store(AggregatedWeightsS3Store):
+    """A partial mock of the
+    ``xain-fl.coordinator.store.AggregatedWeightsS3Store`` class that
+    does not perform any IO. Instead, data is stored in memory.
 
     """
 
@@ -77,7 +78,8 @@ class MockS3Store(S3Store):
             endpoint="endpoint",
             access_key_id="access_key_id",
             secret_access_key="secret_access_key",
-            bucket="bucket",
+            aggregated_weights_bucket="bucket",
+            participants_bucket="bucket",
         )
         self.s3 = MockS3Resource()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,7 +46,8 @@ def storage_sample():
     """
     return {
         "endpoint": "http://localhost:9000",
-        "bucket": "aggregated_weights",
+        "aggregated_weights_bucket": "aggregated_weights",
+        "participants_bucket": "participants_weights",
         "secret_access_key": "my-secret",
         "access_key_id": "my-key-id",
     }
@@ -139,7 +140,8 @@ def test_load_valid_config(config_sample):
     assert config.ai.fraction_participants == 1.0
 
     assert config.storage.endpoint == "http://localhost:9000"
-    assert config.storage.bucket == "aggregated_weights"
+    assert config.storage.aggregated_weights_bucket == "aggregated_weights"
+    assert config.storage.participants_bucket == "participants_weights"
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -46,8 +46,8 @@ def storage_sample():
     """
     return {
         "endpoint": "http://localhost:9000",
-        "aggregated_weights_bucket": "aggregated_weights",
-        "participants_bucket": "participants_weights",
+        "global_weights_bucket": "aggregated_weights",
+        "local_weights_bucket": "participants_weights",
         "secret_access_key": "my-secret",
         "access_key_id": "my-key-id",
     }
@@ -140,8 +140,8 @@ def test_load_valid_config(config_sample):
     assert config.ai.fraction_participants == 1.0
 
     assert config.storage.endpoint == "http://localhost:9000"
-    assert config.storage.aggregated_weights_bucket == "aggregated_weights"
-    assert config.storage.participants_bucket == "participants_weights"
+    assert config.storage.global_weights_bucket == "aggregated_weights"
+    assert config.storage.local_weights_bucket == "participants_weights"
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,7 @@
 """XAIN FL tests for coordinator"""
 
+from unittest import mock
+
 import numpy as np
 import pytest
 from xain_proto.fl.coordinator_pb2 import (
@@ -137,10 +139,9 @@ def start_training_round_wrong_state():
         coordinator.on_message(StartTrainingRoundRequest(), "participant1")
 
 
-def test_end_training_round():
-    """[summary]
-
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
+@mock.patch("xain_fl.coordinator.store.NullObjectStore.read_weights")
+def test_end_training_round(read_weights_mock):
+    """Test handling of a `EndTrainingRoundRequest` message.
     """
 
     # we need two participants so that we can check the status of the local update mid round
@@ -155,6 +156,7 @@ def test_end_training_round():
     coordinator.on_message(EndTrainingRoundRequest(), "participant1")
 
     assert len(coordinator.round.updates) == 1
+    read_weights_mock.assert_called_once_with("participant1", 0)
 
 
 def test_end_training_round_update():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -139,7 +139,7 @@ def start_training_round_wrong_state():
         coordinator.on_message(StartTrainingRoundRequest(), "participant1")
 
 
-@mock.patch("xain_fl.coordinator.store.NullObjectStore.read_weights")
+@mock.patch("xain_fl.coordinator.store.NullObjectLocalWeightsReader.read_weights")
 def test_end_training_round(read_weights_mock):
     """Test handling of a `EndTrainingRoundRequest` message.
     """

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -407,7 +407,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
     """Run a complete training round with multiple participants.
     """
     # Use a MockS3Store so that we can also test the storage logic
-    coordinator_service.coordinator.aggregated_weights_store = MockS3Store()
+    coordinator_service.coordinator.global_weights_writer = MockS3Store()
 
     # Initialize the coordinator with dummy weights, otherwise, the
     # aggregated weights at the end of the round are an empty array.
@@ -463,7 +463,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
         assert response == EndTrainingRoundResponse()
 
     assert not coordinator_service.coordinator.round.is_finished()
-    coordinator_service.coordinator.aggregated_weights_store.assert_didnt_write(1)
+    coordinator_service.coordinator.global_weights_writer.assert_didnt_write(1)
 
     # The last participant finishes training
     response = last_participant.EndTrainingRound(
@@ -471,7 +471,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
     )
     assert response == EndTrainingRoundResponse()
     # Make sure we wrote the results for the given round
-    coordinator_service.coordinator.aggregated_weights_store.assert_wrote(
+    coordinator_service.coordinator.global_weights_writer.assert_wrote(
         0, coordinator_service.coordinator.weights
     )
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -407,7 +407,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
     """Run a complete training round with multiple participants.
     """
     # Use a MockS3Store so that we can also test the storage logic
-    coordinator_service.coordinator.store = MockS3Store()
+    coordinator_service.coordinator.aggregated_weights_store = MockS3Store()
 
     # Initialize the coordinator with dummy weights, otherwise, the
     # aggregated weights at the end of the round are an empty array.
@@ -463,7 +463,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
         assert response == EndTrainingRoundResponse()
 
     assert not coordinator_service.coordinator.round.is_finished()
-    coordinator_service.coordinator.store.assert_didnt_write(1)
+    coordinator_service.coordinator.aggregated_weights_store.assert_didnt_write(1)
 
     # The last participant finishes training
     response = last_participant.EndTrainingRound(
@@ -471,7 +471,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
     )
     assert response == EndTrainingRoundResponse()
     # Make sure we wrote the results for the given round
-    coordinator_service.coordinator.store.assert_wrote(
+    coordinator_service.coordinator.aggregated_weights_store.assert_wrote(
         0, coordinator_service.coordinator.weights
     )
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -35,7 +35,7 @@ from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
 from xain_fl.coordinator.participants import ParticipantContext, Participants
 
-from .store import MockS3Store
+from .store import MockS3Writer
 
 
 @pytest.mark.integration
@@ -406,8 +406,8 @@ def test_end_training_round_denied(  # pylint: disable=unused-argument
 def test_full_training_round(participant_stubs, coordinator_service):
     """Run a complete training round with multiple participants.
     """
-    # Use a MockS3Store so that we can also test the storage logic
-    coordinator_service.coordinator.global_weights_writer = MockS3Store()
+    # Use a MockS3Writer so that we can also test the storage logic
+    coordinator_service.coordinator.global_weights_writer = MockS3Writer()
 
     # Initialize the coordinator with dummy weights, otherwise, the
     # aggregated weights at the end of the round are an empty array.

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -10,7 +10,6 @@ from xain_fl.config import MetricsConfig
 from xain_fl.coordinator.metrics_store import (
     MetricsStore,
     MetricsStoreError,
-    NullObjectMetricsStore,
     transform_metrics_to_influx_data_points,
 )
 
@@ -22,14 +21,6 @@ def metrics_sample():
         "metric_1": np.array([0.2, 0.44]),
         "metric_2": np.array([0.99, 0.55]),
     }
-
-
-def test_null_object_metrics_store_always_return_true(metrics_sample):
-    """Check that the null object metric store always retruns true."""
-
-    no_metric_store = NullObjectMetricsStore()
-
-    assert no_metric_store.write_metrics("participant_id", metrics_sample)
 
 
 def test_transform_data(metrics_sample):

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -11,8 +11,8 @@ from xain_fl.coordinator.metrics_store import (
     NullObjectMetricsStore,
 )
 from xain_fl.coordinator.store import (
-    AggregatedWeightsS3Store,
-    ParticipantsWeightsS3Store,
+    NullObjectLocalWeightsReader,
+    S3GlobalWeightsWriter,
 )
 from xain_fl.logger import StructLogger, get_logger, initialize_logging, set_log_level
 from xain_fl.serve import serve
@@ -39,8 +39,8 @@ def main():
         metrics_store = MetricsStore(config.metrics)
 
     coordinator = Coordinator(
-        aggregated_weights_store=AggregatedWeightsS3Store(config.storage),
-        participants_weights_store=ParticipantsWeightsS3Store(config.storage),
+        global_weights_writer=S3GlobalWeightsWriter(config.storage),
+        local_weights_reader=NullObjectLocalWeightsReader(config.storage),
         num_rounds=config.ai.rounds,
         epochs=config.ai.epochs,
         minimum_participants_in_round=config.ai.min_participants,

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -10,7 +10,10 @@ from xain_fl.coordinator.metrics_store import (
     MetricsStore,
     NullObjectMetricsStore,
 )
-from xain_fl.coordinator.store import S3Store
+from xain_fl.coordinator.store import (
+    AggregatedWeightsS3Store,
+    ParticipantsWeightsS3Store,
+)
 from xain_fl.logger import StructLogger, get_logger, initialize_logging, set_log_level
 from xain_fl.serve import serve
 
@@ -36,7 +39,8 @@ def main():
         metrics_store = MetricsStore(config.metrics)
 
     coordinator = Coordinator(
-        store=S3Store(config.storage),
+        aggregated_weights_store=AggregatedWeightsS3Store(config.storage),
+        participants_weights_store=ParticipantsWeightsS3Store(config.storage),
         num_rounds=config.ai.rounds,
         epochs=config.ai.epochs,
         minimum_participants_in_round=config.ai.min_participants,

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -40,7 +40,7 @@ def main():
 
     coordinator = Coordinator(
         global_weights_writer=S3GlobalWeightsWriter(config.storage),
-        local_weights_reader=NullObjectLocalWeightsReader(config.storage),
+        local_weights_reader=NullObjectLocalWeightsReader(),
         num_rounds=config.ai.rounds,
         epochs=config.ai.epochs,
         minimum_participants_in_round=config.ai.min_participants,

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -203,7 +203,12 @@ AI_SCHEMA = Schema(
 STORAGE_SCHEMA = Schema(
     {
         "endpoint": And(str, url, error=error("storage.endpoint", "a valid URL")),
-        "bucket": Use(str, error=error("storage.endpoint", "an S3 bucket name")),
+        "aggregated_weights_bucket": Use(
+            str, error=error("storage.aggregated_weights_bucket", "an S3 bucket name")
+        ),
+        "participants_bucket": Use(
+            str, error=error("storage.participants_bucket", "an S3 bucket name")
+        ),
         "secret_access_key": Use(
             str, error=error("storage.secret_access_key", "a valid utf-8 string")
         ),
@@ -268,10 +273,11 @@ def create_class_from_schema(class_name: str, schema: Schema) -> Any:
         A new class where attributes are the given schema's keys
     """
     # pylint: disable=protected-access
-    keys = schema._schema.keys()
-    attributes = list(
-        map(lambda key: key._schema if isinstance(key, Schema) else key, keys)
-    )
+    attributes = []
+    for key in schema._schema.keys():
+        if isinstance(key, Schema):
+            key = key._schema
+        attributes.append(key)
     return namedtuple(class_name, attributes)
 
 
@@ -369,7 +375,10 @@ class Config:
        endpoint = "http://localhost:9000"
 
        # Name of the bucket for storing the aggregated models
-       bucket = "aggregated_weights"
+       aggregated_weights_bucket = "aggregated_weights"
+
+       # Name of the bucket where participants store their results
+       participants_bucket = "participants_weights"
 
        # AWS secret access to use to authenticate to the storage service
        secret_access_key = "my-secret"
@@ -394,7 +403,8 @@ class Config:
        assert config.ai.fraction_participants == 1.0
 
        assert config.storage.endpoint == "http://localhost:9000"
-       assert config.storage.bucket == "aggregated_weights"
+       assert config.storage.aggregated_weights_bucket == "aggregated_weights"
+       assert config.storage.participants_bucket == "participants_weights"
        assert config.storage.secret_access_key == "my-access-key"
        assert config.storage.access_key_id == "my-key"
     """

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -26,7 +26,11 @@ from xain_fl.coordinator.metrics_store import (
 )
 from xain_fl.coordinator.participants import Participants
 from xain_fl.coordinator.round import Round
-from xain_fl.coordinator.store import AbstractStore, NullObjectStore
+from xain_fl.coordinator.store import (
+    AbstractAggregatedWeightsStore,
+    AbstractParticipantsWeightsStore,
+    NullObjectStore,
+)
 from xain_fl.fl.coordinator.aggregate import Aggregator, WeightedAverageAggregator
 from xain_fl.fl.coordinator.controller import Controller, RandomController
 from xain_fl.logger import StructLogger, get_logger
@@ -72,6 +76,13 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         regardless of which state the coordinator is on.
 
     Args:
+
+        aggregated_weights_store: service for storing aggregated
+            weights
+
+        participants_weights_store: service for retrieving the
+            participants weights
+
         num_rounds: The number of rounds of the training session.
 
         minimum_participants_in_round: The minimum number of
@@ -97,8 +108,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        store: AbstractStore = NullObjectStore(),
         metrics_store: AbstractMetricsStore = NullObjectMetricsStore(),
+        aggregated_weights_store: AbstractAggregatedWeightsStore = NullObjectStore(),
+        participants_weights_store: AbstractParticipantsWeightsStore = NullObjectStore(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,
         fraction_of_participants: float = 1.0,
@@ -108,7 +120,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         aggregator: Aggregator = WeightedAverageAggregator(),
         controller: Controller = RandomController(),
     ) -> None:
-        self.store: AbstractStore = store
+        self.aggregated_weights_store: AbstractAggregatedWeightsStore = aggregated_weights_store
+        # pylint: disable=line-too-long
+        self.participants_weights_store: AbstractParticipantsWeightsStore = participants_weights_store
         self.minimum_participants_in_round: int = minimum_participants_in_round
         self.fraction_of_participants: float = fraction_of_participants
         self.participants: Participants = Participants()
@@ -360,6 +374,14 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 "Can not write metrics", participant_id=participant_id, error=repr(err)
             )
 
+        # FIXME(XP-515): For now, `read_weights()` doesn't do
+        # anything, we actually get the participants weights through
+        # self.round.add_updates(). Ultimatly, the weights will be
+        # read from S3.
+        _ = self.participants_weights_store.read_weights(
+            participant_id, self.current_round
+        )
+
         # The round is over. Run the aggregation
         if self.round.is_finished():
             logger.info(
@@ -373,7 +395,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 multiple_model_weights=multiple_model_weights,
                 aggregation_data=aggregation_data,
             )
-            self.store.write_weights(round=self.current_round, weights=self.weights)
+            self.aggregated_weights_store.write_weights(
+                self.current_round, self.weights
+            )
 
             # update the round or finish the training session
             if self.current_round >= self.num_rounds - 1:

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -78,11 +78,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     Args:
 
-        global_weights_writer: service for storing aggregated
-            weights
+        global_weights_writer: service for storing global weights
 
-        local_weights_reader: service for retrieving the
-            participants weights
+        local_weights_reader: service for retrieving the local weights
 
         num_rounds: The number of rounds of the training session.
 
@@ -105,6 +103,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
         controller: Controls how the Participants are selected at the
             start of each round. Defaults to :class:`~.RandomController`.
+
     """
 
     def __init__(  # pylint: disable=too-many-arguments

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -14,7 +14,7 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]):
         """Write the participant metrics on behalf of the participant with the given participant_id
         into a metric store.
 
@@ -23,9 +23,9 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
             participant_id: The ID of the participant.
             metrics: The metrics of the participant with the given participant_id.
 
-        Returns:
+        Raises:
 
-            True, on success, otherwise False.
+            MetricsStoreError: If the writing of the metrics to InfluxDB failed.
         """
 
 
@@ -34,7 +34,7 @@ class NullObjectMetricsStore(
 ):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]):
         """A method that has no effect.
 
         Args:
@@ -57,7 +57,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.config.db_name,
         )
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]):
         """Write the participant metrics on behalf of the participant with the given participant_id
         into InfluxDB.
 
@@ -65,10 +65,6 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
             participant_id: The ID of the participant.
             metrics: The metrics of the participant with the given participant_id.
-
-        Returns:
-
-            True, on success, otherwise False.
 
         Raises:
 
@@ -85,8 +81,6 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.influx_client.write_points(influx_data_points)
         except Exception as err:  # pylint: disable=broad-except
             raise MetricsStoreError("Can not write metrics.") from err
-
-        return True
 
 
 # Check if ths function can be removed after PB-390 is done.

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -41,12 +41,7 @@ class NullObjectMetricsStore(
 
             participant_id: The ID of the participant.
             metrics: The metrics of the participant with the given participant_id.
-
-        Returns:
-
-            Always True.
         """
-        return True
 
 
 class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -116,7 +116,7 @@ class S3GlobalWeightsWriter(AbstractGlobalWeightsWriter, S3BaseClass):
             round: A round number the weights correspond to.
             weights: The weights to store.
         """
-        bucket = self.s3.Bucket(self.config.aggregated_weights_bucket)
+        bucket = self.s3.Bucket(self.config.global_weights_bucket)
         bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
 
 

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -33,7 +33,7 @@ class AbstractGlobalWeightsWriter(abc.ABC):
 class AbstractLocalWeightsReader(abc.ABC):
     # pylint: disable=too-few-public-methods
 
-    """An abstract class that defined the API for retrieving the weights
+    """An abstract class that defines the API for retrieving the weights
     participants upload after their training round.
 
     """

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -12,8 +12,13 @@ from numpy import ndarray
 from xain_fl.config import StorageConfig
 
 
-class AbstractStore(abc.ABC):
-    """An abstract class that defines the API a store must implement."""
+class AbstractAggregatedWeightsStore(abc.ABC):
+    # pylint: disable=too-few-public-methods
+
+    """An abstract class that defines the API for storing the aggregated
+    weights the coordinator computes.
+
+    """
 
     @abc.abstractmethod
     def write_weights(self, round: int, weights: ndarray) -> None:
@@ -24,9 +29,19 @@ class AbstractStore(abc.ABC):
             weights: The weights to store.
         """
 
+
+class AbstractParticipantsWeightsStore(abc.ABC):
+    # pylint: disable=too-few-public-methods
+
+    """An abstract class that defined the API for retrieving the weights
+    participants upload after their training round.
+
+    """
+
     @abc.abstractmethod
     def read_weights(self, participant_id: str, round: int) -> ndarray:
-        """Read the weights computed by the given participant for the given round.
+        """Retrieve the weights computed by the given participant for the
+        given round.
 
         Args:
             participant_id: ID of the participant's weights.
@@ -34,8 +49,8 @@ class AbstractStore(abc.ABC):
         """
 
 
-class NullObjectStore(AbstractStore):
-    """A store that does nothing."""
+class NullObjectStore(AbstractAggregatedWeightsStore, AbstractParticipantsWeightsStore):
+    """A store that does nothing"""
 
     def write_weights(self, round: int, weights: ndarray) -> None:
         """A dummy method that has no effect.
@@ -54,7 +69,8 @@ class NullObjectStore(AbstractStore):
         """
 
 
-class S3Store(AbstractStore):
+class S3Store:
+    # pylint: disable=too-few-public-methods
     """A store for services that offer the AWS S3 API.
 
     Args:
@@ -72,6 +88,15 @@ class S3Store(AbstractStore):
             region_name="dummy",
         )
 
+
+class AggregatedWeightsS3Store(AbstractAggregatedWeightsStore, S3Store):
+    # pylint: disable=too-few-public-methods
+
+    """``AbstractAggregatedWeightsStore`` implementor for AWS S3 storage
+    backend.
+
+    """
+
     def write_weights(self, round: int, weights: ndarray):
         """Store the given `weights`, corresponding to the given `round`.
 
@@ -79,9 +104,17 @@ class S3Store(AbstractStore):
             round: A round number the weights correspond to.
             weights: The weights to store.
         """
-
-        bucket = self.s3.Bucket(self.config.bucket)
+        bucket = self.s3.Bucket(self.config.aggregated_weights_bucket)
         bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
+
+
+class ParticipantsWeightsS3Store(AbstractParticipantsWeightsStore, S3Store):
+    # pylint: disable=too-few-public-methods
+
+    """``AbstractParticipantsWeightsStore`` implementor for AWS S3 storage
+    backend.
+
+    """
 
     def read_weights(self, participant_id: str, round: int) -> ndarray:
         """Download the weights computed by the given participant for the given
@@ -89,16 +122,15 @@ class S3Store(AbstractStore):
 
         Args:
 
-            participant_id: ID of the participant's weights. Not used.
-            round: A round number the weights correspond to.
+            participant_id: ID of the participant's weights
+            round: round number the weights correspond to
 
         Return:
             The weights read from the S3 bucket.
         """
-
-        bucket = self.s3.Bucket(self.config.bucket)
+        bucket = self.s3.Bucket(self.config.participants_bucket)
         data = BytesIO()
-        bucket.download_fileobj(str(round), data)
+        bucket.download_fileobj(f"{participant_id}/{round}", data)
         # FIXME: not sure whether getvalue() copies the data. If so we
         # should probably prefer getbuffer() instead.
         return pickle.loads(data.getvalue())

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -12,7 +12,7 @@ from numpy import ndarray
 from xain_fl.config import StorageConfig
 
 
-class AbstractAggregatedWeightsStore(abc.ABC):
+class AbstractGlobalWeightsWriter(abc.ABC):
     # pylint: disable=too-few-public-methods
 
     """An abstract class that defines the API for storing the aggregated
@@ -30,7 +30,7 @@ class AbstractAggregatedWeightsStore(abc.ABC):
         """
 
 
-class AbstractParticipantsWeightsStore(abc.ABC):
+class AbstractLocalWeightsReader(abc.ABC):
     # pylint: disable=too-few-public-methods
 
     """An abstract class that defined the API for retrieving the weights
@@ -49,8 +49,12 @@ class AbstractParticipantsWeightsStore(abc.ABC):
         """
 
 
-class NullObjectStore(AbstractAggregatedWeightsStore, AbstractParticipantsWeightsStore):
-    """A store that does nothing"""
+class NullObjectGlobalWeightsWriter(AbstractGlobalWeightsWriter):
+    # pylint: disable=too-few-public-methods
+    """An implementation of ``AbstractGlobalWeightsWriter`` that does
+    nothing.
+
+    """
 
     def write_weights(self, round: int, weights: ndarray) -> None:
         """A dummy method that has no effect.
@@ -59,6 +63,13 @@ class NullObjectStore(AbstractAggregatedWeightsStore, AbstractParticipantsWeight
             round: A round number the weights correspond to. Not used.
             weights: The weights to store. Not used.
         """
+
+
+class NullObjectLocalWeightsReader(AbstractLocalWeightsReader):
+    # pylint: disable=too-few-public-methods
+    """An implementation of ``AbstractLocalWeightsReader`` that does
+    nothing.
+    """
 
     def read_weights(self, participant_id: str, round: int) -> ndarray:
         """A dummy method that has no effect.
@@ -69,12 +80,13 @@ class NullObjectStore(AbstractAggregatedWeightsStore, AbstractParticipantsWeight
         """
 
 
-class S3Store:
+class S3BaseClass:
     # pylint: disable=too-few-public-methods
-    """A store for services that offer the AWS S3 API.
+    """A base class for implementating AWS S3 clients.
 
     Args:
         config: the storage configuration (endpoint URL, credentials, etc.)
+
     """
 
     def __init__(self, config: StorageConfig):
@@ -89,10 +101,10 @@ class S3Store:
         )
 
 
-class AggregatedWeightsS3Store(AbstractAggregatedWeightsStore, S3Store):
+class S3GlobalWeightsWriter(AbstractGlobalWeightsWriter, S3BaseClass):
     # pylint: disable=too-few-public-methods
 
-    """``AbstractAggregatedWeightsStore`` implementor for AWS S3 storage
+    """``AbstractGlobalWeightsWriter`` implementor for AWS S3 storage
     backend.
 
     """
@@ -108,10 +120,10 @@ class AggregatedWeightsS3Store(AbstractAggregatedWeightsStore, S3Store):
         bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
 
 
-class ParticipantsWeightsS3Store(AbstractParticipantsWeightsStore, S3Store):
+class S3LocalWeightsReader(AbstractLocalWeightsReader, S3BaseClass):
     # pylint: disable=too-few-public-methods
 
-    """``AbstractParticipantsWeightsStore`` implementor for AWS S3 storage
+    """``AbstractLocalWeightsReader`` implementor for AWS S3 storage
     backend.
 
     """

--- a/xain_fl/serve.py
+++ b/xain_fl/serve.py
@@ -25,11 +25,6 @@ def serve(coordinator: Coordinator, server_config: ServerConfig) -> None:
             :class:`xain_fl.coordinator.coordinator.Coordinator`
             instance to run
 
-        store:
-            client for the storage service used by the coordinator to
-            upload the aggregated weights and retrieve the
-            participants weights.
-
         server_config:
             server configuration: binding address, gRPC options, etc.
 


### PR DESCRIPTION
### Summary:

Add code for reading participants weights from S3.

Implementation details:

We split the AbstractStore class in to separate abstract classes:

- `AbstractAggregatedWeightsStore` is used to upload the aggregated
  weights to S3
- `AbstractParticipantsWeightsStore` is used to download participants
  weights from S3

The separation also allows us to use a dummy `NullObjectStore` class
for retrieving the participants weights, while using the real
`AggregatedWeightsS3Store` class for uploading aggregated weights.

In the future, it may be useful to provide different configurations
for the storage service used for aggregated weights and the storage
service used for participants weights: they may use different
credentials, permissions, endpoints, etc.

### References:

https://xainag.atlassian.net/browse/PB-269

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
