### PR TITLE
PB-398 Round resumption in Coordinator

### DIFF
--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -243,7 +243,11 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         self.round = Round(selected_ids)
 
     def select_outstanding(self) -> List[str]:
-        """Selects participant ids."""
+        """Selects participants outstanding for the round."""
+
+        # the following preconditions should hold
+        assert(len(self.round.participant_ids) < self.minimum_participants_in_round)
+        assert(self.participants.len() == self.minimum_connected_participants)
 
         selected = set(self.round.participant_ids)
         num_outstanding = self.minimum_participants_in_round - len(selected)

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -246,8 +246,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         """Selects participants outstanding for the round."""
 
         # the following preconditions should hold
-        assert(len(self.round.participant_ids) < self.minimum_participants_in_round)
-        assert(self.participants.len() == self.minimum_connected_participants)
+        assert len(self.round.participant_ids) < self.minimum_participants_in_round
+        assert self.participants.len() == self.minimum_connected_participants
 
         selected = set(self.round.participant_ids)
         num_outstanding = self.minimum_participants_in_round - len(selected)

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -22,10 +22,30 @@ class Round:
         self.participant_ids = participant_ids
         self.updates: Dict[str, Dict] = {}
 
+    def add_selected(self, more_ids: List[str]) -> None:
+        """Add to the collection of selected participants.
+
+        Args:
+            more_ids: ids of participants to add.
+        """
+
+        self.participant_ids.extend(more_ids)
+
+    def remove_selected(self, participant_id: str) -> None:
+        """Remove from the collection of selected participants.
+
+        Args:
+            participant_id: id of participant to remove.
+        """
+
+        self.participant_ids = [
+            id for id in self.participant_ids if id != participant_id
+        ]
+
     def add_updates(
         self, participant_id: str, model_weights: ndarray, aggregation_data: int,
     ) -> None:
-        """Valid a participant's update for the round.
+        """Add a participant's update for the round.
 
         Args:
             participant_id: The id of the participant making the request.
@@ -57,7 +77,7 @@ class Round:
             round. `False` otherwise.
         """
 
-        return len(self.updates) == len(self.participant_ids)
+        return all(id in self.updates for id in self.participant_ids)
 
     def get_weight_updates(self) -> Tuple[List[ndarray], List[int]]:
         """Get a list of all participants weight updates.
@@ -67,7 +87,8 @@ class Round:
             The lists of model weights and aggregation meta data from all participants.
         """
 
+        updates = [self.updates[id] for id in self.participant_ids]
         return (
-            [v["model_weights"] for v in self.updates.values()],
-            [v["aggregation_data"] for v in self.updates.values()],
+            [upd["model_weights"] for upd in updates],
+            [upd["aggregation_data"] for upd in updates],
         )

--- a/xain_fl/coordinator/round.py
+++ b/xain_fl/coordinator/round.py
@@ -38,9 +38,10 @@ class Round:
             participant_id: id of participant to remove.
         """
 
-        self.participant_ids = [
-            id for id in self.participant_ids if id != participant_id
-        ]
+        try:
+            self.participant_ids.remove(participant_id)
+        except ValueError:
+            pass
 
     def add_updates(
         self, participant_id: str, model_weights: ndarray, aggregation_data: int,

--- a/xain_fl/fl/coordinator/controller.py
+++ b/xain_fl/fl/coordinator/controller.py
@@ -122,4 +122,5 @@ class RandomController(Controller):
         """
 
         num_ids_to_select = self.get_num_ids_to_select(len(participant_ids))
-        return np.random.choice(participant_ids, size=num_ids_to_select, replace=False)
+        ids = np.random.choice(participant_ids, size=num_ids_to_select, replace=False)
+        return ids.tolist()

--- a/xain_fl/fl/coordinator/controller.py
+++ b/xain_fl/fl/coordinator/controller.py
@@ -59,7 +59,7 @@ class Controller(ABC):
 
 
 class IdController(Controller):
-    """[summary
+    """[summary]
 
     ... todo: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
@@ -76,6 +76,28 @@ class IdController(Controller):
         """
 
         return participant_ids
+
+
+class OrderController(Controller):
+    """[summary]
+
+    ... todo: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
+    """
+
+    def select_ids(self, participant_ids: List[str]) -> List[str]:
+        """Selects participants according to order.
+
+        Args:
+            participant_ids (:obj:`list` of :obj:`str`): The list of IDs of all the
+                available participants, a subset of which will be selected.
+
+        Returns:
+            :obj:`list` of :obj:`str`: List of selected participant IDs
+        """
+
+        num_ids_to_select = self.get_num_ids_to_select(len(participant_ids))
+        sorted_ids = sorted(participant_ids)
+        return sorted_ids[:num_ids_to_select]
 
 
 class RandomController(Controller):


### PR DESCRIPTION
### References

[PB-398](https://xainag.atlassian.net/browse/PB-391)

### Summary

Adds proper support for round resumption in the Coordinator.

This merge request adds some resilience to the Coordinator in the face of Participant dropouts. In particular, when there is a dropout mid-round, the Coordinator pauses the round by going to standby. When enough Participants connect again, the round is resumed. While the idea of round resumption has been in the Coordinator for some time (and has recently been supported properly [in the Participant too](https://github.com/xainag/xain-sdk/pull/47)), up until now it has not been properly exercised, and this MR fixes the obvious faults, so that:

- `remove_participant` previously ignored the collection of selected Participants for a round; now it also takes that into account.
- `_handle_rendezvous` previously forced a complete re-selection each time a round resumes; the selection logic has been adjusted to only select from the connected pool while keeping the already selected survivors intact.

In addition:

- `test_select_outstanding` tests the above functionality.
- `test_remove_participant` has been split into 2 cases to properly test the above.
- tighter checks in the functions `is_finished` and `get_weight_updates` of the `Round` class.

### Are there any open tasks/blockers for the ticket?

This MR does not attempt to enable full fault-tolerance nor repair all the potential concurrency-related problems in the Coordinator e.g. ensuring various state collections are thread-safe, but these will be follow-up tasks going forward.

<!-- ### Optional: Next Step -->



---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
