### PR TITLE
PB-428 send coordinator states

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -111,6 +111,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    depends_on:
+      - influxdb
     volumes:
       - /app/xain_fl.egg-info  #  don't use the local egg-info, if one exists
       - ${PWD}/xain_fl:/app/xain_fl

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,8 @@ from .port_forwarding import ConnectionManager
 
 
 @pytest.fixture()
-def metrics_sample():
-    """Return a valid metric object."""
+def participant_metrics_sample():
+    """Return a valid participant metric object."""
     return json.dumps(
         [
             {
@@ -36,6 +36,12 @@ def metrics_sample():
             },
         ]
     )
+
+
+@pytest.fixture()
+def coordinator_metrics_sample():
+    """Return a valid coordinator metric object."""
+    return {"state": 1, "round": 2, "number_of_selected_participants": 0}
 
 
 @pytest.fixture

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -349,7 +349,7 @@ def test_start_training_round_failed_precondition(  # pylint: disable=unused-arg
 
 
 @pytest.mark.integration
-def test_end_training_round(coordinator_service, metrics_sample):
+def test_end_training_round(coordinator_service, participant_metrics_sample):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -368,7 +368,9 @@ def test_end_training_round(coordinator_service, metrics_sample):
         # we first need to rendezvous before we can send any other request
         rendezvous(channel)
         # call EndTrainingRound service method on coordinator
-        end_training_round(channel, test_weights, number_samples, metrics_sample)
+        end_training_round(
+            channel, test_weights, number_samples, participant_metrics_sample
+        )
     # check local model received...
 
     assert len(coordinator_service.coordinator.round.updates) == 1

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -10,13 +10,13 @@ from xain_fl.coordinator.metrics_store import MetricsStore, MetricsStoreError
 
 
 @pytest.fixture()
-def metrics_sample_empty():
+def empty_json_participant_metrics_sample():
     """Return a valid metric object."""
     return json.dumps([])
 
 
 @pytest.fixture()
-def metrics_sample_invalid():
+def invalid_json_participant_metrics_sample():
     """Return a invalid metric object."""
     return json.dumps(
         [
@@ -30,20 +30,20 @@ def metrics_sample_invalid():
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_valid_metric(
-    write_points_mock, metrics_sample,
+def test_valid_participant_metrics(
+    write_points_mock, participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Check that write_points does not raise an exception on a valid metric object."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_participant_metrics(metrics_sample)
+    metric_store.write_participant_metrics(participant_metrics_sample)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
-def test_write_points_exception_handling(
-    write_points_mock, metrics_sample,
+def test_write_points_exception_handling_write_participant_metrics(
+    write_points_mock, participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Check that raised exceptions of the write_points method are caught in the
     write_participant_metrics method."""
@@ -52,7 +52,7 @@ def test_write_points_exception_handling(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(metrics_sample)
+        metric_store.write_participant_metrics(participant_metrics_sample)
 
 
 def test_invalid_json_exception_handling():
@@ -70,7 +70,7 @@ def test_invalid_json_exception_handling():
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_empty_metrics_exception_handling(
-    write_points_mock, metrics_sample_empty,
+    write_points_mock, empty_json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Check that raised exceptions of the write_points method are caught in the
     write_participant_metrics method."""
@@ -79,12 +79,12 @@ def test_empty_metrics_exception_handling(
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(metrics_sample_empty)
+        metric_store.write_participant_metrics(empty_json_participant_metrics_sample)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_invalid_schema_exception_handling(
-    write_points_mock, metrics_sample_invalid,
+    write_points_mock, invalid_json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
     """Check that raised exceptions of the write_points method are caught in the
     write_participant_metrics method."""
@@ -93,4 +93,30 @@ def test_invalid_schema_exception_handling(
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(metrics_sample_invalid)
+        metric_store.write_participant_metrics(invalid_json_participant_metrics_sample)
+
+
+@mock.patch.object(InfluxDBClient, "write_points", return_value=True)
+def test_valid_coordinator_metrics(
+    write_points_mock, coordinator_metrics_sample,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """Check that write_points does not raise an exception on a valid metric object."""
+    metric_store = MetricsStore(
+        MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
+    )
+
+    metric_store.write_coordinator_metrics(coordinator_metrics_sample, tags={"1": "2"})
+
+
+@mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
+def test_write_points_exception_handling_write_coordinator_metrics(
+    write_points_mock, coordinator_metrics_sample,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """Check that raised exceptions of the write_points method are caught in the
+    write_coordinator_metrics method."""
+
+    metric_store = MetricsStore(
+        MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
+    )
+    with pytest.raises(MetricsStoreError):
+        metric_store.write_coordinator_metrics(coordinator_metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -38,62 +38,59 @@ def test_valid_metric(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_participant_ai_metrics(metrics_sample)
+    metric_store.write_participant_metrics(metrics_sample)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
 def test_write_points_exception_handling(
     write_points_mock, metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
-    method.
-    """
+    """Check that raised exceptions of the write_points method are caught in the
+    write_participant_metrics method."""
+
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_ai_metrics(metrics_sample)
+        metric_store.write_participant_metrics(metrics_sample)
 
 
 def test_invalid_json_exception_handling():
-    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
-    method.
-    """
+    """Check that raised exceptions of the write_points method are caught in the
+    write_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_ai_metrics('{"a": 1')
+        metric_store.write_participant_metrics('{"a": 1')
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_ai_metrics("{1: 1}")
+        metric_store.write_participant_metrics("{1: 1}")
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_empty_metrics_exception_handling(
     write_points_mock, metrics_sample_empty,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
-    method.
-    """
+    """Check that raised exceptions of the write_points method are caught in the
+    write_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_ai_metrics(metrics_sample_empty)
+        metric_store.write_participant_metrics(metrics_sample_empty)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_invalid_schema_exception_handling(
     write_points_mock, metrics_sample_invalid,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
-    method.
-    """
+    """Check that raised exceptions of the write_points method are caught in the
+    write_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_ai_metrics(metrics_sample_invalid)
+        metric_store.write_participant_metrics(metrics_sample_invalid)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -38,42 +38,42 @@ def test_valid_metric(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_metrics(metrics_sample)
+    metric_store.write_participant_ai_metrics(metrics_sample)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
 def test_write_points_exception_handling(
     write_points_mock, metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_metrics
+    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
     method.
     """
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_metrics(metrics_sample)
+        metric_store.write_participant_ai_metrics(metrics_sample)
 
 
 def test_invalid_json_exception_handling():
-    """Check that raised exceptions of the write_points method are caught in the write_metrics
+    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
     method.
     """
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_metrics('{"a": 1')
+        metric_store.write_participant_ai_metrics('{"a": 1')
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_metrics("{1: 1}")
+        metric_store.write_participant_ai_metrics("{1: 1}")
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_empty_metrics_exception_handling(
     write_points_mock, metrics_sample_empty,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_metrics
+    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
     method.
     """
     metric_store = MetricsStore(
@@ -81,14 +81,14 @@ def test_empty_metrics_exception_handling(
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_metrics(metrics_sample_empty)
+        metric_store.write_participant_ai_metrics(metrics_sample_empty)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
 def test_invalid_schema_exception_handling(
     write_points_mock, metrics_sample_invalid,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the write_metrics
+    """Check that raised exceptions of the write_points method are caught in the write_participant_ai_metrics
     method.
     """
     metric_store = MetricsStore(
@@ -96,4 +96,4 @@ def test_invalid_schema_exception_handling(
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_metrics(metrics_sample_invalid)
+        metric_store.write_participant_ai_metrics(metrics_sample_invalid)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -39,6 +39,7 @@ def test_valid_participant_metrics(
     )
 
     metric_store.write_participant_metrics(participant_metrics_sample)
+    write_points_mock.assert_called_once()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
@@ -55,7 +56,8 @@ def test_write_points_exception_handling_write_participant_metrics(
         metric_store.write_participant_metrics(participant_metrics_sample)
 
 
-def test_invalid_json_exception_handling():
+@mock.patch.object(InfluxDBClient, "write_points", return_value=True)
+def test_invalid_json_exception_handling(write_points_mock):
     """Check that raised exceptions of the write_points method are caught in the
     write_participant_metrics method."""
     metric_store = MetricsStore(
@@ -63,9 +65,11 @@ def test_invalid_json_exception_handling():
     )
     with pytest.raises(MetricsStoreError):
         metric_store.write_participant_metrics('{"a": 1')
+    write_points_mock.assert_not_called()
 
     with pytest.raises(MetricsStoreError):
         metric_store.write_participant_metrics("{1: 1}")
+    write_points_mock.assert_not_called()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
@@ -80,6 +84,7 @@ def test_empty_metrics_exception_handling(
 
     with pytest.raises(MetricsStoreError):
         metric_store.write_participant_metrics(empty_json_participant_metrics_sample)
+    write_points_mock.assert_not_called()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
@@ -94,6 +99,7 @@ def test_invalid_schema_exception_handling(
 
     with pytest.raises(MetricsStoreError):
         metric_store.write_participant_metrics(invalid_json_participant_metrics_sample)
+    write_points_mock.assert_not_called()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
@@ -106,6 +112,7 @@ def test_valid_coordinator_metrics(
     )
 
     metric_store.write_coordinator_metrics(coordinator_metrics_sample, tags={"1": "2"})
+    write_points_mock.assert_called_once()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -422,7 +422,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
         try:
             if message.metrics != "[]":
-                self.metrics_store.write_participant_ai_metrics(message.metrics)
+                self.metrics_store.write_participant_metrics(message.metrics)
         except MetricsStoreError as err:
             logger.warn(
                 "Can not write metrics", participant_id=participant_id, error=repr(err)

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -476,7 +476,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         If an exception is raised, it will be caught and the error logged.
 
         FIXME: Helper function to make sure that the coordinator does not crash due to exception of
-        the metric store. Prober exception handling should be tackled in PB-125.
+        the metric store. Proper exception handling should be tackled in PB-125.
 
         Args:
 

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -1,6 +1,6 @@
 """XAIN FL Coordinator"""
 
-from typing import List
+from typing import Dict, List, Optional, Union
 
 from google.protobuf.internal.python_message import GeneratedProtocolMessageType
 import numpy as np
@@ -464,7 +464,12 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         logger.debug("Send EndTrainingRoundResponse", participant_id=participant_id)
         return EndTrainingRoundResponse()
 
-    def _write_metrics_fail_silently(self, metric, value, tags=None):
+    def _write_metrics_fail_silently(
+        self,
+        metric: str,
+        value: Union[str, int, float],
+        tags: Optional[Dict[str, str]] = None,
+    ):
         """
         Write the metrics to a metric store that are collected on the coordinator site.
         If a exception is raised, the exception will be caught and the error logged.

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -475,6 +475,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         Write the metrics to a metric store that are collected on the coordinator site.
         If an exception is raised, it will be caught and the error logged.
 
+        FIXME: Helper function to make sure that the coordinator does not crash due to exception of
+        the metric store. Prober exception handling should be tackled in PB-125.
+
         Args:
 
             metrics: A dictionary with the metric names as keys and the metric values as values.

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -473,7 +473,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
     ):
         """
         Write the metrics to a metric store that are collected on the coordinator site.
-        If a exception is raised, the exception will be caught and the error logged.
+        If an exception is raised, it will be caught and the error logged.
 
         Args:
 

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -465,10 +465,20 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         return EndTrainingRoundResponse()
 
     def _write_metrics_fail_silently(self, metric, value, tags=None):
+        """
+        Write the metrics to a metric store that are collected on the coordinator site.
+        If a exception is raised, the exception will be caught and the error logged.
+
+        Args:
+
+            metric: The name of metric.
+            value: The value of the metric.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+        """
         try:
-            self.metrics_store.write_metrics(metric, value, tags)
+            self.metrics_store.write_coordinator_metrics(metric, value, tags)
         except MetricsStoreError as err:
-            logger.warn("Can not write metrics", error=repr(err))
+            logger.warn("Can not write coordinator metrics", error=repr(err))
 
 
 def pb_enum_to_str(pb_enum, member_value: int) -> str:

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -169,7 +169,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.influx_client.write_points([influx_point])
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", err=repr(err))
-            raise MetricsStoreError("Can not write participant metrics.") from err
+            raise MetricsStoreError("Can not write coordinator metrics.") from err
 
 
 class MetricsStoreError(Exception):

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 import json
 import time
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from influxdb import InfluxDBClient
 from jsonschema import validate
@@ -136,7 +136,10 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             raise MetricsStoreError("Can not write participant metrics.") from err
 
     def write_coordinator_metrics(
-        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+        self,
+        metric: str,
+        value: Union[str, int, float],
+        tags: Optional[Dict[str, str]] = None,
     ):
         """
         Write the metrics to influxDB that are collected on the coordinator site.

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -34,15 +34,16 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
 
     @abstractmethod
     def write_coordinator_metrics(
-        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+        self,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
     ):
         """
         Write the metrics to a metric store that are collected on the coordinator site.
 
         Args:
 
-            metric: The name of metric.
-            value: The value of the metric.
+            metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
 
         Raises:
@@ -66,15 +67,16 @@ class NullObjectMetricsStore(
         """
 
     def write_coordinator_metrics(
-        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+        self,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
     ):
         """
         A method that has no effect.
 
         Args:
 
-            metric: The name of metric.
-            value: The value of the metric.
+            metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
         """
 
@@ -137,17 +139,15 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
     def write_coordinator_metrics(
         self,
-        metric: str,
-        value: Union[str, int, float],
+        metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ):
         """
-        Write the metrics to influxDB that are collected on the coordinator site.
+        Write the metrics to InfluxDB that are collected on the coordinator site.
 
         Args:
 
-            metric: The name of metric.
-            value: The value of the metric.
+            metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
 
         Raises:
@@ -158,18 +158,18 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             tags = {}
 
         current_time: int = int(time.time() * 1_000_000_000)
-        metrics = {
-            "measurement": metric,
+        influx_point = {
+            "measurement": "coordinator",
             "time": current_time,
             "tags": tags,
-            "fields": {metric: value},
+            "fields": metrics,
         }
 
         try:
-            self.influx_client.write_points([metrics])
+            self.influx_client.write_points([influx_point])
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", err=repr(err))
-            raise MetricsStoreError("Can not write coordinator metrics.") from err
+            raise MetricsStoreError("Can not write participant metrics.") from err
 
 
 class MetricsStoreError(Exception):

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 import json
 import time
+from typing import Optional, Union
 
 from influxdb import InfluxDBClient
 from jsonschema import validate
@@ -18,8 +19,9 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
     """An abstract metric store."""
 
     @abstractmethod
-    def write_participant_ai_metrics(self, metrics_as_json: str):
-        """Write the participant metrics on behalf of the participant into a metric store.
+    def write_participant_metrics(self, metrics_as_json: str):
+        """
+        Write the participant metrics on behalf of the participant into a metric store.
 
         Args:
 
@@ -30,18 +32,50 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
             MetricsStoreError: If the writing of the metrics has failed.
         """
 
+    @abstractmethod
+    def write_coordinator_metrics(
+        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+    ):
+        """
+        Write the metrics to a metric store that are collected on the coordinator site.
+
+        Args:
+
+            metric: The name of metric.
+            value: The value of the metric.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
+
 
 class NullObjectMetricsStore(
     AbstractMetricsStore
 ):  # pylint: disable=too-few-public-methods
     """A metric store that does nothing."""
 
-    def write_participant_ai_metrics(self, metrics_as_json: str):
-        """A method that has no effect.
+    def write_participant_metrics(self, metrics_as_json: str):
+        """
+        A method that has no effect.
 
         Args:
 
             metrics_as_json: The metrics of a specific participant.
+        """
+
+    def write_coordinator_metrics(
+        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+    ):
+        """
+        A method that has no effect.
+
+        Args:
+
+            metric: The name of metric.
+            value: The value of the metric.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
         """
 
 
@@ -80,8 +114,9 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             "minItems": 1,
         }
 
-    def write_participant_ai_metrics(self, metrics_as_json: str):
-        """Write the participant metrics on behalf of the participant into InfluxDB.
+    def write_participant_metrics(self, metrics_as_json: str):
+        """
+        Write the participant metrics on behalf of the participant into InfluxDB.
 
         Args:
 
@@ -98,25 +133,40 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             self.influx_client.write_points(metrics)
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", err=repr(err))
-            raise MetricsStoreError("Can not write metrics.") from err
+            raise MetricsStoreError("Can not write participant metrics.") from err
 
-    def write_metrics(self, measurement: str, value, tags=None):
+    def write_coordinator_metrics(
+        self, metric: str, value: Union[str, int, float], tags: Optional[dict] = None,
+    ):
+        """
+        Write the metrics to influxDB that are collected on the coordinator site.
+
+        Args:
+
+            metric: The name of metric.
+            value: The value of the metric.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
         if not tags:
             tags = {}
 
         current_time: int = int(time.time() * 1_000_000_000)
         metrics = {
-            "measurement": measurement,
+            "measurement": metric,
             "time": current_time,
             "tags": tags,
-            "fields": {measurement: value},
+            "fields": {metric: value},
         }
 
         try:
             self.influx_client.write_points([metrics])
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", err=repr(err))
-            raise MetricsStoreError("Can not write metrics.") from err
+            raise MetricsStoreError("Can not write coordinator metrics.") from err
 
 
 class MetricsStoreError(Exception):

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -134,7 +134,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             validate(instance=metrics, schema=self.schema)
             self.influx_client.write_points(metrics)
         except Exception as err:  # pylint: disable=broad-except
-            logger.error("Exception", err=repr(err))
+            logger.error("Exception", error=repr(err))
             raise MetricsStoreError("Can not write participant metrics.") from err
 
     def write_coordinator_metrics(
@@ -168,7 +168,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
         try:
             self.influx_client.write_points([influx_point])
         except Exception as err:  # pylint: disable=broad-except
-            logger.error("Exception", err=repr(err))
+            logger.error("Exception", error=repr(err))
             raise MetricsStoreError("Can not write coordinator metrics.") from err
 
 


### PR DESCRIPTION
### References

[PB-428 Send coordinator states to InfluxDB ](https://xainag.atlassian.net/browse/PB-428)

### Summary

* `number_of_selected_participants`, `round` and `state` are send to influxDB

### Are there any open tasks/blockers for the ticket?

<!--(Are all tasks for the referred ticket done, are there any other issues, comments)-->

<!-- ### Optional: Next Step -->

<!-- (If there are any open tasks/blockers, what is the next step) -->

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
