### PR TITLE
PB-425 split weight init from training

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
-    "xain-sdk==0.5.0",  # Apache License 2.0
+    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development",  # Apache License 2.0
 ]
 
 docs_require = [

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -146,6 +146,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         # state variables
         self.state: State = State.STANDBY
         self.current_round: int = 0
+        self.epochs_current_round: int = epochs
 
     def get_minimum_connected_participants(self) -> int:
         """Calculates how many participants are needed so that we can select
@@ -339,14 +340,19 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 "StartTrainingRoundRequest outside of a round"
             )
 
+        if self.weights.size:
+            self.epochs_current_round = self.epochs
+        else:
+            self.epochs_current_round = 0
+
         logger.debug(
             "Send StartTrainingRoundResponse",
-            epochs=self.epochs,
+            epochs=self.epochs_current_round,
             epoch_base=self.epoch_base,
         )
         return StartTrainingRoundResponse(
             weights=ndarray_to_proto(self.weights),
-            epochs=self.epochs,
+            epochs=self.epochs_current_round,
             epoch_base=self.epoch_base,
         )
 
@@ -411,7 +417,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 self.state = State.FINISHED
             else:
                 self.current_round += 1
-                self.epoch_base += self.epochs
+                self.epoch_base += self.epochs_current_round
                 # reinitialize the round
                 self.select_participant_ids_and_init_round()
 

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -377,7 +377,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         )
 
         try:
-            self.metrics_store.write_metrics(message.metrics)
+            if message.metrics != "[]":
+                self.metrics_store.write_metrics(message.metrics)
         except MetricsStoreError as err:
             logger.warn(
                 "Can not write metrics", participant_id=participant_id, error=repr(err)


### PR DESCRIPTION
### References

- [PB-425](https://xainag.atlassian.net/browse/PB-425) (automatically solves [PB-409](https://xainag.atlassian.net/browse/PB-409))

### Summary

- only write metrics when the respective message is not empty (e.g. no metrics for weight init round)
- keep track of the number of epochs for the current training round

### Are there any open tasks/blockers for the ticket?

- none

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
