### PR TITLE
PB-116: pin docutils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,13 @@ docs_require = [
     "m2r==0.2.1",
     "sphinxcontrib-mermaid==0.3.1",
     "sphinx-autodoc-typehints==1.10.3",  # MIT
+    # docutils is a transitive dependency for docs_requires and
+    # install_requires, which are handled sequentially by pip. If the
+    # docs_requires dependencies are handled first, `docutils~=0.16`
+    # gets installed, whereas install_requires depends on
+    # `docutils<0.16`. To prevent this from happening, we just pin the
+    # docutils version here.
+    "docutils < 0.16",
 ]
 
 setup(


### PR DESCRIPTION
### Summary:

It seems that pip resolves the dependencies by profile. If the [doc]
profile is installed first, docutils ~= 0.16 is picked up, and when
xain-fl's install_requires is resolved, pip sees that docutils is
already installed but has an incompatible version.

I suspect the order in which pip handles the profiles depends on your
environment (pip version, platform, python version, etc.) which is why
we don't see this issue consistently.

As a workaround we explicitely depends on docutils in the [doc]
profile and restrict the version here.

### References:

https://xainag.atlassian.net/browse/PB-116


---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
