### PR TITLE
PB-431 send participant state to influxdb

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,13 +24,13 @@ def json_participant_metrics_sample():
         [
             {
                 "measurement": "participant",
-                "time": 1234326435,
+                "time": 1582017483 * 1_000_000_000,
                 "tags": {"id": "127.0.0.1:1345"},
                 "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},
             },
             {
                 "measurement": "participant",
-                "time": 3542626236,
+                "time": 1582017484 * 1_000_000_000,
                 "tags": {"id": "127.0.0.1:1345"},
                 "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from .port_forwarding import ConnectionManager
 
 
 @pytest.fixture()
-def participant_metrics_sample():
+def json_participant_metrics_sample():
     """Return a valid participant metric object."""
     return json.dumps(
         [

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -349,7 +349,7 @@ def test_start_training_round_failed_precondition(  # pylint: disable=unused-arg
 
 
 @pytest.mark.integration
-def test_end_training_round(coordinator_service, participant_metrics_sample):
+def test_end_training_round(coordinator_service, json_participant_metrics_sample):
     """[summary]
 
     .. todo:: Advance docstrings (https://xainag.atlassian.net/browse/XP-425)
@@ -369,7 +369,7 @@ def test_end_training_round(coordinator_service, participant_metrics_sample):
         rendezvous(channel)
         # call EndTrainingRound service method on coordinator
         end_training_round(
-            channel, test_weights, number_samples, participant_metrics_sample
+            channel, test_weights, number_samples, json_participant_metrics_sample
         )
     # check local model received...
 

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from influxdb import InfluxDBClient
 import pytest
+from xain_proto.fl.coordinator_pb2 import State
 
 from xain_fl.config import MetricsConfig
 from xain_fl.coordinator.metrics_store import MetricsStore, MetricsStoreError
@@ -29,101 +30,168 @@ def invalid_json_participant_metrics_sample():
     )
 
 
+@pytest.fixture()
+def participant_metrics_sample():
+    """Return a valid metric object."""
+    return {"state": State.FINISHED}
+
+
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_valid_participant_metrics(
-    write_points_mock, participant_metrics_sample,
+def test_write_received_participant_metrics(
+    write_points_mock, json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that write_points does not raise an exception on a valid metric object."""
+    """Test test_write_received_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_participant_metrics(participant_metrics_sample)
+    metric_store.write_received_participant_metrics(json_participant_metrics_sample)
     write_points_mock.assert_called_once()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
-def test_write_points_exception_handling_write_participant_metrics(
-    write_points_mock, participant_metrics_sample,
+def test_write_received_participant_metrics_write_points_exception(
+    write_points_mock, json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the
-    write_participant_metrics method."""
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_received_participant_metrics method."""
 
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(participant_metrics_sample)
+        metric_store.write_received_participant_metrics(json_participant_metrics_sample)
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_invalid_json_exception_handling(write_points_mock):
-    """Check that raised exceptions of the write_points method are caught in the
-    write_participant_metrics method."""
+def test_write_received_participant_metrics_invalid_json_exception(write_points_mock):
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_received_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics('{"a": 1')
+        metric_store.write_received_participant_metrics('{"a": 1')
     write_points_mock.assert_not_called()
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics("{1: 1}")
+        metric_store.write_received_participant_metrics("{1: 1}")
     write_points_mock.assert_not_called()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_empty_metrics_exception_handling(
+def test_write_received_participant_metrics_empty_metrics_exception(
     write_points_mock, empty_json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the
-    write_participant_metrics method."""
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_received_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(empty_json_participant_metrics_sample)
+        metric_store.write_received_participant_metrics(
+            empty_json_participant_metrics_sample
+        )
     write_points_mock.assert_not_called()
 
 
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_invalid_schema_exception_handling(
+def test_write_received_participant_metrics_invalid_schema_exception(
     write_points_mock, invalid_json_participant_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the
-    write_participant_metrics method."""
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_received_participant_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(invalid_json_participant_metrics_sample)
+        metric_store.write_received_participant_metrics(
+            invalid_json_participant_metrics_sample
+        )
     write_points_mock.assert_not_called()
 
 
+@mock.patch("xain_fl.coordinator.metrics_store.time.time", return_value=1582017483.0)
 @mock.patch.object(InfluxDBClient, "write_points", return_value=True)
-def test_valid_coordinator_metrics(
-    write_points_mock, coordinator_metrics_sample,
+def test_write_coordinator_metrics(
+    write_points_mock, time_mock, coordinator_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that write_points does not raise an exception on a valid metric object."""
+    """Test write_coordinator_metrics method."""
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_coordinator_metrics(coordinator_metrics_sample, tags={"1": "2"})
-    write_points_mock.assert_called_once()
+    metric_store.write_coordinator_metrics(
+        coordinator_metrics_sample, tags={"meta_data": "1"}
+    )
+
+    write_points_mock.assert_called_with(
+        [
+            {
+                "measurement": "coordinator",
+                "time": 1582017483 * 1_000_000_000,
+                "tags": {"meta_data": "1"},
+                "fields": {
+                    "state": State.ROUND,
+                    "round": 2,
+                    "number_of_selected_participants": 0,
+                },
+            }
+        ]
+    )
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
-def test_write_points_exception_handling_write_coordinator_metrics(
+def test_write_coordinator_metrics_write_points_exception(
     write_points_mock, coordinator_metrics_sample,
 ):  # pylint: disable=redefined-outer-name,unused-argument
-    """Check that raised exceptions of the write_points method are caught in the
-    write_coordinator_metrics method."""
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_coordinator_metrics method."""
 
     metric_store = MetricsStore(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
         metric_store.write_coordinator_metrics(coordinator_metrics_sample)
+
+
+@mock.patch("xain_fl.coordinator.metrics_store.time.time", return_value=1582017483.0)
+@mock.patch.object(InfluxDBClient, "write_points", return_value=True)
+def test_write_participant_metrics(
+    write_points_mock, time_mock, participant_metrics_sample,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """Test write_participant_metrics method."""
+    metric_store = MetricsStore(
+        MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
+    )
+
+    metric_store.write_participant_metrics(
+        participant_metrics_sample, tags={"id": "1234-1234-1234"}
+    )
+
+    write_points_mock.assert_called_with(
+        [
+            {
+                "measurement": "participant",
+                "time": 1582017483 * 1_000_000_000,
+                "tags": {"id": "1234-1234-1234"},
+                "fields": {"state": State.FINISHED,},
+            }
+        ]
+    )
+
+
+@mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())
+def test_write_participant_metrics_write_points_exception(
+    write_points_mock, participant_metrics_sample,
+):  # pylint: disable=redefined-outer-name,unused-argument
+    """Check that raised exceptions of the write_points method are re-raised as MetricsStoreError in
+    the write_participant_metrics method."""
+
+    metric_store = MetricsStore(
+        MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
+    )
+    with pytest.raises(MetricsStoreError):
+        metric_store.write_participant_metrics(participant_metrics_sample)

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -46,7 +46,22 @@ def test_write_received_participant_metrics(
     )
 
     metric_store.write_received_participant_metrics(json_participant_metrics_sample)
-    write_points_mock.assert_called_once()
+    write_points_mock.assert_called_with(
+        [
+            {
+                "measurement": "participant",
+                "time": 1582017483 * 1_000_000_000,
+                "tags": {"id": "127.0.0.1:1345"},
+                "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},
+            },
+            {
+                "measurement": "participant",
+                "time": 1582017484 * 1_000_000_000,
+                "tags": {"id": "127.0.0.1:1345"},
+                "fields": {"CPU_1": 90.8, "CPU_2": 90, "CPU_3": "23", "CPU_4": 0.00,},
+            },
+        ]
+    )
 
 
 @mock.patch.object(InfluxDBClient, "write_points", side_effect=Exception())

--- a/tests/test_metric_store.py
+++ b/tests/test_metric_store.py
@@ -138,8 +138,8 @@ def test_write_coordinator_metrics(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_coordinator_metrics(
-        coordinator_metrics_sample, tags={"meta_data": "1"}
+    metric_store.write_metrics(
+        "coordinator", coordinator_metrics_sample, tags={"meta_data": "1"}
     )
 
     write_points_mock.assert_called_with(
@@ -169,7 +169,7 @@ def test_write_coordinator_metrics_write_points_exception(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_coordinator_metrics(coordinator_metrics_sample)
+        metric_store.write_metrics("coordinator", coordinator_metrics_sample)
 
 
 @mock.patch("xain_fl.coordinator.metrics_store.time.time", return_value=1582017483.0)
@@ -182,8 +182,8 @@ def test_write_participant_metrics(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
 
-    metric_store.write_participant_metrics(
-        participant_metrics_sample, tags={"id": "1234-1234-1234"}
+    metric_store.write_metrics(
+        "participant", participant_metrics_sample, tags={"id": "1234-1234-1234"}
     )
 
     write_points_mock.assert_called_with(
@@ -209,4 +209,4 @@ def test_write_participant_metrics_write_points_exception(
         MetricsConfig(enable=True, host="", port=1, user="", password="", db_name="")
     )
     with pytest.raises(MetricsStoreError):
-        metric_store.write_participant_metrics(participant_metrics_sample)
+        metric_store.write_metrics("participant", participant_metrics_sample)

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -149,12 +149,13 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         self.current_round: int = 0
         self.epochs_current_round: int = epochs
 
-        self._write_coordinator_metrics_fail_silently(
+        self._write_metrics_fail_silently(
+            "coordinator",
             {
                 "state": self.state,
                 "round": self.current_round,
                 "number_of_selected_participants": self.participants.len(),
-            }
+            },
         )
 
     def get_minimum_connected_participants(self) -> int:
@@ -244,13 +245,13 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
         if self.participants.len() < self.minimum_connected_participants:
             self.state = State.STANDBY
-            self._write_coordinator_metrics_fail_silently({"state": self.state})
+            self._write_metrics_fail_silently("coordinator", {"state": self.state})
 
-        self._write_participant_metrics_fail_silently(
-            {"state": State.FINISHED}, tags={"id": participant_id}
+        self._write_metrics_fail_silently(
+            "participant", {"state": State.FINISHED}, tags={"id": participant_id}
         )
-        self._write_coordinator_metrics_fail_silently(
-            {"number_of_selected_participants": self.participants.len()}
+        self._write_metrics_fail_silently(
+            "coordinator", {"number_of_selected_participants": self.participants.len()}
         )
 
     def select_participant_ids_and_init_round(self) -> None:
@@ -296,8 +297,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                 participant_id=participant_id,
                 current_participants_count=self.participants.len(),
             )
-            self._write_coordinator_metrics_fail_silently(
-                {"number_of_selected_participants": self.participants.len()}
+            self._write_metrics_fail_silently(
+                "coordinator",
+                {"number_of_selected_participants": self.participants.len()},
             )
 
             # Select participants and change the state to ROUND if the latest added participant
@@ -309,7 +311,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
                     self.round.add_selected(ids)
 
                 self.state = State.ROUND
-                self._write_coordinator_metrics_fail_silently({"state": self.state})
+                self._write_metrics_fail_silently("coordinator", {"state": self.state})
         else:
             reply = RendezvousReply.LATER
             logger.info(
@@ -341,7 +343,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             The response to the participant.
         """
 
-        self._write_participant_metrics_fail_silently(
+        self._write_metrics_fail_silently(
+            "participant",
             {"state": message.state, "round": message.round},
             tags={"id": participant_id},
         )
@@ -360,8 +363,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             round=self.current_round,
             current_participants_count=self.participants.len(),
         )
-        self._write_coordinator_metrics_fail_silently(
-            {"number_of_selected_participants": self.participants.len()}
+        self._write_metrics_fail_silently(
+            "coordinator", {"number_of_selected_participants": self.participants.len()}
         )
         # send heartbeat response advertising the current state
         return HeartbeatResponse(state=state, round=self.current_round)
@@ -464,12 +467,12 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             if self.current_round >= self.num_rounds - 1:
                 logger.info("Last round over", round=self.current_round)
                 self.state = State.FINISHED
-                self._write_coordinator_metrics_fail_silently({"state": self.state})
+                self._write_metrics_fail_silently("coordinator", {"state": self.state})
             else:
                 self.current_round += 1
                 self.epoch_base += self.epochs_current_round
-                self._write_coordinator_metrics_fail_silently(
-                    {"round": self.current_round}
+                self._write_metrics_fail_silently(
+                    "coordinator", {"round": self.current_round}
                 )
                 # reinitialize the round
                 self.select_participant_ids_and_init_round()
@@ -477,14 +480,15 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         logger.debug("Send EndTrainingRoundResponse", participant_id=participant_id)
         return EndTrainingRoundResponse()
 
-    def _write_coordinator_metrics_fail_silently(
+    def _write_metrics_fail_silently(
         self,
+        owner: str,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
         """
         Write the metrics to a metric store that are collected on the coordinator site and owned by
-        the coordinator.
+        the given owner.
         If an exception is raised, it will be caught and the error logged.
 
         FIXME: Helper function to make sure that the coordinator does not crash due to exception of
@@ -492,38 +496,15 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
 
         Args:
 
+            owner: The name of the owner of the metrics e.g. coordinator or participant.
             metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
         """
 
         try:
-            self.metrics_store.write_coordinator_metrics(metrics, tags)
+            self.metrics_store.write_metrics(owner, metrics, tags)
         except MetricsStoreError as err:
-            logger.warn("Can not write coordinator metrics", error=repr(err))
-
-    def _write_participant_metrics_fail_silently(
-        self,
-        metrics: Dict[str, Union[str, int, float]],
-        tags: Optional[Dict[str, str]] = None,
-    ) -> None:
-        """
-        Write the metrics to a metric store that are collected on the coordinator site and owned by
-        a participant.
-        If an exception is raised, it will be caught and the error logged.
-
-        FIXME: Helper function to make sure that the coordinator does not crash due to exception of
-        the metric store. Proper exception handling should be tackled in PB-125.
-
-        Args:
-
-            metrics: A dictionary with the metric names as keys and the metric values as values.
-            tags: A dictionary to append optional metadata to the metric. Defaults to None.
-        """
-
-        try:
-            self.metrics_store.write_participant_metrics(metrics, tags)
-        except MetricsStoreError as err:
-            logger.warn("Can not write participant metrics", error=repr(err))
+            logger.warn("Can not write metrics", error=repr(err), owner=owner)
 
 
 def pb_enum_to_str(pb_enum: EnumDescriptor, member_value: int) -> str:

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -247,7 +247,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             self._write_coordinator_metrics_fail_silently({"state": self.state})
 
         self._write_participant_metrics_fail_silently(
-            {"participant_state": State.FINISHED}, tags={"id": participant_id}
+            {"state": State.FINISHED}, tags={"id": participant_id}
         )
         self._write_coordinator_metrics_fail_silently(
             {"number_of_selected_participants": self.participants.len()}
@@ -342,7 +342,8 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         """
 
         self._write_participant_metrics_fail_silently(
-            {"participant_state": message.state}, tags={"id": participant_id}
+            {"state": message.state, "round": message.round},
+            tags={"id": participant_id},
         )
 
         self.participants.update_expires(participant_id)

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -247,6 +247,9 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             self._write_metrics_fail_silently({"state": self.state})
 
         self._write_metrics_fail_silently(
+            {"participant_state": State.FINISHED}, tags={"id": participant_id}
+        )
+        self._write_metrics_fail_silently(
             {"number_of_selected_participants": self.participants.len()}
         )
 
@@ -321,7 +324,7 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         return RendezvousResponse(reply=reply)
 
     def _handle_heartbeat(
-        self, _message: HeartbeatRequest, participant_id: str
+        self, message: HeartbeatRequest, participant_id: str
     ) -> HeartbeatResponse:
         """Handles a Heartbeat request.
 
@@ -331,12 +334,16 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
             - ``STANDBY``: if the participant is not selected for the current round.
 
         Args:
-            _message: The request to handle. Currently not used.
+            message: The request to handle. Currently not used.
             participant_id: The id of the participant making the request.
 
         Returns:
             The response to the participant.
         """
+
+        self._write_metrics_fail_silently(
+            {"participant_state": message.state}, tags={"id": participant_id}
+        )
 
         self.participants.update_expires(participant_id)
 

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 import json
 from json import JSONDecodeError
 import time
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from influxdb import InfluxDBClient
 from jsonschema import ValidationError, validate
@@ -244,15 +244,15 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             "fields": metrics,
         }
 
-        self._write_metrics(influx_data_point)
+        self._write_metrics([influx_data_point])
 
-    def _write_metrics(self, influx_point: dict) -> None:
+    def _write_metrics(self, influx_points: List[dict]) -> None:
         """
         Write the metrics to InfluxDB that are collected on the coordinator site.
 
         Args:
 
-            influx_point: A InfluxDB data point.
+            influx_points: InfluxDB data points.
 
         Raises:
 
@@ -260,7 +260,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
         """
 
         try:
-            self.influx_client.write_points([influx_point])
+            self.influx_client.write_points(influx_points)
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", error=repr(err))
             raise MetricsStoreError("Can not write metrics.") from err

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -34,43 +34,20 @@ class AbstractMetricsStore(ABC):
         """
 
     @abstractmethod
-    def write_coordinator_metrics(
+    def write_metrics(
         self,
+        owner: str,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
         """
-        Write the metrics to a metric store that are collected on the coordinator site and owned by
-        the coordinator.
+        Write metrics into a metric store.
 
         Args:
 
+            owner: The name of the owner of the metrics e.g. coordinator or participant.
             metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
-
-        Raises:
-
-            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
-        """
-
-    @abstractmethod
-    def write_participant_metrics(
-        self,
-        metrics: Dict[str, Union[str, int, float]],
-        tags: Optional[Dict[str, str]] = None,
-    ) -> None:
-        """
-        Write the metrics to a metric store that are collected on the coordinator site and owned by
-        a participant.
-
-        Args:
-
-            metrics: A dictionary with the metric names as keys and the metric values as values.
-            tags: A dictionary to append optional metadata to the metric. Defaults to None.
-
-        Raises:
-
-            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
         """
 
 
@@ -86,8 +63,9 @@ class NullObjectMetricsStore(AbstractMetricsStore):
             metrics_as_json: The metrics of a specific participant.
         """
 
-    def write_coordinator_metrics(
+    def write_metrics(
         self,
+        owner: str,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
@@ -96,26 +74,13 @@ class NullObjectMetricsStore(AbstractMetricsStore):
 
         Args:
 
-            metrics: A dictionary with the metric names as keys and the metric values as values.
-            tags: A dictionary to append optional metadata to the metric. Defaults to None.
-        """
-
-    def write_participant_metrics(
-        self,
-        metrics: Dict[str, Union[str, int, float]],
-        tags: Optional[Dict[str, str]] = None,
-    ) -> None:
-        """
-        A method that has no effect.
-
-        Args:
-
+            owner: The name of the owner of the metrics e.g. coordinator or participant.
             metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
         """
 
 
-class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-methods
+class MetricsStore(AbstractMetricsStore):
     """A metric store that uses InfluxDB to store the metrics."""
 
     def __init__(self, config: MetricsConfig):
@@ -172,50 +137,9 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
         else:
             self._write_metrics(metrics)
 
-    def write_participant_metrics(
-        self,
-        metrics: Dict[str, Union[str, int, float]],
-        tags: Optional[Dict[str, str]] = None,
-    ) -> None:
-        """
-        Write the metrics to InfluxDB that are collected on the coordinator site and owned by a
-        participant.
-
-        Args:
-
-            metrics: A dictionary with the metric names as keys and the metric values as values.
-            tags: A dictionary to append optional metadata to the metric. Defaults to None.
-
-        Raises:
-
-            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
-        """
-        self.write_metrics("participant", metrics, tags)
-
-    def write_coordinator_metrics(
-        self,
-        metrics: Dict[str, Union[str, int, float]],
-        tags: Optional[Dict[str, str]] = None,
-    ) -> None:
-        """
-        Write the metrics to InfluxDB that are collected on the coordinator site and owned by the
-        coordinator.
-
-        Args:
-
-            metrics: A dictionary with the metric names as keys and the metric values as values.
-            tags: A dictionary to append optional metadata to the metric. Defaults to None.
-
-        Raises:
-
-            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
-        """
-
-        self.write_metrics("coordinator", metrics, tags)
-
     def write_metrics(
         self,
-        measurement: str,
+        owner: str,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
@@ -224,7 +148,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
         Args:
 
-            measurement: The name of the measurement.
+            owner: The name of the owner of the metrics e.g. coordinator or participant.
             metrics: A dictionary with the metric names as keys and the metric values as values.
             tags: A dictionary to append optional metadata to the metric. Defaults to None.
 
@@ -238,7 +162,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
         current_time: int = int(time.time() * 1_000_000_000)
         influx_data_point = {
-            "measurement": measurement,
+            "measurement": owner,
             "time": current_time,
             "tags": tags,
             "fields": metrics,

--- a/xain_fl/coordinator/metrics_store.py
+++ b/xain_fl/coordinator/metrics_store.py
@@ -2,11 +2,12 @@
 
 from abc import ABC, abstractmethod
 import json
+from json import JSONDecodeError
 import time
 from typing import Dict, Optional, Union
 
 from influxdb import InfluxDBClient
-from jsonschema import validate
+from jsonschema import ValidationError, validate
 from structlog import get_logger
 
 from xain_fl.config import MetricsConfig
@@ -15,11 +16,11 @@ from xain_fl.logger import StructLogger
 logger: StructLogger = get_logger(__name__)
 
 
-class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
+class AbstractMetricsStore(ABC):
     """An abstract metric store."""
 
     @abstractmethod
-    def write_participant_metrics(self, metrics_as_json: str) -> None:
+    def write_received_participant_metrics(self, metrics_as_json: str) -> None:
         """
         Write the participant metrics on behalf of the participant into a metric store.
 
@@ -39,7 +40,28 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
         """
-        Write the metrics to a metric store that are collected on the coordinator site.
+        Write the metrics to a metric store that are collected on the coordinator site and owned by
+        the coordinator.
+
+        Args:
+
+            metrics: A dictionary with the metric names as keys and the metric values as values.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
+
+    @abstractmethod
+    def write_participant_metrics(
+        self,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Write the metrics to a metric store that are collected on the coordinator site and owned by
+        a participant.
 
         Args:
 
@@ -52,12 +74,10 @@ class AbstractMetricsStore(ABC):  # pylint: disable=too-few-public-methods
         """
 
 
-class NullObjectMetricsStore(
-    AbstractMetricsStore
-):  # pylint: disable=too-few-public-methods
+class NullObjectMetricsStore(AbstractMetricsStore):
     """A metric store that does nothing."""
 
-    def write_participant_metrics(self, metrics_as_json: str) -> None:
+    def write_received_participant_metrics(self, metrics_as_json: str) -> None:
         """
         A method that has no effect.
 
@@ -67,6 +87,20 @@ class NullObjectMetricsStore(
         """
 
     def write_coordinator_metrics(
+        self,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        A method that has no effect.
+
+        Args:
+
+            metrics: A dictionary with the metric names as keys and the metric values as values.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+        """
+
+    def write_participant_metrics(
         self,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
@@ -116,7 +150,7 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
             "minItems": 1,
         }
 
-    def write_participant_metrics(self, metrics_as_json: str) -> None:
+    def write_received_participant_metrics(self, metrics_as_json: str) -> None:
         """
         Write the participant metrics on behalf of the participant into InfluxDB.
 
@@ -132,18 +166,20 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
         try:
             metrics = json.loads(metrics_as_json)
             validate(instance=metrics, schema=self.schema)
-            self.influx_client.write_points(metrics)
-        except Exception as err:  # pylint: disable=broad-except
+        except (ValidationError, JSONDecodeError) as err:
             logger.error("Exception", error=repr(err))
             raise MetricsStoreError("Can not write participant metrics.") from err
+        else:
+            self._write_metrics(metrics)
 
-    def write_coordinator_metrics(
+    def write_participant_metrics(
         self,
         metrics: Dict[str, Union[str, int, float]],
         tags: Optional[Dict[str, str]] = None,
     ) -> None:
         """
-        Write the metrics to InfluxDB that are collected on the coordinator site.
+        Write the metrics to InfluxDB that are collected on the coordinator site and owned by a
+        participant.
 
         Args:
 
@@ -154,22 +190,80 @@ class MetricsStore(AbstractMetricsStore):  # pylint: disable=too-few-public-meth
 
             MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
         """
+        self.write_metrics("participant", metrics, tags)
+
+    def write_coordinator_metrics(
+        self,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Write the metrics to InfluxDB that are collected on the coordinator site and owned by the
+        coordinator.
+
+        Args:
+
+            metrics: A dictionary with the metric names as keys and the metric values as values.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
+
+        self.write_metrics("coordinator", metrics, tags)
+
+    def write_metrics(
+        self,
+        measurement: str,
+        metrics: Dict[str, Union[str, int, float]],
+        tags: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """
+        Write the metrics to InfluxDB that are collected on the coordinator site.
+
+        Args:
+
+            measurement: The name of the measurement.
+            metrics: A dictionary with the metric names as keys and the metric values as values.
+            tags: A dictionary to append optional metadata to the metric. Defaults to None.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
+
         if not tags:
             tags = {}
 
         current_time: int = int(time.time() * 1_000_000_000)
-        influx_point = {
-            "measurement": "coordinator",
+        influx_data_point = {
+            "measurement": measurement,
             "time": current_time,
             "tags": tags,
             "fields": metrics,
         }
 
+        self._write_metrics(influx_data_point)
+
+    def _write_metrics(self, influx_point: dict) -> None:
+        """
+        Write the metrics to InfluxDB that are collected on the coordinator site.
+
+        Args:
+
+            influx_point: A InfluxDB data point.
+
+        Raises:
+
+            MetricsStoreError: If the writing of the metrics to InfluxDB has failed.
+        """
+
         try:
             self.influx_client.write_points([influx_point])
         except Exception as err:  # pylint: disable=broad-except
             logger.error("Exception", error=repr(err))
-            raise MetricsStoreError("Can not write coordinator metrics.") from err
+            raise MetricsStoreError("Can not write metrics.") from err
 
 
 class MetricsStoreError(Exception):


### PR DESCRIPTION
### References

[PB-431](https://xainag.atlassian.net/browse/PB-431)

### Summary

* added a `write_participant_metrics` method (the method can be used to write participant metrics that are collected on the coordinator site (round, state) into influxdb 
* updated/added tests

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
