### PR TITLE
PB-484 pet messages

### DIFF
--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, iter::Iterator};
+#![allow(dead_code)] // temporary
+
+use std::{collections::HashMap, iter::Iterator, ops::Range};
 
 use sodiumoxide::crypto::{box_, sealedbox, sign};
 
@@ -7,11 +9,15 @@ use super::{utils::is_eligible, PetError};
 pub struct SumMessageBuffer(Vec<u8>);
 
 impl SumMessageBuffer {
+    const SEALEDBOX_RANGE: Range<usize> = 0..117;
+    const NONCE_RANGE: Range<usize> = 117..141;
+    const BOX_RANGE: Range<usize> = 141..320;
+    const MESSAGE_LENGTH: usize = 320;
+
     pub fn new(message: Vec<u8>) -> Result<Self, PetError> {
-        if message.len() != 320 {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+        (message.len() == Self::MESSAGE_LENGTH)
+            .then_some(Self(message))
+            .ok_or(PetError::InvalidMessage)
     }
 
     pub fn open_sealedbox(
@@ -19,7 +25,7 @@ impl SumMessageBuffer {
         coord_encr_pk: &box_::PublicKey,
         coord_encr_sk: &box_::SecretKey,
     ) -> Result<Vec<u8>, PetError> {
-        sealedbox::open(&self.0[0..117], coord_encr_pk, coord_encr_sk)
+        sealedbox::open(&self.0[Self::SEALEDBOX_RANGE], coord_encr_pk, coord_encr_sk)
             .or(Err(PetError::InvalidMessage))
     }
 
@@ -29,8 +35,8 @@ impl SumMessageBuffer {
         coord_encr_sk: &box_::SecretKey,
     ) -> Result<Vec<u8>, PetError> {
         box_::open(
-            &self.0[141..320],
-            &box_::Nonce::from_slice(&self.0[117..141]).ok_or(PetError::InvalidMessage)?,
+            &self.0[Self::BOX_RANGE],
+            &box_::Nonce::from_slice(&self.0[Self::NONCE_RANGE]).ok_or(PetError::InvalidMessage)?,
             part_encr_pk,
             coord_encr_sk,
         )
@@ -38,14 +44,24 @@ impl SumMessageBuffer {
     }
 }
 
-pub struct UpdateMessageBuffer(Vec<u8>);
+pub struct UpdateMessageBuffer(Vec<u8>, Range<usize>);
 
 impl UpdateMessageBuffer {
-    pub fn new(message: Vec<u8>, dict_sum_len: usize) -> Result<Self, PetError> {
-        if message.len() != 323 + 112 * dict_sum_len {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+    const SEALEDBOX_RANGE: Range<usize> = 0..117;
+    const NONCE_RANGE: Range<usize> = 117..141;
+    const BOX_START: usize = 141;
+    const BOX_END_WO_DICT_SEED: usize = 323;
+    const DICT_SEED_ITEM_LENGTH: usize = 112;
+    const MESSAGE_LENGTH_WO_DICT_SEED: usize = 323;
+
+    pub fn new(message: Vec<u8>, dict_sum_length: usize) -> Result<Self, PetError> {
+        let box_range = Self::BOX_START
+            ..Self::BOX_END_WO_DICT_SEED + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
+        let message_length =
+            Self::MESSAGE_LENGTH_WO_DICT_SEED + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
+        (message.len() == message_length)
+            .then_some(Self(message, box_range))
+            .ok_or(PetError::InvalidMessage)
     }
 
     pub fn open_sealedbox(
@@ -53,7 +69,7 @@ impl UpdateMessageBuffer {
         coord_encr_pk: &box_::PublicKey,
         coord_encr_sk: &box_::SecretKey,
     ) -> Result<Vec<u8>, PetError> {
-        sealedbox::open(&self.0[0..117], coord_encr_pk, coord_encr_sk)
+        sealedbox::open(&self.0[Self::SEALEDBOX_RANGE], coord_encr_pk, coord_encr_sk)
             .or(Err(PetError::InvalidMessage))
     }
 
@@ -61,11 +77,10 @@ impl UpdateMessageBuffer {
         &self,
         part_encr_pk: &box_::PublicKey,
         coord_encr_sk: &box_::SecretKey,
-        dict_sum_len: usize,
     ) -> Result<Vec<u8>, PetError> {
         box_::open(
-            &self.0[141..323 + 112 * dict_sum_len],
-            &box_::Nonce::from_slice(&self.0[117..141]).ok_or(PetError::InvalidMessage)?,
+            &self.0[self.1.clone()],
+            &box_::Nonce::from_slice(&self.0[Self::NONCE_RANGE]).ok_or(PetError::InvalidMessage)?,
             part_encr_pk,
             coord_encr_sk,
         )
@@ -76,11 +91,15 @@ impl UpdateMessageBuffer {
 pub struct Sum2MessageBuffer(Vec<u8>);
 
 impl Sum2MessageBuffer {
+    const SEALEDBOX_RANGE: Range<usize> = 0..117;
+    const NONCE_RANGE: Range<usize> = 117..141;
+    const BOX_RANGE: Range<usize> = 141..321;
+    const MESSAGE_LENGTH: usize = 321;
+
     pub fn new(message: Vec<u8>) -> Result<Self, PetError> {
-        if message.len() != 321 {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+        (message.len() == Self::MESSAGE_LENGTH)
+            .then_some(Self(message))
+            .ok_or(PetError::InvalidMessage)
     }
 
     pub fn open_sealedbox(
@@ -88,7 +107,7 @@ impl Sum2MessageBuffer {
         coord_encr_pk: &box_::PublicKey,
         coord_encr_sk: &box_::SecretKey,
     ) -> Result<Vec<u8>, PetError> {
-        sealedbox::open(&self.0[0..117], coord_encr_pk, coord_encr_sk)
+        sealedbox::open(&self.0[Self::SEALEDBOX_RANGE], coord_encr_pk, coord_encr_sk)
             .or(Err(PetError::InvalidMessage))
     }
 
@@ -98,8 +117,8 @@ impl Sum2MessageBuffer {
         coord_encr_sk: &box_::SecretKey,
     ) -> Result<Vec<u8>, PetError> {
         box_::open(
-            &self.0[141..321],
-            &box_::Nonce::from_slice(&self.0[117..141]).ok_or(PetError::InvalidMessage)?,
+            &self.0[Self::BOX_RANGE],
+            &box_::Nonce::from_slice(&self.0[Self::NONCE_RANGE]).ok_or(PetError::InvalidMessage)?,
             part_encr_pk,
             coord_encr_sk,
         )
@@ -110,128 +129,142 @@ impl Sum2MessageBuffer {
 pub struct SealedBoxBuffer(Vec<u8>);
 
 impl SealedBoxBuffer {
+    const ENCR_PK_RANGE: Range<usize> = 0..32;
+    const SIGN_PK_RANGE: Range<usize> = 32..64;
+    const ROUND_RANGE: Range<usize> = 64..69;
+    const MESSAGE_LENGTH: usize = 69;
+
     pub fn new(message: Vec<u8>) -> Result<Self, PetError> {
-        if message.len() != 69 {
-            return Err(PetError::InvalidMessage);
-        }
-        if &message[64..69] != b"round" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+        (message.len() == Self::MESSAGE_LENGTH && &message[Self::ROUND_RANGE] == b"round")
+            .then_some(Self(message))
+            .ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_part_encr_pk(&self) -> Result<box_::PublicKey, PetError> {
-        box_::PublicKey::from_slice(&self.0[0..32]).ok_or(PetError::InvalidMessage)
+        box_::PublicKey::from_slice(&self.0[Self::ENCR_PK_RANGE]).ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_part_sign_pk(&self) -> Result<sign::PublicKey, PetError> {
-        sign::PublicKey::from_slice(&self.0[32..64]).ok_or(PetError::InvalidMessage)
+        sign::PublicKey::from_slice(&self.0[Self::SIGN_PK_RANGE]).ok_or(PetError::InvalidMessage)
     }
 }
 
 pub struct SumBoxBuffer(Vec<u8>);
 
 impl SumBoxBuffer {
+    const CERTIFICATE_RANGE: Range<usize> = 0..0;
+    const SIGN_SUM_RANGE: Range<usize> = 0..64;
+    const SIGN_UPDATE_RANGE: Range<usize> = 64..128;
+    const SUM_RANGE: Range<usize> = 128..131;
+    const EPHM_PK_RANGE: Range<usize> = 131..163;
+    const MESSAGE_LENGTH: usize = 163;
+
     pub fn new(message: Vec<u8>) -> Result<Self, PetError> {
-        if message.len() != 163 {
-            return Err(PetError::InvalidMessage);
-        }
-        if &message[128..131] != b"sum" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+        (message.len() == Self::MESSAGE_LENGTH && &message[Self::SUM_RANGE] == b"sum")
+            .then_some(Self(message))
+            .ok_or(PetError::InvalidMessage)
     }
 
     // dummy
     pub fn get_certificate(&self) -> Vec<u8> {
-        self.0[0..0].to_vec()
+        self.0[Self::CERTIFICATE_RANGE].to_vec()
     }
 
     pub fn get_signature_sum(&self) -> Result<sign::Signature, PetError> {
-        sign::Signature::from_slice(&self.0[0..64]).ok_or(PetError::InvalidMessage)
+        sign::Signature::from_slice(&self.0[Self::SIGN_SUM_RANGE]).ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_part_ephm_pk(&self) -> Result<box_::PublicKey, PetError> {
-        box_::PublicKey::from_slice(&self.0[131..163]).ok_or(PetError::InvalidMessage)
+        box_::PublicKey::from_slice(&self.0[Self::EPHM_PK_RANGE]).ok_or(PetError::InvalidMessage)
     }
 }
 
-pub struct UpdateBoxBuffer(Vec<u8>);
+pub struct UpdateBoxBuffer(Vec<u8>, usize, Range<usize>);
 
 impl UpdateBoxBuffer {
-    pub fn new(message: Vec<u8>, dict_sum_len: usize) -> Result<Self, PetError> {
-        if message.len() != 166 + 112 * dict_sum_len {
-            return Err(PetError::InvalidMessage);
-        }
-        if &message[128..134] != b"update" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+    const CERTIFICATE_RANGE: Range<usize> = 0..0;
+    const SIGN_SUM_RANGE: Range<usize> = 0..64;
+    const SIGN_UPDATE_RANGE: Range<usize> = 64..128;
+    const UPDATE_RANGE: Range<usize> = 128..134;
+    const MODEL_URL_RANGE: Range<usize> = 134..166;
+    const DICT_SEED_START: usize = 166;
+    const DICT_SEED_KEY_LENGTH: usize = 32;
+    const DICT_SEED_ITEM_LENGTH: usize = 112;
+    const MESSAGE_LENGTH_WO_DICT_SEED: usize = 166;
+
+    pub fn new(message: Vec<u8>, dict_sum_length: usize) -> Result<Self, PetError> {
+        let dict_seed_range = Self::DICT_SEED_START
+            ..Self::DICT_SEED_START + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
+        let message_length =
+            Self::MESSAGE_LENGTH_WO_DICT_SEED + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
+        (message.len() == message_length && &message[Self::UPDATE_RANGE] == b"update")
+            .then_some(Self(message, dict_sum_length, dict_seed_range))
+            .ok_or(PetError::InvalidMessage)
     }
 
     // dummy
     pub fn get_certificate(&self) -> Vec<u8> {
-        self.0[0..0].to_vec()
+        self.0[Self::CERTIFICATE_RANGE].to_vec()
     }
 
     pub fn get_signature_sum(&self) -> Result<sign::Signature, PetError> {
-        sign::Signature::from_slice(&self.0[0..64]).ok_or(PetError::InvalidMessage)
+        sign::Signature::from_slice(&self.0[Self::SIGN_SUM_RANGE]).ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_signature_update(&self) -> Result<sign::Signature, PetError> {
-        sign::Signature::from_slice(&self.0[64..128]).ok_or(PetError::InvalidMessage)
+        sign::Signature::from_slice(&self.0[Self::SIGN_UPDATE_RANGE])
+            .ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_model_url(&self) -> Vec<u8> {
-        self.0[134..166].to_vec()
+        self.0[Self::MODEL_URL_RANGE].to_vec()
     }
 
-    pub fn get_dict_seed(
-        &self,
-        dict_sum_len: usize,
-    ) -> Result<HashMap<box_::PublicKey, Vec<u8>>, PetError> {
+    pub fn get_dict_seed(&self) -> Result<HashMap<box_::PublicKey, Vec<u8>>, PetError> {
         let mut dict_seed: HashMap<box_::PublicKey, Vec<u8>> = HashMap::new();
-        for i in (166..166 + 112 * dict_sum_len).step_by(112) {
+        for i in (self.2.clone()).step_by(Self::DICT_SEED_ITEM_LENGTH) {
             dict_seed.insert(
-                box_::PublicKey::from_slice(&self.0[i..i + 32]).ok_or(PetError::InvalidMessage)?,
-                self.0[i + 32..i + 112].to_vec(),
+                box_::PublicKey::from_slice(&self.0[i..i + Self::DICT_SEED_KEY_LENGTH])
+                    .ok_or(PetError::InvalidMessage)?,
+                self.0[i + Self::DICT_SEED_KEY_LENGTH..i + Self::DICT_SEED_ITEM_LENGTH].to_vec(),
             );
         }
-        if dict_seed.len() != dict_sum_len {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(dict_seed)
+        (dict_seed.len() == self.1)
+            .then_some(dict_seed)
+            .ok_or(PetError::InvalidMessage)
     }
 }
 
 pub struct Sum2BoxBuffer(Vec<u8>);
 
 impl Sum2BoxBuffer {
+    const CERTIFICATE_RANGE: Range<usize> = 0..0;
+    const SIGN_SUM_RANGE: Range<usize> = 0..64;
+    const SIGN_UPDATE_RANGE: Range<usize> = 64..128;
+    const SUM2_RANGE: Range<usize> = 128..132;
+    const MASK_URL_RANGE: Range<usize> = 132..164;
+    const MESSAGE_LENGTH: usize = 164;
+
     pub fn new(message: Vec<u8>) -> Result<Self, PetError> {
-        if message.len() != 164 {
-            return Err(PetError::InvalidMessage);
-        }
-        if &message[128..132] != b"sum2" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(Self(message))
+        (message.len() == Self::MESSAGE_LENGTH && &message[Self::SUM2_RANGE] == b"sum2")
+            .then_some(Self(message))
+            .ok_or(PetError::InvalidMessage)
     }
 
     // dummy
     pub fn get_certificate(&self) -> Vec<u8> {
-        self.0[0..0].to_vec()
+        self.0[Self::CERTIFICATE_RANGE].to_vec()
     }
 
     pub fn get_signature_sum(&self) -> Result<sign::Signature, PetError> {
-        sign::Signature::from_slice(&self.0[0..64]).ok_or(PetError::InvalidMessage)
+        sign::Signature::from_slice(&self.0[Self::SIGN_SUM_RANGE]).ok_or(PetError::InvalidMessage)
     }
 
     pub fn get_mask_url(&self) -> Vec<u8> {
-        self.0[132..164].to_vec()
+        self.0[Self::MASK_URL_RANGE].to_vec()
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct SumMessage {
     sum_encr_pk: box_::PublicKey,
     sum_ephm_pk: box_::PublicKey,
@@ -272,10 +305,9 @@ impl SumMessage {
 
     // dummy
     fn validate_certificate(certificate: &[u8]) -> Result<(), PetError> {
-        if certificate != b"" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(())
+        (certificate == b"")
+            .then_some(())
+            .ok_or(PetError::InvalidMessage)
     }
 
     fn validate_signature(
@@ -284,17 +316,13 @@ impl SumMessage {
         seed: &[u8],
         sum: f64,
     ) -> Result<(), PetError> {
-        if sign::verify_detached(sig_sum, &[seed, &b"sum"[..]].concat(), sign_pk)
-            && is_eligible(&sig_sum.0[..], sum).ok_or(PetError::InvalidMessage)?
-        {
-            Ok(())
-        } else {
-            Err(PetError::InvalidMessage)
-        }
+        (sign::verify_detached(sig_sum, &[seed, b"sum"].concat(), sign_pk)
+            && is_eligible(&sig_sum.0[..], sum).ok_or(PetError::InvalidMessage)?)
+        .then_some(())
+        .ok_or(PetError::InvalidMessage)
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct UpdateMessage {
     model_url: Vec<u8>,
     dict_seed: HashMap<box_::PublicKey, Vec<u8>>,
@@ -319,10 +347,8 @@ impl UpdateMessage {
         let sum_encr_pk = sbox.get_part_encr_pk()?;
 
         // get model url and dictionary of encrypted seeds
-        let updatebox = UpdateBoxBuffer::new(
-            msg.open_box(&sum_encr_pk, coord_encr_sk, dict_sum_len)?,
-            dict_sum_len,
-        )?;
+        let updatebox =
+            UpdateBoxBuffer::new(msg.open_box(&sum_encr_pk, coord_encr_sk)?, dict_sum_len)?;
         Self::validate_certificate(&updatebox.get_certificate())?;
         Self::validate_signature(
             &updatebox.get_signature_sum()?,
@@ -333,7 +359,7 @@ impl UpdateMessage {
             round_update,
         )?;
         let model_url = updatebox.get_model_url();
-        let dict_seed = updatebox.get_dict_seed(dict_sum_len)?;
+        let dict_seed = updatebox.get_dict_seed()?;
 
         Ok(Self {
             model_url,
@@ -343,10 +369,9 @@ impl UpdateMessage {
 
     // dummy
     fn validate_certificate(certificate: &[u8]) -> Result<(), PetError> {
-        if certificate != b"" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(())
+        (certificate == b"")
+            .then_some(())
+            .ok_or(PetError::InvalidMessage)
     }
 
     fn validate_signature(
@@ -357,19 +382,15 @@ impl UpdateMessage {
         sum: f64,
         update: f64,
     ) -> Result<(), PetError> {
-        if sign::verify_detached(sig_sum, &[seed, &b"sum"[..]].concat(), sign_pk)
-            && sign::verify_detached(sig_update, &[seed, &b"update"[..]].concat(), sign_pk)
+        (sign::verify_detached(sig_sum, &[seed, b"sum"].concat(), sign_pk)
+            && sign::verify_detached(sig_update, &[seed, b"update"].concat(), sign_pk)
             && !is_eligible(&sig_sum.0[..], sum).ok_or(PetError::InvalidMessage)?
-            && is_eligible(&sig_update.0[..], update).ok_or(PetError::InvalidMessage)?
-        {
-            Ok(())
-        } else {
-            Err(PetError::InvalidMessage)
-        }
+            && is_eligible(&sig_update.0[..], update).ok_or(PetError::InvalidMessage)?)
+        .then_some(())
+        .ok_or(PetError::InvalidMessage)
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct Sum2Message {
     mask_url: Vec<u8>,
 }
@@ -406,10 +427,9 @@ impl Sum2Message {
 
     // dummy
     fn validate_certificate(certificate: &[u8]) -> Result<(), PetError> {
-        if certificate != b"" {
-            return Err(PetError::InvalidMessage);
-        }
-        Ok(())
+        (certificate == b"")
+            .then_some(())
+            .ok_or(PetError::InvalidMessage)
     }
 
     fn validate_signature(
@@ -418,12 +438,9 @@ impl Sum2Message {
         seed: &[u8],
         sum: f64,
     ) -> Result<(), PetError> {
-        if sign::verify_detached(sig_sum, &[seed, &b"sum"[..]].concat(), sign_pk)
-            && is_eligible(&sig_sum.0[..], sum).ok_or(PetError::InvalidMessage)?
-        {
-            Ok(())
-        } else {
-            Err(PetError::InvalidMessage)
-        }
+        (sign::verify_detached(sig_sum, &[seed, b"sum"].concat(), sign_pk)
+            && is_eligible(&sig_sum.0[..], sum).ok_or(PetError::InvalidMessage)?)
+        .then_some(())
+        .ok_or(PetError::InvalidMessage)
     }
 }

--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -62,7 +62,7 @@ impl Default for Coordinator {
 //                 └-> ephm_pk
 //
 // UpdateMessage
-//  └-> SumMessageBuffer
+//  └-> UpdateMessageBuffer
 //       ├-> SealedBox
 //       |    └-> SealedBoxBuffer
 //       |         ├-> encr_pk

--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -88,15 +88,15 @@ impl Default for Coordinator {
 //                 └-> mask_url
 
 /// Buffer and access an encrypted "sum" message.
-struct SumMessageBuffer<'a>(&'a [u8]);
+struct SumMessageBuffer<'msg>(&'msg [u8]);
 
-impl<'a> SumMessageBuffer<'a> {
+impl<'msg> SumMessageBuffer<'msg> {
     const SEALEDBOX_RANGE: Range<usize> = 0..117;
     const NONCE_RANGE: Range<usize> = 117..141;
     const BOX_RANGE: Range<usize> = 141..320;
     const MESSAGE_LENGTH: usize = 320;
 
-    fn new(message: &'a [u8]) -> Result<Self, PetError> {
+    fn new(message: &'msg [u8]) -> Result<Self, PetError> {
         (message.len() == Self::MESSAGE_LENGTH)
             .then_some(Self(message))
             .ok_or(PetError::InvalidMessage)
@@ -127,9 +127,9 @@ impl<'a> SumMessageBuffer<'a> {
 }
 
 /// Buffer and access an encrypted "update" message.
-struct UpdateMessageBuffer<'a>(&'a [u8], Range<usize>);
+struct UpdateMessageBuffer<'msg>(&'msg [u8], Range<usize>);
 
-impl<'a> UpdateMessageBuffer<'a> {
+impl<'msg> UpdateMessageBuffer<'msg> {
     const SEALEDBOX_RANGE: Range<usize> = 0..117;
     const NONCE_RANGE: Range<usize> = 117..141;
     const BOX_START: usize = 141;
@@ -137,7 +137,7 @@ impl<'a> UpdateMessageBuffer<'a> {
     const DICT_SEED_ITEM_LENGTH: usize = 112;
     const MESSAGE_LENGTH_WO_DICT_SEED: usize = 323;
 
-    fn new(message: &'a [u8], dict_sum_length: usize) -> Result<Self, PetError> {
+    fn new(message: &'msg [u8], dict_sum_length: usize) -> Result<Self, PetError> {
         let box_range = Self::BOX_START
             ..Self::BOX_END_WO_DICT_SEED + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
         let message_length =
@@ -172,15 +172,15 @@ impl<'a> UpdateMessageBuffer<'a> {
 }
 
 /// Buffer and access an encrypted "sum2" message.
-struct Sum2MessageBuffer<'a>(&'a [u8]);
+struct Sum2MessageBuffer<'msg>(&'msg [u8]);
 
-impl<'a> Sum2MessageBuffer<'a> {
+impl<'msg> Sum2MessageBuffer<'msg> {
     const SEALEDBOX_RANGE: Range<usize> = 0..117;
     const NONCE_RANGE: Range<usize> = 117..141;
     const BOX_RANGE: Range<usize> = 141..321;
     const MESSAGE_LENGTH: usize = 321;
 
-    fn new(message: &'a [u8]) -> Result<Self, PetError> {
+    fn new(message: &'msg [u8]) -> Result<Self, PetError> {
         (message.len() == Self::MESSAGE_LENGTH)
             .then_some(Self(message))
             .ok_or(PetError::InvalidMessage)
@@ -211,15 +211,15 @@ impl<'a> Sum2MessageBuffer<'a> {
 }
 
 /// Buffer and access the asymmetrically decrypted part of a "sum/update/sum2" message.
-struct SealedBoxBuffer<'a>(&'a [u8]);
+struct SealedBoxBuffer<'sbox>(&'sbox [u8]);
 
-impl<'a> SealedBoxBuffer<'a> {
+impl<'sbox> SealedBoxBuffer<'sbox> {
     const ROUND_RANGE: Range<usize> = 0..5;
     const ENCR_PK_RANGE: Range<usize> = 5..37;
     const SIGN_PK_RANGE: Range<usize> = 37..69;
     const MESSAGE_LENGTH: usize = 69;
 
-    fn new(message: &'a [u8]) -> Result<Self, PetError> {
+    fn new(message: &'sbox [u8]) -> Result<Self, PetError> {
         (message.len() == Self::MESSAGE_LENGTH && &message[Self::ROUND_RANGE] == b"round")
             .then_some(Self(message))
             .ok_or(PetError::InvalidMessage)
@@ -235,9 +235,9 @@ impl<'a> SealedBoxBuffer<'a> {
 }
 
 /// Buffer and access the symmetrically decrypted part of a "sum" message.
-struct SumBoxBuffer<'a>(&'a [u8]);
+struct SumBoxBuffer<'box__>(&'box__ [u8]);
 
-impl<'a> SumBoxBuffer<'a> {
+impl<'box__> SumBoxBuffer<'box__> {
     const SUM_RANGE: Range<usize> = 0..3;
     const CERTIFICATE_RANGE: Range<usize> = 3..3;
     const SIGN_SUM_RANGE: Range<usize> = 3..67;
@@ -245,7 +245,7 @@ impl<'a> SumBoxBuffer<'a> {
     const EPHM_PK_RANGE: Range<usize> = 131..163;
     const MESSAGE_LENGTH: usize = 163;
 
-    fn new(message: &'a [u8]) -> Result<Self, PetError> {
+    fn new(message: &'box__ [u8]) -> Result<Self, PetError> {
         (message.len() == Self::MESSAGE_LENGTH && &message[Self::SUM_RANGE] == b"sum")
             .then_some(Self(message))
             .ok_or(PetError::InvalidMessage)
@@ -266,9 +266,9 @@ impl<'a> SumBoxBuffer<'a> {
 }
 
 /// Buffer and access the symmetrically decrypted part of an "update" message.
-struct UpdateBoxBuffer<'a>(&'a [u8], usize, Range<usize>);
+struct UpdateBoxBuffer<'box__>(&'box__ [u8], usize, Range<usize>);
 
-impl<'a> UpdateBoxBuffer<'a> {
+impl<'box__> UpdateBoxBuffer<'box__> {
     const UPDATE_RANGE: Range<usize> = 0..6;
     const CERTIFICATE_RANGE: Range<usize> = 6..6;
     const SIGN_SUM_RANGE: Range<usize> = 6..70;
@@ -279,7 +279,7 @@ impl<'a> UpdateBoxBuffer<'a> {
     const DICT_SEED_ITEM_LENGTH: usize = 112;
     const MESSAGE_LENGTH_WO_DICT_SEED: usize = 166;
 
-    fn new(message: &'a [u8], dict_sum_length: usize) -> Result<Self, PetError> {
+    fn new(message: &'box__ [u8], dict_sum_length: usize) -> Result<Self, PetError> {
         let dict_seed_range = Self::DICT_SEED_START
             ..Self::DICT_SEED_START + Self::DICT_SEED_ITEM_LENGTH * dict_sum_length;
         let message_length =
@@ -324,9 +324,9 @@ impl<'a> UpdateBoxBuffer<'a> {
 }
 
 /// Buffer and access the symmetrically decrypted part of a "sum2" message.
-struct Sum2BoxBuffer<'a>(&'a [u8]);
+struct Sum2BoxBuffer<'box__>(&'box__ [u8]);
 
-impl<'a> Sum2BoxBuffer<'a> {
+impl<'box__> Sum2BoxBuffer<'box__> {
     const SUM2_RANGE: Range<usize> = 0..4;
     const CERTIFICATE_RANGE: Range<usize> = 4..4;
     const SIGN_SUM_RANGE: Range<usize> = 4..68;
@@ -334,7 +334,7 @@ impl<'a> Sum2BoxBuffer<'a> {
     const MASK_URL_RANGE: Range<usize> = 132..164;
     const MESSAGE_LENGTH: usize = 164;
 
-    fn new(message: &'a [u8]) -> Result<Self, PetError> {
+    fn new(message: &'box__ [u8]) -> Result<Self, PetError> {
         (message.len() == Self::MESSAGE_LENGTH && &message[Self::SUM2_RANGE] == b"sum2")
             .then_some(Self(message))
             .ok_or(PetError::InvalidMessage)

--- a/rust/src/pet/participant.rs
+++ b/rust/src/pet/participant.rs
@@ -59,7 +59,7 @@ impl Participant {
     }
 
     /// Compute the "sum" and "update" signatures.
-    pub fn compute_signature(&mut self, round_seed: &[u8]) -> () {
+    pub fn compute_signature(&mut self, round_seed: &[u8]) {
         self.signature_sum = sign::sign_detached(&[round_seed, b"sum"].concat(), &self.sign_sk);
         self.signature_update =
             sign::sign_detached(&[round_seed, b"update"].concat(), &self.sign_sk);

--- a/rust/src/pet/participant.rs
+++ b/rust/src/pet/participant.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // temporary
+
 use std::collections::HashMap;
 
 use sodiumoxide::{
@@ -159,7 +161,6 @@ impl Sum2MessageBuffer {
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct SumMessage {
     part_ephm_pk: box_::PublicKey,
     part_ephm_sk: box_::SecretKey,
@@ -194,7 +195,6 @@ impl SumMessage {
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct UpdateMessage {
     mask_seed: Vec<u8>,
     message: UpdateMessageBuffer,
@@ -234,7 +234,6 @@ impl UpdateMessage {
     }
 }
 
-#[allow(dead_code)] // temporary
 pub struct Sum2Message {
     mask_url: Vec<u8>,
     message: Sum2MessageBuffer,

--- a/rust/src/pet/participant.rs
+++ b/rust/src/pet/participant.rs
@@ -14,6 +14,266 @@ pub enum Task {
     None,
 }
 
+pub struct SealedBoxBuffer(Vec<u8>);
+
+impl SealedBoxBuffer {
+    pub fn new(encr_pk: &box_::PublicKey, sign_pk: &sign::PublicKey) -> Self {
+        Self(
+            [
+                &encr_pk.0[..], // 32 bytes
+                &sign_pk.0[..], // 32 bytes
+                b"round",       // 5 bytes
+            ]
+            .concat(),
+        ) // 69 bytes in total
+    }
+
+    pub fn seal(&self, coord_encr_pk: &box_::PublicKey) -> Result<Vec<u8>, PetError> {
+        init().or(Err(PetError::InvalidMessage))?;
+        let sbox = sealedbox::seal(&self.0[..], coord_encr_pk); // 48 + 69 bytes
+        Ok(sbox) // 117 bytes in total
+    }
+}
+
+pub struct SumBoxBuffer(Vec<u8>);
+
+impl SumBoxBuffer {
+    pub fn new(certificate: &[u8], signature: &[u8], ephm_pk: box_::PublicKey) -> Self {
+        Self(
+            [
+                certificate,    // 0 bytes (dummy)
+                signature,      // 128 bytes
+                b"sum",         // 3 bytes
+                &ephm_pk.0[..], // 32 bytes
+            ]
+            .concat(),
+        ) // 163 bytes in total
+    }
+
+    pub fn seal(
+        &self,
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+    ) -> Result<Vec<u8>, PetError> {
+        init().or(Err(PetError::InvalidMessage))?;
+        let nonce = box_::gen_nonce(); // 24 bytes
+        let sumbox = box_::seal(&self.0[..], &nonce, coord_encr_pk, part_encr_sk); // 16 + 163 bytes
+        Ok([nonce.0.to_vec(), sumbox].concat()) // 203 bytes in total
+    }
+}
+
+pub struct UpdateBoxBuffer(Vec<u8>);
+
+impl UpdateBoxBuffer {
+    pub fn new(certificate: &[u8], signature: &[u8], model_url: &[u8], dict_seed: &[u8]) -> Self {
+        Self(
+            [
+                certificate, // 0 bytes (dummy)
+                signature,   // 128 bytes
+                b"update",   // 6 bytes
+                model_url,   // 32 bytes (dummy)
+                dict_seed,   // 112 * dict_sum.len() bytes
+            ]
+            .concat(),
+        ) // 166 + 112 * dict_sum.len() bytes in total
+    }
+
+    pub fn seal(
+        &self,
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+    ) -> Result<Vec<u8>, PetError> {
+        init().or(Err(PetError::InvalidMessage))?;
+        let nonce = box_::gen_nonce(); // 24 bytes
+        let updatebox = box_::seal(&self.0[..], &nonce, coord_encr_pk, part_encr_sk); // 16 + 166 + 112 * dict_sum.len() bytes
+        Ok([nonce.0.to_vec(), updatebox].concat()) // 206 + 112 * dict_sum.len() bytes in total
+    }
+}
+
+pub struct Sum2BoxBuffer(Vec<u8>);
+
+impl Sum2BoxBuffer {
+    pub fn new(certificate: &[u8], signature: &[u8], mask_url: &[u8]) -> Self {
+        Self(
+            [
+                certificate,  // 0 bytes (dummy)
+                signature,    // 128 bytes
+                &b"sum2"[..], // 4 bytes
+                mask_url,     // 32 bytes (dummy)
+            ]
+            .concat(),
+        ) // 164 bytes in total
+    }
+
+    pub fn seal(
+        &self,
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+    ) -> Result<Vec<u8>, PetError> {
+        init().or(Err(PetError::InvalidMessage))?;
+        let nonce = box_::gen_nonce(); // 24 bytes
+        let sum2box = box_::seal(&self.0[..], &nonce, coord_encr_pk, part_encr_sk); // 16 + 164 bytes
+        Ok([nonce.0.to_vec(), sum2box].concat()) // 204 bytes in total
+    }
+}
+
+pub struct SumMessageBuffer(Vec<u8>);
+
+impl SumMessageBuffer {
+    pub fn new(sealedbox: &[u8], sumbox: &[u8]) -> Self {
+        Self(
+            [
+                sealedbox, // 117 bytes
+                sumbox,    // 203 bytes
+            ]
+            .concat(),
+        ) // 320 bytes in total
+    }
+}
+
+pub struct UpdateMessageBuffer(Vec<u8>);
+
+impl UpdateMessageBuffer {
+    pub fn new(sealedbox: &[u8], updatebox: &[u8]) -> Self {
+        Self(
+            [
+                sealedbox, // 117 bytes
+                updatebox, // 206 + 112 * dict_sum.len() bytes
+            ]
+            .concat(),
+        ) // 323 + 112 * dict_sum.len() bytes in total
+    }
+}
+
+pub struct Sum2MessageBuffer(Vec<u8>);
+
+impl Sum2MessageBuffer {
+    pub fn new(sealedbox: &[u8], sum2box: &[u8]) -> Self {
+        Self(
+            [
+                sealedbox, // 117 bytes
+                sum2box,   // 204 bytes
+            ]
+            .concat(),
+        ) // 321 bytes in total
+    }
+}
+
+#[allow(dead_code)] // temporary
+pub struct SumMessage {
+    part_ephm_pk: box_::PublicKey,
+    part_ephm_sk: box_::SecretKey,
+    message: SumMessageBuffer,
+}
+
+impl SumMessage {
+    /// Generate an ephemeral asymmetric key pair and encrypt the "sum" message parts.
+    /// Eligibility for the "sum" task should be checked beforehand.
+    pub fn compose(
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+        part_sign_pk: &sign::PublicKey,
+        certificate: &[u8],
+        signature: &[u8],
+    ) -> Result<Self, PetError> {
+        // generate ephemeral key pair
+        init().or(Err(PetError::InvalidMessage))?;
+        let (part_ephm_pk, part_ephm_sk) = box_::gen_keypair();
+
+        // encrypt message parts
+        let sbox = SealedBoxBuffer::new(part_encr_pk, part_sign_pk).seal(coord_encr_pk)?;
+        let sumbox = SumBoxBuffer::new(certificate, signature, part_ephm_pk)
+            .seal(coord_encr_pk, part_encr_sk)?;
+        let message = SumMessageBuffer::new(&sbox, &sumbox);
+        Ok(Self {
+            part_ephm_pk,
+            part_ephm_sk,
+            message,
+        })
+    }
+}
+
+#[allow(dead_code)] // temporary
+pub struct UpdateMessage {
+    mask_seed: Vec<u8>,
+    message: UpdateMessageBuffer,
+}
+
+impl UpdateMessage {
+    /// Mask a trained local model, create a dictionary of encrypted masking seeds and
+    /// encrypt the "update" message parts. Eligibility for the "update" task should be
+    /// checked beforehand.
+    pub fn compose(
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+        part_sign_pk: &sign::PublicKey,
+        certificate: &[u8],
+        signature: &[u8],
+        dict_sum: &HashMap<box_::PublicKey, box_::PublicKey>,
+    ) -> Result<Self, PetError> {
+        // mask the local model
+        init().or(Err(PetError::InvalidMessage))?;
+        let mask_seed = randombytes(32_usize);
+        let model_url = randombytes(32_usize); // dummy
+
+        // create dictionary of encrypted masking seeds
+        let mut dict_seed: Vec<u8> = Vec::new();
+        for (sum_encr_pk, sum_ephm_pk) in dict_sum.iter() {
+            dict_seed.extend(sum_encr_pk.0.to_vec()); // 32 bytes
+            dict_seed.extend(sealedbox::seal(&mask_seed, sum_ephm_pk)); // 48 + 32 bytes
+        } // 112 * dict_sum.len() bytes in total
+
+        // encrypt message parts
+        let sbox = SealedBoxBuffer::new(part_encr_pk, part_sign_pk).seal(coord_encr_pk)?;
+        let updatebox = UpdateBoxBuffer::new(certificate, signature, &model_url, &dict_seed)
+            .seal(coord_encr_pk, part_encr_sk)?;
+        let message = UpdateMessageBuffer::new(&sbox, &updatebox);
+        Ok(Self { mask_seed, message })
+    }
+}
+
+#[allow(dead_code)] // temporary
+pub struct Sum2Message {
+    mask_url: Vec<u8>,
+    message: Sum2MessageBuffer,
+}
+
+impl Sum2Message {
+    pub fn compose(
+        coord_encr_pk: &box_::PublicKey,
+        part_encr_pk: &box_::PublicKey,
+        part_encr_sk: &box_::SecretKey,
+        part_sign_pk: &sign::PublicKey,
+        certificate: &[u8],
+        signature: &[u8],
+        dict_seed: &HashMap<box_::PublicKey, HashMap<box_::PublicKey, Vec<u8>>>,
+    ) -> Result<Self, PetError> {
+        // initialize csprng
+        init().or(Err(PetError::InvalidMessage))?;
+
+        // compute global mask
+        let mut seeds: Vec<Vec<u8>> = Vec::new();
+        for seed in dict_seed
+            .get(part_encr_pk)
+            .ok_or(PetError::InvalidMessage)?
+            .values()
+        {
+            seeds.append(&mut vec![sealedbox::open(seed, part_encr_pk, part_encr_sk)
+                .or(Err(PetError::InvalidMessage))?]);
+        }
+        let mask_url = randombytes(32_usize); // dummy
+
+        // encrypt message parts
+        let sbox = SealedBoxBuffer::new(part_encr_pk, part_sign_pk).seal(coord_encr_pk)?;
+        let sum2box = Sum2BoxBuffer::new(certificate, signature, &mask_url)
+            .seal(coord_encr_pk, part_encr_sk)?;
+        let message = Sum2MessageBuffer::new(&sbox, &sum2box);
+        Ok(Self { mask_url, message })
+    }
+}
+
 pub struct Message {
     round_sum: f64,
     round_update: f64,
@@ -51,172 +311,5 @@ impl Message {
         }
 
         Ok((signature, Task::None))
-    }
-
-    /// Generate an ephemeral asymmetric key pair and encrypt the "sum" message parts.
-    /// Eligibility for the "sum" task should be checked beforehand.
-    pub fn compose_sum(
-        coord_encr_pk: &box_::PublicKey,
-        part_encr_pk: &box_::PublicKey,
-        part_encr_sk: &box_::SecretKey,
-        part_sign_pk: &sign::PublicKey,
-        certificate: &[u8],
-        signature: &[u8],
-    ) -> Result<(box_::PublicKey, box_::SecretKey, Vec<u8>), PetError> {
-        // initialize csprng
-        init().or(Err(PetError::InvalidMessage))?;
-
-        // generate ephemeral key pair
-        let (part_ephm_pk, part_ephm_sk) = box_::gen_keypair();
-
-        // encrypt message parts
-        let nonce = box_::gen_nonce();
-        let message = [
-            sealedbox::seal(
-                // 48 bytes +
-                &[
-                    &part_encr_pk.0[..], // 32 bytes
-                    &part_sign_pk.0[..], // 32 bytes
-                    &b"round"[..],       // 5 bytes
-                ]
-                .concat(),
-                coord_encr_pk,
-            ),
-            nonce.0.to_vec(), // 24 bytes
-            box_::seal(
-                // 16 bytes +
-                &[
-                    certificate,         // 0 bytes (dummy)
-                    signature,           // 128 bytes
-                    &b"sum"[..],         // 3 bytes
-                    &part_ephm_pk.0[..], // 32 bytes
-                ]
-                .concat(),
-                &nonce,
-                coord_encr_pk,
-                part_encr_sk,
-            ),
-        ]
-        .concat(); // 320 bytes in total
-
-        Ok((part_ephm_pk, part_ephm_sk, message))
-    }
-
-    /// Mask a trained local model, create a dictionary of encrypted masking seeds and
-    /// encrypt the "update" message parts. Eligibility for the "update" task should be
-    /// checked beforehand.
-    pub fn compose_update(
-        coord_encr_pk: &box_::PublicKey,
-        part_encr_pk: &box_::PublicKey,
-        part_encr_sk: &box_::SecretKey,
-        part_sign_pk: &sign::PublicKey,
-        certificate: &[u8],
-        signature: &[u8],
-        dict_sum: &HashMap<box_::PublicKey, box_::PublicKey>,
-    ) -> Result<Vec<u8>, PetError> {
-        // initialize csprng
-        init().or(Err(PetError::InvalidMessage))?;
-
-        // mask the local model
-        let mask_seed = randombytes(32_usize);
-        let model_url = randombytes(32_usize); // dummy
-
-        // create dictionary of encrypted masking seeds
-        let mut dict_seed: Vec<u8> = Vec::new();
-        for (sum_encr_pk, sum_ephm_pk) in dict_sum.iter() {
-            dict_seed.extend(sum_encr_pk.0.to_vec()); // 32 bytes
-            dict_seed.extend(sealedbox::seal(&mask_seed, sum_ephm_pk)); // 48 + 32 bytes
-        } // 112 * dict_sum.len() bytes in total
-
-        // encrypt message parts
-        let nonce = box_::gen_nonce();
-        let message = [
-            sealedbox::seal(
-                // 48 bytes +
-                &[
-                    &part_encr_pk.0[..], // 32 bytes
-                    &part_sign_pk.0[..], // 32 bytes
-                    &b"round"[..],       // 5 bytes
-                ]
-                .concat(),
-                coord_encr_pk,
-            ),
-            nonce.0.to_vec(), // 24 bytes
-            box_::seal(
-                // 16 bytes +
-                &[
-                    certificate,    // 0 bytes (dummy)
-                    signature,      // 128 bytes
-                    &b"update"[..], // 6 bytes
-                    &model_url,     // 32 bytes
-                    &dict_seed,     // 112 * dict_sum.len() bytes
-                ]
-                .concat(),
-                &nonce,
-                coord_encr_pk,
-                part_encr_sk,
-            ),
-        ]
-        .concat(); // 323 + 112 * dict_sum.len() bytes in total
-
-        Ok(message)
-    }
-
-    pub fn compose_sum2(
-        coord_encr_pk: &box_::PublicKey,
-        part_encr_pk: &box_::PublicKey,
-        part_encr_sk: &box_::SecretKey,
-        part_sign_pk: &sign::PublicKey,
-        certificate: &[u8],
-        signature: &[u8],
-        dict_seed: &HashMap<box_::PublicKey, HashMap<box_::PublicKey, Vec<u8>>>,
-    ) -> Result<Vec<u8>, PetError> {
-        // initialize csprng
-        init().or(Err(PetError::InvalidMessage))?;
-
-        // compute global mask
-        let mut seeds: Vec<Vec<u8>> = Vec::new();
-        for seed in dict_seed
-            .get(part_encr_pk)
-            .ok_or(PetError::InvalidMessage)?
-            .values()
-        {
-            seeds.append(&mut vec![sealedbox::open(seed, part_encr_pk, part_encr_sk)
-                .or(Err(PetError::InvalidMessage))?]);
-        }
-        let mask_url = randombytes(32_usize); // dummy
-
-        // encrypt message parts
-        let nonce = box_::gen_nonce();
-
-        let message = [
-            sealedbox::seal(
-                // 48 bytes +
-                &[
-                    &part_encr_pk.0[..], // 32 bytes
-                    &part_sign_pk.0[..], // 32 bytes
-                    &b"round"[..],       // 5 bytes
-                ]
-                .concat(),
-                coord_encr_pk,
-            ),
-            nonce.0.to_vec(), // 24 bytes
-            box_::seal(
-                // 16 bytes +
-                &[
-                    certificate,  // 0 bytes (dummy)
-                    signature,    // 128 bytes
-                    &b"sum2"[..], // 4 bytes
-                    &mask_url,    // 32 bytes
-                ]
-                .concat(),
-                &nonce,
-                coord_encr_pk,
-                part_encr_sk,
-            ),
-        ]
-        .concat(); // 321 bytes in total
-
-        Ok(message)
     }
 }

--- a/rust/src/pet/utils.rs
+++ b/rust/src/pet/utils.rs
@@ -4,6 +4,8 @@ use num::{
 };
 use sodiumoxide::crypto::hash::sha256::hash;
 
+/// Compute the floating point representation of the hashed signature and ensure that it
+/// is below the given threshold: int(hash(signature)) / (2**hashbits - 1) <= threshold.
 pub fn is_eligible(signature: &[u8], threshold: f64) -> Option<bool> {
     Some(
         Ratio::new(

--- a/rust/src/pet/utils.rs
+++ b/rust/src/pet/utils.rs
@@ -2,14 +2,14 @@ use num::{
     bigint::{BigUint, ToBigInt},
     rational::Ratio,
 };
-use sodiumoxide::crypto::hash::sha256::hash;
+use sodiumoxide::crypto::{hash::sha256::hash, sign::Signature};
 
 /// Compute the floating point representation of the hashed signature and ensure that it
 /// is below the given threshold: int(hash(signature)) / (2**hashbits - 1) <= threshold.
-pub fn is_eligible(signature: &[u8], threshold: f64) -> Option<bool> {
+pub fn is_eligible(signature: &Signature, threshold: f64) -> Option<bool> {
     Some(
         Ratio::new(
-            BigUint::from_bytes_be(&hash(signature).0[..]).to_bigint()?,
+            BigUint::from_bytes_be(&hash(&signature.0[..]).0[..]).to_bigint()?,
             BigUint::from_bytes_be(&[255_u8; 32][..]).to_bigint()?,
         ) <= Ratio::from_float(threshold)?,
     )

--- a/rust/src/pet/utils.rs
+++ b/rust/src/pet/utils.rs
@@ -2,14 +2,14 @@ use num::{
     bigint::{BigUint, ToBigInt},
     rational::Ratio,
 };
-use sodiumoxide::crypto::{hash::sha256::hash, sign::Signature};
+use sodiumoxide::crypto::{hash::sha256, sign::Signature};
 
 /// Compute the floating point representation of the hashed signature and ensure that it
 /// is below the given threshold: int(hash(signature)) / (2**hashbits - 1) <= threshold.
 pub fn is_eligible(signature: &Signature, threshold: f64) -> Option<bool> {
     Some(
         Ratio::new(
-            BigUint::from_bytes_be(&hash(&signature.0[..]).0[..]).to_bigint()?,
+            BigUint::from_bytes_be(&sha256::hash(&signature.0[..]).0[..]).to_bigint()?,
             BigUint::from_bytes_be(&[255_u8; 32][..]).to_bigint()?,
         ) <= Ratio::from_float(threshold)?,
     )


### PR DESCRIPTION
**References**

- [PB-484](https://xainag.atlassian.net/browse/PB-484) including [PB-498](https://xainag.atlassian.net/browse/PB-498), [PB-499](https://xainag.atlassian.net/browse/PB-499), [PB-500](https://xainag.atlassian.net/browse/PB-500)

**Summary**

- compose and validate "sum", "update" and "sum2" messages of the PET protocol
- provide multi-layer buffers to serialize and deserialize the messages

**Open tasks**
- none