### PR TITLE
PB-402 Add more logs

### DIFF
--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -181,7 +181,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         logger.debug(
             "Received message from participant",
             message_type=message.DESCRIPTOR.name,
-            message_size_in_bytes=message.ByteSize(),
+            message_byte_size=message.ByteSize(),
             participant_id=participant_id,
         )
 

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -277,8 +277,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             )
 
         logger.debug(
-            "Send RendezvousResponse",
-            reply=_RENDEZVOUSREPLY.values_by_number[reply].name,
+            "Send RendezvousResponse", reply=pb_enum_to_str(_RENDEZVOUSREPLY, reply)
         )
         return RendezvousResponse(reply=reply)
 
@@ -311,7 +310,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         logger.debug(
             "Heartbeat response",
             participant_id=participant_id,
-            state=_STATE.values_by_number[state].name,
+            state=pb_enum_to_str(_STATE, state),
             round=self.current_round,
             current_participants_count=self.participants.len(),
         )
@@ -417,3 +416,16 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
         logger.debug("Send EndTrainingRoundResponse", participant_id=participant_id)
         return EndTrainingRoundResponse()
+
+
+def pb_enum_to_str(pb_enum, member_value: int) -> str:
+    """Return the human readable string of a enum member value.
+
+    Args:
+        pb_enum: The proto enum definition.
+        member_value:  The enum member value.
+    
+    Returns:
+        The human readable string of a enum member value.
+    """
+    return pb_enum.values_by_number[member_value].name

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -424,7 +424,7 @@ def pb_enum_to_str(pb_enum, member_value: int) -> str:
     Args:
         pb_enum: The proto enum definition.
         member_value:  The enum member value.
-    
+
     Returns:
         The human readable string of a enum member value.
     """


### PR DESCRIPTION
### References

[PB-402](https://xainag.atlassian.net/browse/PB-402)

### Summary

* made the current logs more expressive and less visual noisy:
  - `reply=LATER` instead of `reply=1`
  - `state=ROUND` instead of `state=1`
  - `message_type=HeartbeatRequest` instead of `message_type=<class 'xain_proto.fl.coordinator_pb2.HeartbeatRequest'>`

* add logs for message_byte_size, current_participants_count

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
