### PR TITLE
PB-159: remove weights from gRPC messages

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -34,10 +34,8 @@ fraction_participants = 1.0
 [storage]
 # (Required) URL to the storage service to use
 endpoint = "http://minio-dev:9000"
-# (Required) Name of the bucket for storing the global model weights
-global_weights_bucket = "xain-fl-aggregated-weights"
-# (Required) Name of the bucket for retrieving the local model weights
-local_weights_bucket = "xain-fl-participants-weights"
+# (Required) Name of the bucket for storing the model weights
+bucket = "xain-fl"
 # (Required) AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # (Required) AWS secret access to use to authenticate to the storage service

--- a/configs/xain-fl.toml
+++ b/configs/xain-fl.toml
@@ -30,10 +30,8 @@ fraction_participants = 1.0
 [storage]
 # URL to the storage service to use
 endpoint = "http://minio-dev:9000"
-# Name of the bucket for storing the global model weights
-global_weights_bucket = "xain-fl-aggregated-weights"
-# Name of the bucket for retrieving the local model weights
-local_weights_bucket = "xain-fl-participants-weights"
+# Name of the bucket for storing the model weights
+bucket = "xain-fl"
 # AWS access key ID to use to authenticate to the storage service
 access_key_id = "minio"
 # AWS secret access to use to authenticate to the storage service

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -38,12 +38,9 @@ services:
         done;
         echo Connected!;
         mc config host add dev-minio http://minio-dev:9000 $${MINIO_ACCESS_KEY} $${MINIO_SECRET_KEY};
-        /usr/bin/mc mb -p dev-minio/xain-fl-temporary-weights;
-        /usr/bin/mc mb -p dev-minio/xain-fl-aggregated-weights;
-        /usr/bin/mc policy set upload dev-minio/xain-fl-temporary-weights;
-        /usr/bin/mc policy set download dev-minio/xain-fl-temporary-weights;
-        /usr/bin/mc policy set upload dev-minio/xain-fl-aggregated-weights;
-        /usr/bin/mc policy set download dev-minio/xain-fl-aggregated-weights;
+        /usr/bin/mc mb -p dev-minio/xain-fl;
+        /usr/bin/mc policy set upload dev-minio/xain-fl;
+        /usr/bin/mc policy set download dev-minio/xain-fl;
         /usr/bin/mc admin trace -v -e dev-minio;
       "
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     "numpy==1.15",  # BSD
     "grpcio==1.23",  # Apache License 2.0
     "structlog==19.2.0",  # Apache License 2.0
-    "xain-proto==0.5.0",  # Apache License 2.0
+    "xain-proto @ git+https://github.com/xainag/xain-proto.git@PB-159-use-s3-for-transfering-weights#egg=xain_proto-0.6.0&subdirectory=python",  # Apache License 2.0
     "boto3==1.10.48",  # Apache License 2.0
     "toml==0.10.0",  # MIT
     "schema~=0.7",  # MIT
@@ -52,7 +52,8 @@ tests_require = [
     "pytest==5.3.2",  # MIT license
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
-    "xain-sdk @ git+https://github.com/xainag/xain-sdk.git@development",  # Apache License 2.0
+    "pytest-mock==2.0.0",  # MIT
+    "xain-sdk@ git+https://github.com/xainag/xain-sdk.git@PB-159-use-s3-for-transfering-weights#egg=xain_sdk-0.6.0",  # Apache License 2.0
 ]
 
 docs_require = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def end_training_request(s3_mock_stores):
 @pytest.fixture(scope="function")
 def coordinator(s3_mock_stores):
     """
-    A function that instantiate a new coordinator.
+    A function that instantiates a new coordinator.
     """
     store: MockS3Coordinator = s3_mock_stores[0]
     default_global_weights_writer: AbstractGlobalWeightsWriter = store

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,16 +5,122 @@ import json
 import threading
 
 import grpc
+import numpy as np
+from numpy import ndarray
 import pytest
 from xain_proto.fl import coordinator_pb2_grpc
+from xain_proto.fl.coordinator_pb2 import EndTrainingRoundRequest
 
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
-from xain_fl.fl.coordinator.aggregate import ModelSumAggregator
-from xain_fl.fl.coordinator.controller import IdController
+from xain_fl.coordinator.metrics_store import (
+    AbstractMetricsStore,
+    NullObjectMetricsStore,
+)
+from xain_fl.coordinator.store import (
+    AbstractGlobalWeightsWriter,
+    AbstractLocalWeightsReader,
+)
+from xain_fl.fl.coordinator.aggregate import (
+    Aggregator,
+    ModelSumAggregator,
+    WeightedAverageAggregator,
+)
+from xain_fl.fl.coordinator.controller import Controller, IdController, RandomController
 
 from .port_forwarding import ConnectionManager
