### PR TITLE
DO-66 :sparkles: Add keycloak

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -70,6 +70,21 @@ services:
     ports:
       - "8086:8086"
 
+  keycloak:
+    image: jboss/keycloak:8.0.2
+    hostname: keycloak
+    environment:
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: adminadmin
+      DB_VENDOR: h2
+      # Can't properly provision a login theme
+#    volumes:
+#      - ${PWD}/xain-theme-keycloak:/opt/jboss/keycloak/themes
+    networks:
+      - xain-fl-dev
+    ports:
+      - "8080:8080"
+
   xain-fl-dev:
     build:
       context: .


### PR DESCRIPTION
### References

[DO-66](https://xainag.atlassian.net/browse/DO-66)

### Summary

This MR Adds Keycloack to the development docker-compose for OpenID Connect usage alongside Grafana

### Are there any open tasks/blockers for the ticket?

No

<!-- ### Optional: Next Step -->

[DO-78](https://xainag.atlassian.net/browse/DO-78) Will follow up adding Grafana.
A third PR may be required to finish the set-up of OpenID Connect for Grafana

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
