### PR TITLE
PB-44 add heartbeat time and timeout to config

### DIFF
--- a/configs/example-config.toml
+++ b/configs/example-config.toml
@@ -9,6 +9,10 @@ host = "localhost"
 port = 50051
 # (Optional) The maximum number of gRPC thread pool workers
 thread_pool_workers = 10
+# (Optional) The heartbeat time in seconds
+heartbeat_time = 10
+# (Optional) The heartbeat timeout in seconds
+heartbeat_timeout = 5
 
 # (Optional)
 [server.grpc_options]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,8 @@ def server_sample():
             "grpc.max_send_message_length": -1,
         },
         "thread_pool_workers": 11,
+        "heartbeat_time": 11,
+        "heartbeat_timeout": 6,
     }
 
 
@@ -128,6 +130,8 @@ def test_load_valid_config(config_sample):  # pylint: disable=redefined-outer-na
         ("grpc.max_send_message_length", -1),
     ]
     assert config.server.thread_pool_workers == 11
+    assert config.server.heartbeat_time == 11
+    assert config.server.heartbeat_timeout == 6
 
     assert config.ai.rounds == 1
     assert config.ai.epochs == 1

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -218,7 +218,7 @@ def test_many_heartbeats_expire_in_short_interval(coordinator):
     """
     participants = {}
     for i in range(0, 100):
-        participant = ParticipantContext(str(i))
+        participant = ParticipantContext(str(i), 10, 5)
         participant.heartbeat_expires = time.time() + 0.1 + i / 1000
         participants[str(i)] = participant
     coordinator = coordinator()

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -6,7 +6,7 @@ import sys
 from structlog import get_logger
 
 from xain_fl.config import Config, InvalidConfig, get_cmd_parameters
-from xain_fl.coordinator.coordinator import Coordinator
+from xain_fl.coordinator.coordinator import Coordinator, Participants
 from xain_fl.coordinator.metrics_store import (
     AbstractMetricsStore,
     MetricsStore,
@@ -44,6 +44,10 @@ def main() -> None:
         minimum_participants_in_round=config.ai.min_participants,  # type: ignore
         fraction_of_participants=config.ai.fraction_participants,  # type: ignore
         metrics_store=metrics_store,
+        participants=Participants(
+            heartbeat_time=config.server.heartbeat_time,
+            heartbeat_timeout=config.server.heartbeat_timeout,
+        ),
     )
 
     serve(coordinator=coordinator, server_config=config.server)

--- a/xain_fl/__main__.py
+++ b/xain_fl/__main__.py
@@ -45,8 +45,8 @@ def main() -> None:
         fraction_of_participants=config.ai.fraction_participants,  # type: ignore
         metrics_store=metrics_store,
         participants=Participants(
-            heartbeat_time=config.server.heartbeat_time,
-            heartbeat_timeout=config.server.heartbeat_timeout,
+            heartbeat_time=config.server.heartbeat_time,  # type: ignore
+            heartbeat_timeout=config.server.heartbeat_timeout,  # type: ignore
         ),
     )
 

--- a/xain_fl/config/schema.py
+++ b/xain_fl/config/schema.py
@@ -182,6 +182,12 @@ SERVER_SCHEMA = Schema(
         Optional("thread_pool_workers", default=10): positive_integer(
             "server.thread_pool_workers"
         ),
+        Optional("heartbeat_time", default=10): positive_integer(
+            "server.heartbeat_time"
+        ),
+        Optional("heartbeat_timeout", default=5): positive_integer(
+            "server.heartbeat_timeout"
+        ),
     }
 )
 

--- a/xain_fl/coordinator/__init__.py
+++ b/xain_fl/coordinator/__init__.py
@@ -1,8 +1,1 @@
-"""Defines constants to be used throughout the module
-"""
-
-# TODO: move to `xain_fl.config.py`
-# once https://xainag.atlassian.net/browse/XP-265 is done
-_ONE_DAY_IN_SECONDS: int = 60 * 60 * 24
-HEARTBEAT_TIME: int = 10
-HEARTBEAT_TIMEOUT: int = 5
+"""Defines constants to be used throughout the module"""

--- a/xain_fl/coordinator/coordinator.py
+++ b/xain_fl/coordinator/coordinator.py
@@ -120,13 +120,14 @@ class Coordinator:  # pylint: disable=too-many-instance-attributes
         epoch_base: int = 0,
         aggregator: Aggregator = WeightedAverageAggregator(),
         controller: Controller = RandomController(),
+        participants: Participants = None,
     ) -> None:
         self.global_weights_writer: AbstractGlobalWeightsWriter = global_weights_writer
         # pylint: disable=line-too-long
         self.local_weights_reader: AbstractLocalWeightsReader = local_weights_reader
         self.minimum_participants_in_round: int = minimum_participants_in_round
         self.fraction_of_participants: float = fraction_of_participants
-        self.participants: Participants = Participants()
+        self.participants: Participants = participants or Participants()
         self.num_rounds: int = num_rounds
         self.aggregator: Aggregator = aggregator
         self.controller: Controller = controller


### PR DESCRIPTION
### References

[PB-44 Make HEARTBEAT_TIME and HEARTBEAT_TIMEOUT configurable](https://xainag.atlassian.net/browse/PB-44)

### Summary

*  Made `HEARTBEAT_TIME` and `HEARTBEAT_TIMEOUT` configurable

### Are there any open tasks/blockers for the ticket?

No

---

### Reviewer checklist

*Reviewer agreement:*

* Reviewers assign themselves at the start of the review.
* Reviewers do **not** commit or merge the merge request.
* Reviewers have to check and mark items in the checklist.

**Merge request checklist**

- [x] Conforms to the merge request title naming `XP-XXX <a description in imperative form>`.
- [x] Each commit conforms to the naming convention `XP-XXX <a description in imperative form>`.
- [x] Linked the ticket in the merge request title or the references section.
- [x] Added an informative merge request summary.

**Code checklist**

- [x] Conforms to the branch naming `XP-XXX-<a_small_stub>`.
- [x] Passed scope checks.
- [x] Added or updated tests if needed.
- [x] Added or updated code documentation if needed.
- [x] Conforms to Google docstring style.
- [x] Conforms to XAIN structlog style.
