### PR TITLE
PB-385 Fix xain-sdk test

### DIFF
--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -247,7 +247,7 @@ def test_many_heartbeats_expire_in_short_interval():
     "xain_sdk.participant_state_machine.threading.Event.is_set",
     side_effect=[False, False, True],
 )
-@mock.patch("xain_sdk.participant_state_machine.time.sleep", return_value=None)
+@mock.patch("xain_sdk.participant_state_machine.threading.Event.wait", return_value=None)
 @mock.patch("xain_sdk.participant_state_machine.HeartbeatRequest")
 def test_message_loop(mock_heartbeat_request, _mock_sleep, _mock_event):
     """[summary]

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -247,7 +247,9 @@ def test_many_heartbeats_expire_in_short_interval():
     "xain_sdk.participant_state_machine.threading.Event.is_set",
     side_effect=[False, False, True],
 )
-@mock.patch("xain_sdk.participant_state_machine.threading.Event.wait", return_value=None)
+@mock.patch(
+    "xain_sdk.participant_state_machine.threading.Event.wait", return_value=None
+)
 @mock.patch("xain_sdk.participant_state_machine.HeartbeatRequest")
 def test_message_loop(mock_heartbeat_request, _mock_sleep, _mock_event):
     """[summary]


### PR DESCRIPTION
### References

Follow up ticket of:

[PB-385 Replace time.sleep() with Event.wait() in SDK message_loop function](https://xainag.atlassian.net/browse/PB-385)

### Summary

* fixed sdk test

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
