### PR TITLE
PB-352 Add sdk config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
-    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.3.0",  # Apache License 2.0
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.5.0",  # Apache License 2.0
 ]
 
 docs_require = [

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
-    "xain-sdk==0.4.0",  # Apache License 2.0
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.3.0",  # Apache License 2.0
 ]
 
 docs_require = [

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -39,6 +39,28 @@ from xain_fl.coordinator.participants import ParticipantContext, Participants
 from .store import MockS3Writer
 
 
+@pytest.fixture
+def participant_config():
+    return {
+        "coordinator": {
+            "host": "localhost",
+            "port": 50051,
+            "grpc_options": {
+                "grpc.max_receive_message_length": -1,
+                "grpc.max_send_message_length": -1,
+            },
+        },
+        "storage": {
+            "enable": False,
+            "endpoint": "http://localhost:9000",
+            "bucket": "aggregated_weights",
+            "secret_access_key": "my-secret",
+            "access_key_id": "my-key-id",
+        },
+        "logging": {"level": "info",},
+    }
+
+
 @pytest.mark.integration
 def test_participant_rendezvous_accept(  # pylint: disable=unused-argument
     participant_stub, coordinator_service
@@ -479,7 +501,7 @@ def test_full_training_round(participant_stubs, coordinator_service):
 
 @pytest.mark.integration
 @pytest.mark.slow
-def test_start_participant(mock_coordinator_service):
+def test_start_participant(mock_coordinator_service, participant_config):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -496,26 +518,7 @@ def test_start_participant(mock_coordinator_service):
         mock_local_part = mock_obj.return_value
         mock_local_part.train_round.return_value = init_weight, 1, {}
 
-        config: Config = Config().from_valid_dict(
-            {
-                "coordinator": {
-                    "host": "localhost",
-                    "port": 50051,
-                    "grpc_options": {
-                        "grpc.max_receive_message_length": -1,
-                        "grpc.max_send_message_length": -1,
-                    },
-                },
-                "storage": {
-                    "enable": False,
-                    "endpoint": "http://localhost:9000",
-                    "bucket": "aggregated_weights",
-                    "secret_access_key": "my-secret",
-                    "access_key_id": "my-key-id",
-                },
-                "logging": {"level": "info",},
-            }
-        )
+        config: Config = Config.from_unchecked_dict(participant_config)
 
         start_participant(mock_local_part, config)
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -40,7 +40,10 @@ from .store import MockS3Writer
 
 
 @pytest.fixture
-def participant_config():
+def participant_config() -> dict:
+    """
+    Return a valid participant config.
+    """
     return {
         "coordinator": {
             "host": "localhost",
@@ -501,7 +504,9 @@ def test_full_training_round(participant_stubs, coordinator_service):
 
 @pytest.mark.integration
 @pytest.mark.slow
-def test_start_participant(mock_coordinator_service, participant_config):
+def test_start_participant( # pylint: disable=redefined-outer-name
+    mock_coordinator_service, participant_config
+    ):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -504,9 +504,9 @@ def test_full_training_round(participant_stubs, coordinator_service):
 
 @pytest.mark.integration
 @pytest.mark.slow
-def test_start_participant( # pylint: disable=redefined-outer-name
+def test_start_participant(  # pylint: disable=redefined-outer-name
     mock_coordinator_service, participant_config
-    ):
+):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)


### PR DESCRIPTION
### References

Follow up task to complete [PB-352](https://xainag.atlassian.net/browse/PB-352)

### Summary

* Added participant config

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
