### PR TITLE
PB-159: update xain-{proto,sdk} dependencies to the right branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ install_requires = [
     "numpy==1.15",  # BSD
     "grpcio==1.23",  # Apache License 2.0
     "structlog==19.2.0",  # Apache License 2.0
-    "xain-proto @ git+https://github.com/xainag/xain-proto.git@PB-159-use-s3-for-transfering-weights#egg=xain_proto-0.6.0&subdirectory=python",  # Apache License 2.0
+    "xain-proto @ git+https://github.com/xainag/xain-proto.git@development#egg=xain_proto-0.6.0&subdirectory=python",  # Apache License 2.0
     "boto3==1.10.48",  # Apache License 2.0
     "toml==0.10.0",  # MIT
     "schema~=0.7",  # MIT
@@ -53,7 +53,7 @@ tests_require = [
     "pytest-cov==2.8.1",  # MIT
     "pytest-watch==4.2.0",  # MIT
     "pytest-mock==2.0.0",  # MIT
-    "xain-sdk@ git+https://github.com/xainag/xain-sdk.git@PB-159-use-s3-for-transfering-weights#egg=xain_sdk-0.6.0",  # Apache License 2.0
+    "xain-sdk@ git+https://github.com/xainag/xain-sdk.git@development#egg=xain_sdk-0.6.0",  # Apache License 2.0
 ]
 
 docs_require = [

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -265,7 +265,8 @@ def test_message_loop(mock_heartbeat_request, _mock_sleep, _mock_event):
     message_loop(channel, state_record, terminate_event)
 
     # check that the heartbeat is sent exactly twice
-    mock_heartbeat_request.assert_has_calls([mock.call(), mock.call()])
+    expected_call = mock.call(round=-1, state=State.READY)
+    mock_heartbeat_request.assert_has_calls([expected_call, expected_call])
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### References

https://xainag.atlassian.net/browse/PB-159

### Summary

Follow-up of https://github.com/xainag/xain-fl/pull/298

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
