### PR TITLE
Mock the aggregator RPC client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +278,12 @@ checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
@@ -317,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "float-cmp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da62c4f1b81918835a8c6a484a397775fff5953fe83529afd51b05f5c6a6617d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +357,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fragile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -878,6 +905,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95a7e7cfbce0e99ebbf5356a085d3b5e320a7ef300f77cd50a7148aa362e7c2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a615a1ad92048ad5d9633251edb7492b8abc057d7a679a9898476aef173935"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multipart"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +994,12 @@ dependencies = [
  "memchr",
  "version_check 0.9.1",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -1174,6 +1234,35 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "predicates"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2042,6 +2131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2445,7 @@ dependencies = [
  "derive_more",
  "futures",
  "influxdb",
+ "mockall",
  "opentelemetry",
  "opentelemetry-jaeger",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,9 @@ opentelemetry = { version = "0.2.0", optional = true }
 tracing-opentelemetry = { version = "0.2.0", optional = true }
 opentelemetry-jaeger = { version = "0.1.0", optional = true }
 
+[dev-dependencies]
+mockall = "0.6.0"
+
 [[bin]]
 name = "coordinator"
 path = "src/bin/coordinator.rs"


### PR DESCRIPTION
## Description

The main tasks, _ie_ that tasks that implement most of the business logic are `aggregator::Service` for the aggregator and `coordinator::Service` for the coordinator. This is where we'll focus our effort for testing at the beginning. In order to test these two `Service`, we need to control their inputs and outputs.

Let's focus on the coordinator, since the situation is pretty similar for the aggregator anyway. The question is: what are the sources of IO. We have:

- an RPC server that receives requests from the network and sends back responses
- an RPC client that sends requests to the network and receives responses back
- an REST API that receives requests from the network, and sends back responses

However, two of these are not _direct_ sources of the `Service`. The API and RPC server layers are already isolated and run in their own task. They communicate with the `Service` via a `Handle` as illustrated below:

```
                                           +-------------+
                                           |     API     |
                                           | +------+    |
    +---------------------------+      +----->Handle|    <---+
    |           Service         |      |   | +------+    |   |
    | +----------+   +--------+ |      |   +-------------+   |
  +--->RPC client|   |Receiver<--------+   +-------------+   |
  | | +----------+   +--------+ |      |   |  RPC server |   |
  | +---------------------------+      |   | +------+    |   |
  |                                    +----->Handle|    <---+
  |                                        | +------+    |   |
  |                                        +-------------+   |
  |                                                          |
  |                   +---------+                            |
  |                   |         |                            |
  +-------------------> Network <----------------------------+
                      |         |
                      +---------+
```

We already control these handles and we can use them to send requests to the service. Thus, there is no need to mock the API and RPC server and our system under test can already be simplified:

```
                                           +------+
  +---------------------------+      +----->Handle|
  |           Service         |      |     +------+
  | +----------+   +--------+ |      |
+--->RPC client|   |Receiver<--------+
| | +----------+   +--------+ |      |
| +---------------------------+      |     +------+
|                                    +----->Handle|
|                                          +------+
|
|
|                   +---------+
|                   |         |
+-------------------> Network |
                    |         |
                    +---------+
```

The RPC client is the only remaining piece, and the idea of the PR is to mock it away so that our system under test is finally fully under our control:

```
                                         +------+
+---------------------------+      +----->Handle|
|           Service         |      |     +------+
| +----------+   +--------+ |      |
| |  Mock    |   |Receiver<--------+
| +----------+   +--------+ |      |
+---------------------------+      |     +------+
                                   +----->Handle|
                                         +------+
```

--------------------------------

## Implementation

For the mocking itself, we use the `mockall` crate. The idea is to leverage rust's conditional compilation to replace the `rpc::Client` by our mock when running `cargo test`. For this, we use the `#[cfg(test)]` and `#[cfg(not(test))]` attributes.

The mock itself doesn't expose the exact same API than the `rpc::Client`: the types in some of the function signatures are slightly simpler. That's works well in Rust because most APIs are designed around traits.

For instance the real `rpc::Client::select` method looks like this:

```
pub fn select(
    &mut self,
    ctx: Context,
    credentials: Credentials
) -> impl Future<Output = Result<Result<(), ()>>> + '_
```

Thus, the return type is _some type that implements `Future<Output=io::Result<Result<(), ()>>>`, and an anonymous lifetime (the `'_` part). But in our mock, the return type is an actual concrete type:

```
fn select(&mut self, ctx: Context, credentials: Credentials) -> future::Ready<io::Result<Result<(), ()>>>;
```

It works, because that concrete type satisfies the `Future<Output = Result<Result<(), ()>>> + '_` trait bound.

