### PR TITLE
DO-47 :newspaper: build test packages

### DIFF
--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -1,0 +1,44 @@
+name: Build test package
+
+on:
+  push:
+    branches:
+      - release/v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build_test_package:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Cache pip packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip-master-${{ hashFiles('setup.py') }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          pip install wheel twine
+
+      - name: Create packages
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Output tag name
+        id: get_tag_name
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF##*/}
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.get_tag_name.outputs.TAG_NAME }}-test
+          path: dist


### PR DESCRIPTION
### References

[DO-47](https://xainag.atlassian.net/browse/DO-47)

### Summary

CI builds test packages on release branches named `release/vX.X.X`

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
