### PR TITLE
remove the rustfmt config file

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-merge_imports = true


### PR DESCRIPTION
- This file has been forgotten when we moved the rust code from the root of the repo to the `rust/` directory
- The only option set in this file is now a default of `rustfmt`