+from .store import MockS3Coordinator, MockS3Participant, MockS3Resource
+
+# pylint: disable=redefined-outer-name
+
+
+@pytest.fixture(scope="function")
+def s3_mock_stores():
+    """
+    Create a fake S3 store
+    """
+
+    s3_resource = MockS3Resource()
+    participant_store = MockS3Participant(s3_resource)
+    coordinator_store = MockS3Coordinator(s3_resource)
+    return (coordinator_store, participant_store)
+
+
+@pytest.fixture(scope="function")
+def participant_store(s3_mock_stores):
+    """Return an object the participants can use to read the global
+    weights and write their local weights
+
+    """
+    return s3_mock_stores[1]
+
+
+@pytest.fixture(scope="function")
+def end_training_request(s3_mock_stores):
+    """A fixture that returns a function that can be used to send an
+    ``EndTrainingRequest`` to the coordinator.
+
+    """
+    participant_store = s3_mock_stores[1]
+
+    def wrapped(
+        coordinator: Coordinator,
+        participant_id: str,
+        round: int = 0,
+        weights: ndarray = ndarray([]),
+    ):
+        """Write the local weights for the given round and the given
+        participant, and send an ``EndTrainingRequest`` on behalf of
+        that participant.
+
+        """
+        participant_store.write_weights(participant_id, round, weights)
+        coordinator.on_message(
+            EndTrainingRoundRequest(participant_id=participant_id), participant_id
+        )
+
+    return wrapped
+
+
+@pytest.fixture(scope="function")
+def coordinator(s3_mock_stores):
+    """
+    A function that instantiate a new coordinator.
+    """
+    store: MockS3Coordinator = s3_mock_stores[0]
+    default_global_weights_writer: AbstractGlobalWeightsWriter = store
+    default_local_weights_reader: AbstractLocalWeightsReader = store
+
+    # pylint: disable=too-many-arguments
+    def wrapped(
+        global_weights_writer=default_global_weights_writer,
+        local_weights_reader=default_local_weights_reader,
+        metrics_store: AbstractMetricsStore = NullObjectMetricsStore(),
+        num_rounds: int = 1,
+        minimum_participants_in_round: int = 1,
+        fraction_of_participants: float = 1.0,
+        weights: ndarray = np.empty(shape=(0,)),
+        epochs: int = 1,
+        epoch_base: int = 0,
+        aggregator: Aggregator = WeightedAverageAggregator(),
+        controller: Controller = RandomController(),
+    ):
+        return Coordinator(
+            global_weights_writer,
+            local_weights_reader,
+            metrics_store=metrics_store,
+            num_rounds=num_rounds,
+            minimum_participants_in_round=minimum_participants_in_round,
+            fraction_of_participants=fraction_of_participants,
+            weights=weights,
+            epochs=epochs,
+            epoch_base=epoch_base,
+            aggregator=aggregator,
+            controller=controller,
+        )
+
+    return wrapped
 
 
 @pytest.fixture()
@@ -45,14 +151,14 @@ def coordinator_metrics_sample():
 
 
 @pytest.fixture
-def coordinator_service():
+def coordinator_service(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=10, fraction_of_participants=1.0
     )
     coordinator_grpc = CoordinatorGrpc(coordinator)
@@ -64,7 +170,7 @@ def coordinator_service():
 
 
 @pytest.fixture
