### PR TITLE
PB-439 Make thread pool workers configurable

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -7,6 +7,8 @@
 host = "localhost"
 # (Optional) Port to listen on for incoming gRPC connections
 port = 50051
+# (Optional) The maximum number of gRPC thread pool workers
+thread_pool_workers = 10
 
 # (Optional)
 [server.grpc_options]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,7 @@ def server_sample():
             "grpc.max_receive_message_length": -1,
             "grpc.max_send_message_length": -1,
         },
+        "thread_pool_workers": 11,
     }
 
 
@@ -122,11 +123,11 @@ def test_load_valid_config(config_sample):  # pylint: disable=redefined-outer-na
 
     assert config.server.host == "localhost"
     assert config.server.port == 50051
-
     assert config.server.grpc_options == [
         ("grpc.max_receive_message_length", -1),
         ("grpc.max_send_message_length", -1),
     ]
+    assert config.server.thread_pool_workers == 11
 
     assert config.ai.rounds == 1
     assert config.ai.epochs == 1

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -179,6 +179,9 @@ SERVER_SCHEMA = Schema(
             lambda opt: list(opt.items()),
             error=error("server.grpc_options", "valid gRPC options"),
         ),
+        Optional("thread_pool_workers", default=10): positive_integer(
+            "server.thread_pool_workers"
+        ),
     }
 )
 

--- a/xain_fl/serve.py
+++ b/xain_fl/serve.py
@@ -31,7 +31,8 @@ def serve(coordinator: Coordinator, server_config: ServerConfig) -> None:
 
     """
     server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=10), options=server_config.grpc_options
+        futures.ThreadPoolExecutor(max_workers=server_config.thread_pool_workers),
+        options=server_config.grpc_options,
     )
     coordinator_pb2_grpc.add_CoordinatorServicer_to_server(
         CoordinatorGrpc(coordinator), server


### PR DESCRIPTION
### References

[PB-439](https://xainag.atlassian.net/browse/PB-439)

### Summary

* made thread pool workers configurable

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [ ] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [ ] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [ ] Linked the ticket in the merge request title or the references section.
- [ ] Added an informative merge request summary.

**Code checklist**

- [ ] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [ ] Passed scope checks.
- [ ] Added or updated tests if needed.
- [ ] Added or updated code documentation if needed.
- [ ] Conforms to Google docstring style.
- [ ] Conforms to XAIN structlog style.
