### PR TITLE
PB-119 enable isort diff

### DIFF
--- a/.github/workflows/development_pull_request.yml
+++ b/.github/workflows/development_pull_request.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: isort
         run: |
-          isort --check-only --settings-path=.isort.cfg -rc setup.py xain_fl tests
+          isort --check-only --diff --settings-path=.isort.cfg -rc setup.py xain_fl tests
 
       - name: pylint
         run: |

--- a/.github/workflows/master_pull_request.yml
+++ b/.github/workflows/master_pull_request.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: isort
         run: |
-          isort --check-only --settings-path=.isort.cfg -rc setup.py xain_fl tests
+          isort --check-only --diff --settings-path=.isort.cfg -rc setup.py xain_fl tests
 
       - name: pylint
         run: |

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -5,7 +5,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR/../
 
 # sort import
-isort --check-only --settings-path=.isort.cfg -rc setup.py xain_fl tests && echo "===> isort says: well done <===" &&
+isort --check-only --diff --settings-path=.isort.cfg -rc setup.py xain_fl tests && echo "===> isort says: well done <===" &&
 
 # format code
 black --check setup.py xain_fl tests && echo "===> black says: well done <===" &&


### PR DESCRIPTION
### References

- [PB-119](https://xainag.atlassian.net/browse/PB-119)

### Summary

- enable `--diff` for `isort` calls

### Are there any open tasks/blockers for the ticket?

- none

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