-def mock_coordinator_service():
+def mock_coordinator_service(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -73,7 +179,7 @@ def mock_coordinator_service():
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     agg = ModelSumAggregator()
     ctrl = IdController()
-    coordinator = Coordinator(
+    coordinator = coordinator(
         num_rounds=2,
         minimum_participants_in_round=1,
         fraction_of_participants=1.0,

--- a/tests/store.py
+++ b/tests/store.py
@@ -104,7 +104,7 @@ class MockS3Coordinator(S3GlobalWeightsWriter, S3LocalWeightsReader):
         writes = self.s3.writes[f"{round}/global"]
         # Under normal conditions, we should write data exactly once
         assert writes == 1, f"got {writes} writes for round {round}, expected 1"
-        assert_ndarray_eq(self.s3.fake_store[f"{round}/global"], weights)
+        np.testing.assert_array_equal(self.s3.fake_store[f"{round}/global"], weights)
 
     def assert_didnt_write(self, round: int):
         """Check that the weights for the given round have NOT been written to the store.
@@ -144,7 +144,7 @@ class MockS3Participant(S3LocalWeightsWriter, S3GlobalWeightsReader):
         key = f"{round}/{participant_id}"
         writes = self.s3.writes[key]
         assert writes == 1, f"got {writes} writes for {key}, expected 1"
-        assert_ndarray_eq(self.s3.fake_store[key], weights)
+        np.testing.assert_array_equal(self.s3.fake_store[key], weights)
 
     def assert_didnt_write(self, participant_id: str, round: int):
         """Check that the weights for the given round have NOT been written to
@@ -157,11 +157,3 @@ class MockS3Participant(S3LocalWeightsWriter, S3GlobalWeightsReader):
         """
         key = f"{round}/{participant_id}"
         assert self.s3.writes[key] == 0
-
-
-def assert_ndarray_eq(nd_array1, nd_array2):
-    """Check that the two given numpy arrays are equal, ignoring NaN
-    values.
-
-    """
-    assert np.array_equal(np.nan_to_num(nd_array1), np.nan_to_num(nd_array2))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,8 +43,7 @@ def storage_sample():
     """
     return {
         "endpoint": "http://localhost:9000",
-        "global_weights_bucket": "aggregated_weights",
-        "local_weights_bucket": "participants_weights",
+        "bucket": "bucket",
         "secret_access_key": "my-secret",
         "access_key_id": "my-key-id",
     }
@@ -135,8 +134,7 @@ def test_load_valid_config(config_sample):  # pylint: disable=redefined-outer-na
     assert config.ai.fraction_participants == 1.0
 
     assert config.storage.endpoint == "http://localhost:9000"
-    assert config.storage.global_weights_bucket == "aggregated_weights"
-    assert config.storage.local_weights_bucket == "participants_weights"
+    assert config.storage.bucket == "bucket"
     assert config.storage.secret_access_key == "my-secret"
     assert config.storage.access_key_id == "my-key-id"
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -218,7 +218,7 @@ def test_training_finished(coordinator, end_training_request):
     coordinator.on_message(RendezvousRequest(), "participant1")
 
     # Deliver results for 2 rounds
-    end_training_request(coordinator, "participant1")
+    end_training_request(coordinator, "participant1", round=0)
     end_training_request(coordinator, "participant1", round=1)
 
     assert coordinator.state == State.FINISHED

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,8 +1,6 @@
 """XAIN FL tests for coordinator"""
 
-from unittest import mock
-
-import numpy as np
+from numpy import ndarray
 import pytest
 from xain_proto.fl.coordinator_pb2 import (
     EndTrainingRoundRequest,
@@ -13,7 +11,6 @@ from xain_proto.fl.coordinator_pb2 import (
     StartTrainingRoundRequest,
     State,
 )
-from xain_proto.np import proto_to_ndarray
 
 from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.fl.coordinator.controller import OrderController
@@ -23,14 +20,18 @@ from xain_fl.tools.exceptions import (
     UnknownParticipantError,
 )
 
+from .store import assert_ndarray_eq
 
-def test_rendezvous_accept():
+# pylint: disable=redefined-outer-name
+
+
+def test_rendezvous_accept(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator: Coordinator = Coordinator()
+    coordinator: Coordinator = coordinator()
     response: RendezvousResponse = coordinator.on_message(
         RendezvousRequest(), "participant1"
     )
@@ -39,13 +40,13 @@ def test_rendezvous_accept():
     assert response.reply == RendezvousReply.ACCEPT
 
 
-def test_rendezvous_later_fraction_1():
+def test_rendezvous_later_fraction_1(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -55,13 +56,13 @@ def test_rendezvous_later_fraction_1():
     assert response.reply == RendezvousReply.LATER
 
 
-def test_rendezvous_later_fraction_05():
+def test_rendezvous_later_fraction_05(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=0.5
     )
 
@@ -83,7 +84,7 @@ def test_rendezvous_later_fraction_05():
     assert response.reply == RendezvousReply.LATER
 
 
-def test_coordinator_state_standby_round():
+def test_coordinator_state_standby_round(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -91,7 +92,7 @@ def test_coordinator_state_standby_round():
 
     # tests that the coordinator transitions from STANDBY to ROUND once enough participants
     # are connected
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=1.0
     )
 
@@ -103,27 +104,7 @@ def test_coordinator_state_standby_round():
     assert coordinator.current_round == 0
 
 
-def test_start_training_round():
-    """[summary]
-
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
-    """
-
-    test_weights = np.arange(10)
-    coordinator = Coordinator(
-        minimum_participants_in_round=1,
-        fraction_of_participants=1.0,
-        weights=test_weights,
-    )
-    coordinator.on_message(RendezvousRequest(), "participant1")
-
-    response = coordinator.on_message(StartTrainingRoundRequest(), "participant1")
-    received_weights = proto_to_ndarray(response.weights)
-
-    np.testing.assert_equal(test_weights, received_weights)
-
-
-def start_training_round_wrong_state():
+def start_training_round_wrong_state(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -131,7 +112,7 @@ def start_training_round_wrong_state():
 
     # if the coordinator receives a StartTrainingRound request while not in the
     # ROUND state it will raise an exception
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -140,39 +121,42 @@ def start_training_round_wrong_state():
         coordinator.on_message(StartTrainingRoundRequest(), "participant1")
 
 
-@mock.patch("xain_fl.coordinator.store.NullObjectLocalWeightsReader.read_weights")
-def test_end_training_round(read_weights_mock):
+def test_end_training_round(coordinator, end_training_request):
     """Test handling of a `EndTrainingRoundRequest` message.
     """
 
     # we need two participants so that we can check the status of the local update mid round
     # with only one participant it wouldn't work because the local updates state is cleaned at
     # the end of each round
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
     coordinator.on_message(RendezvousRequest(), "participant2")
 
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+    local_weights = ndarray([1, 2, 3])
+    end_training_request(coordinator, "participant1", 0, local_weights)
 
     assert len(coordinator.round.updates) == 1
-    read_weights_mock.assert_called_once_with("participant1", 0)
+    # check that the coordinator read the correct local weights from the store
+    coordinator.local_weights_reader.assert_read("participant1", 0)
+    update = coordinator.round.updates["participant1"]
+    assert_ndarray_eq(update["model_weights"], local_weights)
 
 
-def test_end_training_round_update():
-    """[summary]
+def test_end_training_round_update(coordinator, end_training_request):
+    """Test that the round number is updated once all participants sent
+    their updates
 
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    # Test that the round number is updated once all participants sent their updates
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2,
         fraction_of_participants=1.0,
         num_rounds=2,
         epochs=3,
     )
+
     coordinator.on_message(RendezvousRequest(), "participant1")
     coordinator.on_message(RendezvousRequest(), "participant2")
 
@@ -180,67 +164,75 @@ def test_end_training_round_update():
     assert coordinator.current_round == 0
     assert coordinator.epoch_base == 0
 
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+    # Pretend participant1 sent their result to s3 and then sent an
+    # EndTraining request
+    end_training_request(coordinator, "participant1")
+
     # check we are still in round 0
     assert coordinator.current_round == 0
     assert coordinator.epoch_base == 0
-    coordinator.on_message(EndTrainingRoundRequest(), "participant2")
+
+    # Pretend participant2 sent their result to s3, and then sent an
+    # EndTraining request
+    end_training_request(coordinator, "participant2")
 
     # check that round number was updated
     assert coordinator.current_round == 1
     assert coordinator.epoch_base == 3
 
 
-def test_end_training_round_reinitialize_local_models():
+def test_end_training_round_reinitialize_local_models(
+    coordinator, end_training_request
+):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2, fraction_of_participants=1.0, num_rounds=2
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
     coordinator.on_message(RendezvousRequest(), "participant2")
 
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+    end_training_request(coordinator, "participant1")
 
     # After one participant sends its updates we should have one update in the coordinator
     assert len(coordinator.round.updates) == 1
 
-    coordinator.on_message(EndTrainingRoundRequest(), "participant2")
+    end_training_request(coordinator, "participant2")
 
     # once the second participant delivers its updates the round ends and the local models
     # are reinitialized
     assert coordinator.round.updates == {}
 
 
-def test_training_finished():
+def test_training_finished(coordinator, end_training_request):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=1.0, num_rounds=2
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
 
     # Deliver results for 2 rounds
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+    end_training_request(coordinator, "participant1")
+    end_training_request(coordinator, "participant1", round=1)
 
     assert coordinator.state == State.FINISHED
 
 
-def test_wrong_participant():
+def test_wrong_participant(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
     # coordinator should not accept requests from participants that it has not accepted
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -255,7 +247,7 @@ def test_wrong_participant():
         coordinator.on_message(EndTrainingRoundRequest(), "participant2")
 
 
-def test_duplicated_update_submit():
+def test_duplicated_update_submit(coordinator, end_training_request):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -263,25 +255,25 @@ def test_duplicated_update_submit():
 
     # the coordinator should not accept multiples updates from the same participant
     # in the same round
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
     coordinator.on_message(RendezvousRequest(), "participant2")
 
-    coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+    end_training_request(coordinator, "participant1")
 
     with pytest.raises(DuplicatedUpdateError):
-        coordinator.on_message(EndTrainingRoundRequest(), "participant1")
+        end_training_request(coordinator, "participant1")
 
 
-def test_remove_selected_participant():
+def test_remove_selected_participant(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=1.0
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -303,38 +295,14 @@ def test_remove_selected_participant():
     assert coordinator.state == State.ROUND
 
 
-def test_remove_unselected_participant():
-    """[summary]
-
-    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
-    """
-
-    coordinator = Coordinator(
-        minimum_participants_in_round=1, fraction_of_participants=0.5
-    )
-    coordinator.on_message(RendezvousRequest(), "participant1")
-    coordinator.on_message(RendezvousRequest(), "participant2")
-
-    assert coordinator.participants.len() == 2
-    assert len(coordinator.round.participant_ids) == 1
-
-    # override selection
-    coordinator.round.participant_ids = ["participant1"]
-
-    coordinator.remove_participant("participant2")
-
-    assert coordinator.participants.len() == 1
-    assert coordinator.round.participant_ids == ["participant1"]
-
-
-def test_number_of_selected_participants():
+def test_number_of_selected_participants(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
     # test that the coordinator needs minimum 3 participants and selects 2 of them
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=2, fraction_of_participants=0.6
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -358,14 +326,14 @@ def test_number_of_selected_participants():
     assert len(coordinator.round.participant_ids) == 2
 
 
-def test_correct_round_advertised_to_participants():
+def test_correct_round_advertised_to_participants(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
     # test that only selected participants receive ROUND state and the others STANDBY
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=1, fraction_of_participants=0.5
     )
     coordinator.on_message(RendezvousRequest(), "participant1")
@@ -383,14 +351,14 @@ def test_correct_round_advertised_to_participants():
     assert response.state == State.STANDBY
 
 
-def test_select_outstanding():
+def test_select_outstanding(coordinator):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
     """
 
     # setup: select first 3 of 4 in order per round
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=3,
         fraction_of_participants=0.75,
         controller=OrderController(),

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -294,6 +294,29 @@ def test_remove_selected_participant(coordinator):
     assert coordinator.state == State.ROUND
 
 
+def test_remove_unselected_participant(coordinator):
+    """[summary]
+
+    .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
+    """
+    coordinator = coordinator(
+        minimum_participants_in_round=1, fraction_of_participants=0.5
+    )
+    coordinator.on_message(RendezvousRequest(), "participant1")
+    coordinator.on_message(RendezvousRequest(), "participant2")
+
+    assert coordinator.participants.len() == 2
+    assert len(coordinator.round.participant_ids) == 1
+
+    # override selection
+    coordinator.round.participant_ids = ["participant1"]
+
+    coordinator.remove_participant("participant2")
+
+    assert coordinator.participants.len() == 1
+    assert coordinator.round.participant_ids == ["participant1"]
+
+
 def test_number_of_selected_participants(coordinator):
     """[summary]
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """XAIN FL tests for coordinator"""
 
+import numpy as np
 from numpy import ndarray
 import pytest
 from xain_proto.fl.coordinator_pb2 import (
@@ -19,8 +20,6 @@ from xain_fl.tools.exceptions import (
     InvalidRequestError,
     UnknownParticipantError,
 )
-
-from .store import assert_ndarray_eq
 
 # pylint: disable=redefined-outer-name
 
@@ -141,7 +140,7 @@ def test_end_training_round(coordinator, end_training_request):
     # check that the coordinator read the correct local weights from the store
     coordinator.local_weights_reader.assert_read("participant1", 0)
     update = coordinator.round.updates["participant1"]
-    assert_ndarray_eq(update["model_weights"], local_weights)
+    np.testing.assert_array_equal(update["model_weights"], local_weights)
 
 
 def test_end_training_round_update(coordinator, end_training_request):

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -537,6 +537,7 @@ def test_start_participant(  # pylint: disable=redefined-outer-name
     )
     mock_local_part = mocker.patch("xain_sdk.participant.Participant")
     mock_local_part.init_weights.return_value = init_weight
+    mock_local_part.train_round.return_value = init_weight, 1
     mock_local_part.dummy_id = "participant1"
 
     config: Config = Config.from_unchecked_dict(participant_config)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -50,7 +50,6 @@ def participant_config() -> dict:
             },
         },
         "storage": {
-            "enable": False,
             "endpoint": "http://localhost:9000",
             "bucket": "aggregated_weights",
             "secret_access_key": "my-secret",

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -536,8 +536,8 @@ def test_start_participant(  # pylint: disable=redefined-outer-name
         "xain_sdk.participant_state_machine.S3GlobalWeightsReader",
         new=mock_participant_store,
     )
-    mock_local_part = mocker.patch("xain_sdk.participant_state_machine.Participant")
-    mock_local_part.train_round.return_value = init_weight, 1
+    mock_local_part = mocker.patch("xain_sdk.participant.Participant")
+    mock_local_part.init_weights.return_value = init_weight
     mock_local_part.dummy_id = "participant1"
 
     config: Config = Config.from_unchecked_dict(participant_config)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -20,7 +20,6 @@ from xain_proto.fl.coordinator_pb2 import (
     State,
 )
 from xain_proto.fl.coordinator_pb2_grpc import add_CoordinatorServicer_to_server
-from xain_proto.np import ndarray_to_proto
 from xain_sdk.config import Config
 from xain_sdk.participant_state_machine import (
     StateRecord,
@@ -31,12 +30,9 @@ from xain_sdk.participant_state_machine import (
     start_training_round,
 )
 
-from xain_fl.coordinator.coordinator import Coordinator
 from xain_fl.coordinator.coordinator_grpc import CoordinatorGrpc
 from xain_fl.coordinator.heartbeat import monitor_heartbeats
 from xain_fl.coordinator.participants import ParticipantContext, Participants
-
-from .store import MockS3Writer
 
 
 @pytest.fixture
@@ -83,7 +79,7 @@ def test_participant_rendezvous_accept(  # pylint: disable=unused-argument
 
 
 @pytest.mark.integration
-def test_participant_rendezvous_later(participant_stub):
+def test_participant_rendezvous_later(coordinator, participant_stub):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -93,7 +89,7 @@ def test_participant_rendezvous_later(participant_stub):
     """
 
     # populate participants
-    coordinator = Coordinator(
+    coordinator = coordinator(
         minimum_participants_in_round=10, fraction_of_participants=1.0
     )
     required_participants = 10
@@ -154,42 +150,36 @@ def test_heartbeat_denied(
         assert response.status_code == grpc.StatusCode.PERMISSION_DENIED
 
 
-@mock.patch(
-    "xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True]
-)
-@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None)
-@mock.patch("xain_fl.coordinator.heartbeat.Coordinator.remove_participant")
-def test_monitor_heartbeats(
-    mock_participants_remove, _mock_event_wait, _mock_event_is_set
-):
+def test_monitor_heartbeats(mocker, coordinator):
     """Test that when there is a participant with an expired heartbeat,
     ``Coordinator.remove_participant`` is called exactly once.
 
-    Args:
-        mock_participants_remove: mock of ``Coordinator.remove_participant()``
-        _mock_event_wait: mock of ``threading.Event.wait`` that does not block
-        _mock_event_is_set: mock of ``threading.Event.is_set``
-
     """
+    mock_remove_participant = mocker.patch(
+        "xain_fl.coordinator.heartbeat.Coordinator.remove_participant"
+    )
+    mocker.patch(
+        "xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None
+    )
+    mocker.patch(
+        "xain_fl.coordinator.heartbeat.threading.Event.is_set",
+        side_effect=[False, True],
+    )
 
     participants = Participants()
     participants.add("participant_1")
     participants.participants["participant_1"].heartbeat_expires = 0
 
-    coordinator = Coordinator()
+    coordinator = coordinator()
     coordinator.participants = participants
 
     terminate_event = threading.Event()
     monitor_heartbeats(coordinator, terminate_event)
 
-    mock_participants_remove.assert_called_once_with("participant_1")
+    mock_remove_participant.assert_called_once_with("participant_1")
 
 
-@mock.patch(
-    "xain_fl.coordinator.heartbeat.threading.Event.is_set", side_effect=[False, True]
-)
-@mock.patch("xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None)
-def test_monitor_heartbeats_remove_participant(_mock_event_wait, _mock_event_is_set):
+def test_monitor_heartbeats_remove_participant(coordinator, mocker):
     """Test that when the coordinator has exactly one participant with an
     expired heartbeat, it is removed correctly.
 
@@ -199,12 +189,19 @@ def test_monitor_heartbeats_remove_participant(_mock_event_wait, _mock_event_is_
         _mock_event_is_set: mock of ``threading.Event.is_set``
 
     """
+    mocker.patch(
+        "xain_fl.coordinator.heartbeat.threading.Event.is_set",
+        side_effect=[False, True],
+    )
+    mocker.patch(
+        "xain_fl.coordinator.heartbeat.threading.Event.wait", return_value=None
+    )
 
     participants = Participants()
     participants.add("participant_1")
     participants.participants["participant_1"].heartbeat_expires = 0
 
-    coordinator = Coordinator()
+    coordinator = coordinator()
     coordinator.participants = participants
 
     terminate_event = threading.Event()
@@ -214,7 +211,7 @@ def test_monitor_heartbeats_remove_participant(_mock_event_wait, _mock_event_is_
 
 
 @pytest.mark.slow
-def test_many_heartbeats_expire_in_short_interval():
+def test_many_heartbeats_expire_in_short_interval(coordinator):
     """Make sure that heartbeat_monitor() works correctly under heavy
     load. This test was added to reproduce
     https://xainag.atlassian.net/browse/PB-104
@@ -225,7 +222,7 @@ def test_many_heartbeats_expire_in_short_interval():
         participant = ParticipantContext(str(i))
         participant.heartbeat_expires = time.time() + 0.1 + i / 1000
         participants[str(i)] = participant
-    coordinator = Coordinator()
+    coordinator = coordinator()
     coordinator.participants.participants = participants
 
     terminate_event = threading.Event()
@@ -298,12 +295,11 @@ def test_start_training_round(coordinator_service):
         # we need to rendezvous before we can send any other requests
         rendezvous(channel)
         # call StartTrainingRound service method on coordinator
-        weights, epochs, epoch_base = start_training_round(channel)
+        epochs, epoch_base = start_training_round(channel)
 
     # check global model received
     assert epochs == 5
     assert epoch_base == 2
-    np.testing.assert_equal(weights, test_weights)
 
 
 @pytest.mark.integration
@@ -349,7 +345,9 @@ def test_start_training_round_failed_precondition(  # pylint: disable=unused-arg
 
 
 @pytest.mark.integration
-def test_end_training_round(coordinator_service, json_participant_metrics_sample):
+def test_end_training_round(
+    coordinator_service, json_participant_metrics_sample, participant_store
+):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -368,8 +366,9 @@ def test_end_training_round(coordinator_service, json_participant_metrics_sample
         # we first need to rendezvous before we can send any other request
         rendezvous(channel)
         # call EndTrainingRound service method on coordinator
+        participant_store.write_weights("participant1", 0, test_weights)
         end_training_round(
-            channel, test_weights, number_samples, json_participant_metrics_sample
+            channel, "participant1", number_samples, json_participant_metrics_sample
         )
     # check local model received...
 
@@ -385,7 +384,7 @@ def test_end_training_round(coordinator_service, json_participant_metrics_sample
 
 @pytest.mark.integration
 def test_end_training_round_duplicated_updates(  # pylint: disable=unused-argument
-    coordinator_service, participant_stub
+    coordinator_service, participant_stub, participant_store
 ):
     """[summary]
 
@@ -399,7 +398,10 @@ def test_end_training_round_duplicated_updates(  # pylint: disable=unused-argume
     # participant can only send updates once in a single round
     participant_stub.Rendezvous(RendezvousRequest())
 
-    participant_stub.EndTrainingRound(EndTrainingRoundRequest())
+    participant_store.write_weights("participant1", 0, np.ndarray([]))
+    participant_stub.EndTrainingRound(
+        EndTrainingRoundRequest(participant_id="participant1")
+    )
 
     with pytest.raises(grpc.RpcError):
         response = participant_stub.EndTrainingRound(EndTrainingRoundRequest())
@@ -427,17 +429,11 @@ def test_end_training_round_denied(  # pylint: disable=unused-argument
 
 
 @pytest.mark.integration
-def test_full_training_round(participant_stubs, coordinator_service):
+def test_full_training_round(participant_stubs, coordinator_service, participant_store):
     """Run a complete training round with multiple participants.
     """
-    # Use a MockS3Writer so that we can also test the storage logic
-    coordinator_service.coordinator.global_weights_writer = MockS3Writer()
-
-    # Initialize the coordinator with dummy weights, otherwise, the
-    # aggregated weights at the end of the round are an empty array.
-    dummy_weights = np.array([1, 2, 3, 4])
-    coordinator_service.coordinator.weights = dummy_weights
-    weights_proto = ndarray_to_proto(dummy_weights)
+    weights = np.ndarray([1, 2, 3, 4])
+    coordinator_service.coordinator.weights = weights
 
     # Create 10 partipants
     participants = [next(participant_stubs) for _ in range(0, 10)]
@@ -476,36 +472,45 @@ def test_full_training_round(participant_stubs, coordinator_service):
     for participant in participants:
         response = participant.StartTrainingRound(StartTrainingRoundRequest())
         assert response == StartTrainingRoundResponse(
-            weights=weights_proto,
             epochs=coordinator_service.coordinator.epochs,
             epoch_base=coordinator_service.coordinator.epoch_base,
         )
 
     # The first 9 participants end training
-    for participant in participants[:-1]:
+    for (i, participant) in enumerate(participants[:-1]):
+        participant_id = f"participant{i}"
+        participant_store.write_weights(participant_id, 0, weights)
         response = participant.EndTrainingRound(
-            EndTrainingRoundRequest(weights=weights_proto, number_samples=1)
+            EndTrainingRoundRequest(participant_id=participant_id, number_samples=1)
         )
         assert response == EndTrainingRoundResponse()
+        coordinator_service.coordinator.local_weights_reader.assert_read(
+            participant_id, 0
+        )
 
     assert not coordinator_service.coordinator.round.is_finished()
     coordinator_service.coordinator.global_weights_writer.assert_didnt_write(1)
 
     # The last participant finishes training
+
+    # pylint: disable=undefined-loop-variable
+    participant_id = f"participant{i+1}"
+    participant_store.write_weights(participant_id, 0, weights)
     response = last_participant.EndTrainingRound(
-        EndTrainingRoundRequest(weights=weights_proto, number_samples=1)
+        EndTrainingRoundRequest(participant_id=participant_id, number_samples=1)
     )
     assert response == EndTrainingRoundResponse()
+
     # Make sure we wrote the results for the given round
     coordinator_service.coordinator.global_weights_writer.assert_wrote(
-        0, coordinator_service.coordinator.weights
+        1, coordinator_service.coordinator.weights
     )
 
 
 @pytest.mark.integration
 @pytest.mark.slow
 def test_start_participant(  # pylint: disable=redefined-outer-name
-    mock_coordinator_service, participant_config
+    mock_coordinator_service, participant_config, mocker, participant_store
 ):
     """[summary]
 
@@ -518,21 +523,33 @@ def test_start_participant(  # pylint: disable=redefined-outer-name
     init_weight = np.arange(10)
     mock_coordinator_service.coordinator.weights = init_weight
 
+    # pylint: disable=missing-docstring
+    def mock_participant_store(*_args):
+        return participant_store
+
     # mock a local participant with a constant train_round function
-    with mock.patch("xain_sdk.participant_state_machine.Participant") as mock_obj:
-        mock_local_part = mock_obj.return_value
-        mock_local_part.train_round.return_value = init_weight, 1
+    mocker.patch(
+        "xain_sdk.participant_state_machine.S3LocalWeightsWriter",
+        new=mock_participant_store,
+    )
+    mocker.patch(
+        "xain_sdk.participant_state_machine.S3GlobalWeightsReader",
+        new=mock_participant_store,
+    )
+    mock_local_part = mocker.patch("xain_sdk.participant_state_machine.Participant")
+    mock_local_part.train_round.return_value = init_weight, 1
+    mock_local_part.dummy_id = "participant1"
 
-        config: Config = Config.from_unchecked_dict(participant_config)
+    config: Config = Config.from_unchecked_dict(participant_config)
 
-        start_participant(mock_local_part, config)
+    start_participant(mock_local_part, config)
 
-        coord = mock_coordinator_service.coordinator
-        assert coord.state == State.FINISHED
+    coord = mock_coordinator_service.coordinator
+    assert coord.state == State.FINISHED
 
-        # coordinator set to 2 rounds for good measure, but the resulting
-        # aggregated weights are the same as a single round
-        assert coord.current_round == 1
+    # coordinator set to 2 rounds for good measure, but the resulting
+    # aggregated weights are the same as a single round
+    assert coord.current_round == 1
 
-        # expect weight aggregated by summation - see mock_coordinator_service
-        np.testing.assert_equal(coord.weights, init_weight)
+    # expect weight aggregated by summation - see mock_coordinator_service
+    np.testing.assert_equal(coord.weights, init_weight)

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -491,9 +491,7 @@ def test_full_training_round(participant_stubs, coordinator_service, participant
     coordinator_service.coordinator.global_weights_writer.assert_didnt_write(1)
 
     # The last participant finishes training
-
-    # pylint: disable=undefined-loop-variable
-    participant_id = f"participant{i+1}"
+    participant_id = f"participant9"
     participant_store.write_weights(participant_id, 0, weights)
     response = last_participant.EndTrainingRound(
         EndTrainingRoundRequest(participant_id=participant_id, number_samples=1)

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -12,10 +12,7 @@ from xain_fl.coordinator.metrics_store import (
     MetricsStore,
     NullObjectMetricsStore,
 )
-from xain_fl.coordinator.store import (
-    NullObjectLocalWeightsReader,
-    S3GlobalWeightsWriter,
-)
+from xain_fl.coordinator.store import S3GlobalWeightsWriter, S3LocalWeightsReader
 from xain_fl.logger import StructLogger, configure_structlog
 from xain_fl.serve import serve
 
@@ -41,7 +38,7 @@ def main() -> None:
 
     coordinator = Coordinator(
         global_weights_writer=S3GlobalWeightsWriter(config.storage),
-        local_weights_reader=NullObjectLocalWeightsReader(),
+        local_weights_reader=S3LocalWeightsReader(config.storage),
         num_rounds=config.ai.rounds,  # type: ignore
         epochs=config.ai.epochs,  # type: ignore
         minimum_participants_in_round=config.ai.min_participants,  # type: ignore

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -200,12 +200,7 @@ AI_SCHEMA = Schema(
 STORAGE_SCHEMA = Schema(
     {
         "endpoint": And(str, url, error=error("storage.endpoint", "a valid URL")),
-        "global_weights_bucket": Use(
-            str, error=error("storage.global_weights_bucket", "an S3 bucket name")
-        ),
-        "local_weights_bucket": Use(
-            str, error=error("storage.local_weights_bucket", "an S3 bucket name")
-        ),
+        "bucket": Use(str, error=error("storage.bucket", "an S3 bucket name")),
         "secret_access_key": Use(
             str, error=error("storage.secret_access_key", "a valid utf-8 string")
         ),
@@ -378,11 +373,8 @@ class Config:
        # URL to the storage service to use
        endpoint = "http://localhost:9000"
 
-       # Name of the bucket for storing the aggregated models
-       global_weights_bucket = "global_weights"
-
-       # Name of the bucket where participants store their results
-       local_weights_bucket = "local_weights"
+       # Name of the bucket for storing the models
+       bucket = "weights"
 
        # AWS secret access to use to authenticate to the storage service
        secret_access_key = "my-secret"

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -423,7 +423,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         # submitting the updates and raise an exception if it is the wrong
         # round.
 
-        # HACK: Participants are currently not aware of they ID the
+        # HACK: Participants are currently not aware of the ID the
         # coordinator uses to identify them, so they generate a UUID
         # and use it to upload their results. The EndTrainingMessage
         # contains that UUID, so that the coordinator can retrieve the

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -109,8 +109,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        global_weights_writer,
-        local_weights_reader,
+        global_weights_writer: AbstractGlobalWeightsWriter,
+        local_weights_reader: AbstractLocalWeightsReader,
         metrics_store: AbstractMetricsStore = NullObjectMetricsStore(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -146,6 +146,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         self.current_round: int = 0
         self.epochs_current_round: int = epochs
 
+        # Write the weights for the initial round
+        self.global_weights_writer.write_weights(0, self.weights)
+
         self._write_metrics_fail_silently(
             "coordinator",
             {

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -21,7 +21,6 @@ from xain_proto.fl.coordinator_pb2 import (
     StartTrainingRoundResponse,
     State,
 )
-from xain_proto.np import ndarray_to_proto, proto_to_ndarray
 
 from xain_fl.coordinator.metrics_store import (
     AbstractMetricsStore,
@@ -33,8 +32,6 @@ from xain_fl.coordinator.round import Round
 from xain_fl.coordinator.store import (
     AbstractGlobalWeightsWriter,
     AbstractLocalWeightsReader,
-    NullObjectGlobalWeightsWriter,
-    NullObjectLocalWeightsReader,
 )
 from xain_fl.fl.coordinator.aggregate import Aggregator, WeightedAverageAggregator
 from xain_fl.fl.coordinator.controller import Controller, RandomController
@@ -112,9 +109,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
+        global_weights_writer,
+        local_weights_reader,
         metrics_store: AbstractMetricsStore = NullObjectMetricsStore(),
-        global_weights_writer: AbstractGlobalWeightsWriter = NullObjectGlobalWeightsWriter(),
-        local_weights_reader: AbstractLocalWeightsReader = NullObjectLocalWeightsReader(),
         num_rounds: int = 1,
         minimum_participants_in_round: int = 1,
         fraction_of_participants: float = 1.0,
@@ -403,9 +400,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             epoch_base=self.epoch_base,
         )
         return StartTrainingRoundResponse(
-            weights=ndarray_to_proto(self.weights),
-            epochs=self.epochs_current_round,
-            epoch_base=self.epoch_base,
+            epochs=self.epochs_current_round, epoch_base=self.epoch_base,
         )
 
     def _handle_end_training_round(
@@ -425,8 +420,22 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         # submitting the updates and raise an exception if it is the wrong
         # round.
 
-        # record the request data
-        model_weights: ndarray = proto_to_ndarray(message.weights)
+        # HACK: Participants are currently not aware of they ID the
+        # coordinator uses to identify them, so they generate a UUID
+        # and use it to upload their results. The EndTrainingMessage
+        # contains that UUID, so that the coordinator can retrieve the
+        # weights.
+        #
+        # FIXME(PB-436): handle the case where the participant didn't
+        # send a participant ID, or sent an invalid one. Reading from
+        # storage will fail in that case, and we hshould gracefully
+        # handle this by removing the participant.
+        fake_participant_id: str = message.participant_id
+        logger.debug("downloading results", participant_id=participant_id)
+        model_weights: ndarray = self.local_weights_reader.read_weights(
+            fake_participant_id, self.current_round
+        )
+        logger.debug("done downloading results", participant_id=participant_id)
         number_samples: int = message.number_samples
         self.round.add_updates(
             participant_id=participant_id,
@@ -442,12 +451,6 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 "Can not write metrics", participant_id=participant_id, error=repr(err)
             )
 
-        # FIXME(XP-515): For now, `read_weights()` doesn't do
-        # anything, we actually get the participants weights through
-        # self.round.add_updates(). Ultimatly, the weights will be
-        # read from S3.
-        _ = self.local_weights_reader.read_weights(participant_id, self.current_round)
-
         # The round is over. Run the aggregation
         if self.round.is_finished():
             logger.info(
@@ -461,7 +464,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 multiple_model_weights=multiple_model_weights,
                 aggregation_data=aggregation_data,
             )
-            self.global_weights_writer.write_weights(self.current_round, self.weights)
+            self.global_weights_writer.write_weights(
+                self.current_round + 1, self.weights
+            )
 
             # update the round or finish the training session
             if self.current_round >= self.num_rounds - 1:

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -431,7 +431,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         #
         # FIXME(PB-436): handle the case where the participant didn't
         # send a participant ID, or sent an invalid one. Reading from
-        # storage will fail in that case, and we hshould gracefully
+        # storage will fail in that case, and we should gracefully
         # handle this by removing the participant.
         fake_participant_id: str = message.participant_id
         logger.debug("downloading results", participant_id=participant_id)

--- a/xain_fl/coordinator/store.py
+++ b/xain_fl/coordinator/store.py
@@ -49,37 +49,6 @@ class AbstractLocalWeightsReader(abc.ABC):
         """
 
 
-class NullObjectGlobalWeightsWriter(AbstractGlobalWeightsWriter):
-    # pylint: disable=too-few-public-methods
-    """An implementation of ``AbstractGlobalWeightsWriter`` that does
-    nothing.
-
-    """
-
-    def write_weights(self, round: int, weights: ndarray) -> None:
-        """A dummy method that has no effect.
-
-        Args:
-            round: A round number the weights correspond to. Not used.
-            weights: The weights to store. Not used.
-        """
-
-
-class NullObjectLocalWeightsReader(AbstractLocalWeightsReader):
-    # pylint: disable=too-few-public-methods
-    """An implementation of ``AbstractLocalWeightsReader`` that does
-    nothing.
-    """
-
-    def read_weights(self, participant_id: str, round: int) -> ndarray:
-        """A dummy method that has no effect.
-
-        Args:
-            participant_id: ID of the participant's weights. Not used.
-            round: A round number the weights correspond to. Not used.
-        """
-
-
 class S3BaseClass:
     # pylint: disable=too-few-public-methods
     """A base class for implementating AWS S3 clients.
@@ -116,8 +85,8 @@ class S3GlobalWeightsWriter(AbstractGlobalWeightsWriter, S3BaseClass):
             round: A round number the weights correspond to.
             weights: The weights to store.
         """
-        bucket = self.s3.Bucket(self.config.global_weights_bucket)
-        bucket.put_object(Body=pickle.dumps(weights), Key=str(round))
+        bucket = self.s3.Bucket(self.config.bucket)
+        bucket.put_object(Body=pickle.dumps(weights), Key=f"{round}/global")
 
 
 class S3LocalWeightsReader(AbstractLocalWeightsReader, S3BaseClass):
@@ -140,9 +109,9 @@ class S3LocalWeightsReader(AbstractLocalWeightsReader, S3BaseClass):
         Return:
             The weights read from the S3 bucket.
         """
-        bucket = self.s3.Bucket(self.config.participants_bucket)
+        bucket = self.s3.Bucket(self.config.bucket)
         data = BytesIO()
-        bucket.download_fileobj(f"{participant_id}/{round}", data)
+        bucket.download_fileobj(f"{round}/{participant_id}", data)
         # FIXME: not sure whether getvalue() copies the data. If so we
         # should probably prefer getbuffer() instead.
         return pickle.loads(data.getvalue())


### PR DESCRIPTION
## References:

https://xainag.atlassian.net/browse/PB-159

Needs to be merged along with:

- https://github.com/xainag/xain-proto/pull/25
- https://github.com/xainag/xain-sdk/pull/88
- https://github.com/xainag/xain-fl/pull/298

## Summary:

Remove the weights from the gRPC messages. From now on, weights will
be exchanged via s3 buckets.

The sequence diagram below illustrate this new behavior.

At the beginning of a round (1) the selected participants send a
`StartTrainingRound` request, and the coordinator response with the
same `StartTrainingRoundResponse` that does not contain the global
weights anymore.

Instead, the participant fetches these weights from the store (2). S3
buckets are key-value stores, and the key for global weights is the
round number.

Then, the participant trains. Once done, it uploads its local weights
to the S3 bucket (3). The key is `<round_number>/<participant_id>`.

Finally (4), the participant sends it's `EndTrainingRequest`. Before
answering, the coordinator retrieves the local weights the participant
has uploaded.

_**Important note**: At the moment, the participants don't know their
ID, because the coordinator does not send it to them. Thus, they
currently generate a random ID when they start, and send it to the
coordinator so that it can retrieve the participant's weights. This is
why the `EndTrainingRoundRequest` currently has a `participant_id`
field._

```
    P                                C                      Store
1.  |   StartTrainingRoundRequest    |                        |
    | -----------------------------> |                        |
    |   StartTrainingRoundResponse   |                        |
    | <----------------------------- |                        |
    |                                |                        |
    |                Get global weights (key="round/global")  |
2.  | ------------------------------------------------------> |
    |                         Global weights                  |
    | <------------------------------------------------------ |
    |                                |                        |
    | [train...]                     |                        |
    |                                |                        |
3.  |       Set local weights (key="round/participant")       |
    | ------------------------------------------------------> |
    |                               Ok                        |
    | <------------------------------------------------------ |
    |                                |                        |
4.  |   EndTrainingRoundRequest      |                        |
    | -----------------------------> | Get local weights (key="round/participant")
    |                                | ---------------------> |
    |                                | Local weights          |
    |  EndTrainingRoundResponse      | <--------------------> |
    | <----------------------------- |                        |
```

At the end of the round, the coordinator writes the weights to the s3
bucket, using the next upcoming round number as key (see the sequence
diagram below).

```
P                                C                      Store
|   EndTrainingRoundRequest      |                        |
| -----------------------------> | Get local weights (key="round/participant")
|                                | ---------------------> |
|                                | Local weights          |
|  EndTrainingRoundResponse      | <--------------------> |
| <----------------------------- |                        |
|                                |                        |
|                                | Set global weights (key="round+1/participant")
|                                | ---------------------> |
|                                | Ok                     |
|                                | <--------------------> |
```

Implementation notes:

- Initially, we thought we would be using different buckets for the
  local and global weights. But for now, we use the same bucket for
  local and global weights for now

- We currently store the global weights under different keys. It turns
  out that this brings un-necessary complexity so we'll probably
  simplify this in the future

- For now, the coordinator doesn't send any storage information to the
  participants. Thus, the participants need to be configured with the
  storage information. In the future, the `StartTrainingRoundResponse`
  could contain the endpoint url, bucket name, etc.


---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
