### PR TITLE
remove redundant key in Cargo.toml

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.8.0"
 authors = ["XAIN AG <engineering@xain.io>"]
 edition = "2018"
 description = "The XAIN project is building a privacy layer for machine learning so that AI projects can meet compliance such as GDPR and CCPA. The approach relies on Federated Learning as enabling technology that allows production AI applications to be fully privacy compliant."
-license = "Apache-2.0"
 license-file = "../LICENSE"
 keywords = ["federated-learning", "fl", "ai", "machine-learning"]
 repository = "https://github.com/xainag/xain-fl/"


### PR DESCRIPTION
This fixes the following warning:

```
warning: only one of `license` or `license-file` is necessary
```