### PR TITLE
PB-434 separate metrics

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,13 +23,13 @@ def participant_metrics_sample():
     return json.dumps(
         [
             {
-                "measurement": "CPU utilization",
+                "measurement": "participant",
                 "time": 1234326435,
                 "tags": {"id": "127.0.0.1:1345"},
                 "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},
             },
             {
-                "measurement": "CPU utilization",
+                "measurement": "participant",
                 "time": 3542626236,
                 "tags": {"id": "127.0.0.1:1345"},
                 "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -99,7 +99,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
                 {
                     "type": "object",
                     "properties": {
-                        "measurement": "participant",
+                        "measurement": {"const": "participant"},
                         "time": {"type": "number"},
                         "tags": {
                             "type": "object",

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -99,7 +99,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
                 {
                     "type": "object",
                     "properties": {
-                        "measurement": {"type": "string"},
+                        "measurement": "participant",
                         "time": {"type": "number"},
                         "tags": {
                             "type": "object",


### PR DESCRIPTION
### References

[PB-434 Separate participant metrics from coordinator metrics](https://xainag.atlassian.net/browse/PB-434)

### Summary

* adjust jsonschema (ensure that the value of measurement is always `participant`)
* fix tests

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
