### PR TITLE
Hotfix: update ci

### DIFF
--- a/.github/workflows/development_e2e_tests.yml
+++ b/.github/workflows/development_e2e_tests.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 jobs:
-  e2e:
+  e2e_comment_trigger:
     runs-on: ubuntu-18.04
     steps:
       - name: logging

--- a/.github/workflows/development_pull_request.yml
+++ b/.github/workflows/development_pull_request.yml
@@ -6,7 +6,7 @@ on:
       - development
 
 jobs:
-  development:
+  development_lint_and_test:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -35,14 +35,13 @@ jobs:
 
       - name: isort
         run: |
-          isort --check-only --settings-path=.isort.cfg -rc setup.py xain_fl tests
+          isort --check-only --diff --settings-path=.isort.cfg -rc setup.py xain_fl tests
 
       - name: pylint
         run: |
           pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
-        continue-on-error: true
         run: |
           mypy xain_fl tests
 

--- a/.github/workflows/master_pull_request.yml
+++ b/.github/workflows/master_pull_request.yml
@@ -6,7 +6,7 @@ on:
       - master
 
 jobs:
-  main:
+  master_lint_and_test:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -35,14 +35,13 @@ jobs:
 
       - name: isort
         run: |
-          isort --check-only --settings-path=.isort.cfg -rc setup.py xain_fl tests
+          isort --check-only --diff --settings-path=.isort.cfg -rc setup.py xain_fl tests
 
       - name: pylint
         run: |
           pylint --rcfile=.pylintrc xain_fl tests
 
       - name: mypy
-        continue-on-error: true
         run: |
           mypy xain_fl tests
 

--- a/.github/workflows/master_tag.yml
+++ b/.github/workflows/master_tag.yml
@@ -1,4 +1,4 @@
-name: Package release
+name: Build release package
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - v[0-9]+.[0-9]+.[0-9]+
 
 jobs:
-  main:
+  build_release_package:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
 
       - name: Output tag name
         id: get_tag_name
-        run: echo ::set-output name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF##*/}
 
       - name: Upload packages
         uses: actions/upload-artifact@v1

--- a/.github/workflows/release_branch.yml
+++ b/.github/workflows/release_branch.yml
@@ -1,0 +1,44 @@
+name: Build test package
+
+on:
+  push:
+    branches:
+      - release/v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build_test_package:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Python 3.6
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+
+      - name: Cache pip packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: pip-master-${{ hashFiles('setup.py') }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          pip install wheel twine
+
+      - name: Create packages
+        run: |
+          python setup.py sdist bdist_wheel
+
+      - name: Output tag name
+        id: get_tag_name
+        run: echo ::set-output name=TAG_NAME::${GITHUB_REF##*/}
+
+      - name: Upload packages
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.get_tag_name.outputs.TAG_NAME }}-test
+          path: dist


### PR DESCRIPTION
### References

[DO-72](https://xainag.atlassian.net/browse/DO-72) [DO-47](https://xainag.atlassian.net/browse/DO-47)

### Summary

CI builds test packages for release branches. Jobs are renamed to be consistent across all repos. 
GitHub Actions only parses the jobs present in the default branch, in our case, `master`, thus the need to merge to `master`

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
