### PR TITLE
DO-73 :green_heart: Disable continue_on_failure for CI jobs

### DIFF
--- a/.github/workflows/development_pull_request.yml
+++ b/.github/workflows/development_pull_request.yml
@@ -42,7 +42,6 @@ jobs:
           pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
-        continue-on-error: true
         run: |
           mypy xain_fl tests
 

--- a/.github/workflows/master_pull_request.yml
+++ b/.github/workflows/master_pull_request.yml
@@ -42,7 +42,6 @@ jobs:
           pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
-        continue-on-error: true
         run: |
           mypy xain_fl tests
 

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -14,7 +14,7 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
         """Write the participant metrics on behalf of the participant with the given participant_id
         into a metric store.
 
@@ -34,7 +34,7 @@ class NullObjectMetricsStore(
 ):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
         """A method that has no effect.
 
         Args:
@@ -62,7 +62,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.config.db_name,
         )
 
-    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> None:
+    def write_metrics(self, participant_id: str, metrics: Dict[str, ndarray]) -> bool:
         """Write the participant metrics on behalf of the participant with the given participant_id
         into InfluxDB.
 
@@ -90,6 +90,8 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.influx_client.write_points(influx_data_points)
         except Exception as err:  # pylint: disable=broad-except
             raise MetricsStoreError("Can not write metrics.") from err
+
+        return True
 
 
 # Check if ths function can be removed after PB-390 is done.


### PR DESCRIPTION
### References

[DO-73](https://xainag.atlassian.net/browse/DO-73)

### Summary

Disable continue_on_error for all jobs in CI

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
