### PR TITLE
PB-570: add the first coordinator::core::Service test

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -265,6 +265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +278,12 @@ checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "dtoa"
@@ -317,6 +329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "float-cmp"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da62c4f1b81918835a8c6a484a397775fff5953fe83529afd51b05f5c6a6617d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +357,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fragile"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f8140122fa0d5dcb9fc8627cfce2b37cc1500f752636d46ea28bc26785c2f9"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -878,6 +905,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95a7e7cfbce0e99ebbf5356a085d3b5e320a7ef300f77cd50a7148aa362e7c2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a615a1ad92048ad5d9633251edb7492b8abc057d7a679a9898476aef173935"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multipart"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +994,12 @@ dependencies = [
  "memchr",
  "version_check 0.9.1",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-integer"
@@ -1174,6 +1234,35 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "predicates"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
+dependencies = [
+ "predicates-core",
+ "treeline",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2042,6 +2131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2350,6 +2445,7 @@ dependencies = [
  "derive_more",
  "futures",
  "influxdb",
+ "mockall",
  "opentelemetry",
  "opentelemetry-jaeger",
  "pyo3",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -36,6 +36,9 @@ opentelemetry = { version = "0.2.0", optional = true }
 tracing-opentelemetry = { version = "0.2.0", optional = true }
 opentelemetry-jaeger = { version = "0.1.0", optional = true }
 
+[dev-dependencies]
+mockall = "0.6.0"
+
 [[bin]]
 name = "coordinator"
 path = "src/bin/coordinator.rs"

--- a/rust/src/aggregator/mod.rs
+++ b/rust/src/aggregator/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 pub mod api;
 pub mod py_aggregator;
 pub mod rpc;

--- a/rust/src/aggregator/py_aggregator.rs
+++ b/rust/src/aggregator/py_aggregator.rs
@@ -190,7 +190,7 @@ pub struct PyAggregatorHandle {
 
 impl Aggregator for PyAggregatorHandle {
     type Error = ();
-    type AggregateFut = Pin<Box<dyn Future<Output = Result<Bytes, ()>>>>;
+    type AggregateFut = Pin<Box<dyn Future<Output = Result<Bytes, ()>> + Send>>;
     type AddWeightsFut = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
 
     fn add_weights(&mut self, weights: Bytes) -> Self::AddWeightsFut {

--- a/rust/src/aggregator/rpc.rs
+++ b/rust/src/aggregator/rpc.rs
@@ -28,7 +28,12 @@ mod inner {
     }
 }
 
-pub use inner::{Rpc, RpcClient as Client};
+pub use inner::Rpc;
+
+#[cfg(test)]
+pub use crate::tests::lib::rpc::aggregator::Client;
+#[cfg(not(test))]
+pub use inner::RpcClient as Client;
 
 /// A server that serves a single client. A new `Server` is created
 /// for each new client.

--- a/rust/src/coordinator/core/mod.rs
+++ b/rust/src/coordinator/core/mod.rs
@@ -3,4 +3,6 @@ mod heartbeat;
 mod protocol;
 mod service;
 
+#[cfg(test)]
+pub(crate) use self::service::ServiceRequests;
 pub use self::service::{RequestError, Selector, Service, ServiceHandle};

--- a/rust/src/coordinator/core/service.rs
+++ b/rust/src/coordinator/core/service.rs
@@ -31,7 +31,7 @@ use tokio::{
     },
 };
 
-struct AggregationFuture(Pin<Box<dyn Future<Output = Result<(), ()>>>>);
+struct AggregationFuture(Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>);
 
 impl Future for AggregationFuture {
     type Output = Result<(), ()>;
@@ -478,6 +478,7 @@ where
     }
 }
 
+#[derive(Debug)]
 pub struct RequestError;
 
 pub struct ServiceRequests(Pin<Box<dyn Stream<Item = Request> + Send>>);

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -10,3 +10,6 @@ extern crate serde;
 pub mod aggregator;
 pub mod common;
 pub mod coordinator;
+
+#[cfg(test)]
+mod tests;

--- a/rust/src/tests/coordinator.rs
+++ b/rust/src/tests/coordinator.rs
@@ -1,0 +1,76 @@
+use crate::{
+    coordinator::{core::Service, models::HeartBeatResponse, settings::FederatedLearningSettings},
+    tests::lib::{
+        coordinator::{MaxSelector, ServiceHandle},
+        enable_logging,
+        rpc::aggregator::{Client, MockClient},
+        sleep_ms,
+    },
+};
+use futures::future;
+use tokio::task::JoinHandle;
+
+const AGGREGATOR_URL: &str = "http://localhost:8082";
+
+fn start_service(settings: FederatedLearningSettings) -> (Client, ServiceHandle, JoinHandle<()>) {
+    // Make it easy to debug this test by setting the `TEST_LOGS`
+    // environment variable
+    enable_logging();
+
+    let rpc_client: Client = MockClient::default().into();
+
+    let (service_handle, service_requests) = ServiceHandle::new();
+
+    let service = Service::new(
+        MaxSelector,
+        settings,
+        AGGREGATOR_URL.to_string(),
+        rpc_client.clone(),
+        service_requests,
+    );
+    let join_handle = tokio::spawn(service);
+    (rpc_client, service_handle, join_handle)
+}
+
+/// Test a full cycle with a single round and a single participant.
+#[tokio::test]
+async fn full_cycle_1_round_1_participant() {
+    let settings = FederatedLearningSettings {
+        rounds: 1,
+        participants_ratio: 1.0,
+        min_clients: 1,
+        heartbeat_timeout: 10,
+    };
+    let (rpc_client, service_handle, _join_handle) = start_service(settings);
+
+    let id = service_handle.rendez_vous_accepted().await;
+    let round = service_handle.heartbeat_selected(id).await;
+    assert_eq!(round, 0);
+
+    rpc_client
+        .mock()
+        .expect_select()
+        .returning(|_, _| future::ready(Ok(Ok(()))));
+
+    let (url, _token) = service_handle.start_training_accepted(id).await;
+    assert_eq!(&url, AGGREGATOR_URL);
+
+    // pretend the client trained and sent its weights to the
+    // aggregator. The aggregator now sends an end training requests
+    // to the coordinator RPC server that we fake with the
+    // service_handle. The service should then trigger the aggregation
+    // and reject subsequent heartbeats and rendez-vous
+    rpc_client
+        .mock()
+        .expect_aggregate()
+        .returning(|_| future::ready(Ok(Ok(()))));
+
+    service_handle.end_training(id, true).await;
+    loop {
+        match service_handle.heartbeat(id).await {
+            HeartBeatResponse::StandBy => sleep_ms(10).await,
+            HeartBeatResponse::Finish => break,
+            _ => panic!("expected StandBy or Finish"),
+        }
+    }
+}

--- a/rust/src/tests/lib/coordinator.rs
+++ b/rust/src/tests/lib/coordinator.rs
@@ -1,0 +1,95 @@
+use crate::{
+    common::client::{ClientId, Token},
+    coordinator::{
+        core::{Selector, ServiceHandle as InnerServiceHandle, ServiceRequests},
+        models::{HeartBeatResponse, RendezVousResponse, StartTrainingResponse},
+    },
+};
+
+/// A selector that always select all the participants currently
+/// waiting.
+pub struct MaxSelector;
+
+impl Selector for MaxSelector {
+    fn select(
+        &mut self,
+        _min_count: usize,
+        waiting: impl Iterator<Item = ClientId>,
+        _selected: impl Iterator<Item = ClientId>,
+    ) -> Vec<ClientId> {
+        waiting.collect()
+    }
+}
+
+/// A wrapper for [`coordinator::core::ServiceHandle`] with some
+/// convenience methods that reduce boilerplate in the tests.
+#[derive(Clone)]
+pub struct ServiceHandle(InnerServiceHandle);
+
+impl ServiceHandle {
+    /// Create a new `ServiceHandle`. The returned [`ServiceRequets`]
+    /// can be passed directly to [`Service::new`].
+    pub fn new() -> (Self, ServiceRequests) {
+        let (inner, requests) = InnerServiceHandle::new();
+        (Self(inner), requests)
+    }
+
+    /// Send a rendez-vous request assuming it's going to be accepted
+    /// and return the client ID given by the coordinator service.
+    ///
+    /// # Panic
+    ///
+    /// This method panics if the service fails to answer the request
+    /// of if the rendez-vous request is rejected.
+    pub async fn rendez_vous_accepted(&self) -> ClientId {
+        match self.0.rendez_vous().await.unwrap() {
+            RendezVousResponse::Accept(id) => id,
+            RendezVousResponse::Reject => panic!("rendez-vous rejected"),
+        }
+    }
+
+    /// Send a heartbeat, assuming the response will be a
+    /// [`HeartBeatResponse::Round`].
+    ///
+    /// # Panic
+    ///
+    /// This method panics if the service fails to answer the request,
+    /// or if the heartbeat response is not
+    /// `HeartBeatResponse::Round`.
+    pub async fn heartbeat_selected(&self, id: ClientId) -> u32 {
+        match self.0.heartbeat(id).await.unwrap() {
+            HeartBeatResponse::Round(round) => round,
+            resp => panic!("expected HeartBeatResponse::Round(_) got {:?}", resp),
+        }
+    }
+
+    /// Send a heartbeat, assuming the response will be a
+    /// [`HeartBeatResponse::Round`].
+    ///
+    /// # Panic
+    ///
+    /// This method panics if the service fails to answer the request
+    /// or if the heartbeat response is not
+    /// `HeartBeatResponse::Round`.
+    pub async fn heartbeat(&self, id: ClientId) -> HeartBeatResponse {
+        self.0.heartbeat(id).await.unwrap()
+    }
+
+    /// Send a start training request, assuming it will be accepted.
+    ///
+    /// # Panic
+    ///
+    /// This method panics if the service fails to answer the request
+    /// or if it rejects it.
+    pub async fn start_training_accepted(&self, id: ClientId) -> (String, Token) {
+        match self.0.start_training(id).await.unwrap() {
+            StartTrainingResponse::Accept(url, token) => (url, token),
+            StartTrainingResponse::Reject => panic!("start_training rejected"),
+        }
+    }
+
+    /// Send an training request
+    pub async fn end_training(&self, id: ClientId, success: bool) {
+        self.0.end_training(id, success).await
+    }
+}

--- a/rust/src/tests/lib/mod.rs
+++ b/rust/src/tests/lib/mod.rs
@@ -1,0 +1,28 @@
+pub mod coordinator;
+pub mod rpc;
+
+use crate::common::{logging, settings::LoggingSettings};
+use tokio::time::{delay_for, Duration};
+use tracing_subscriber::filter::EnvFilter;
+
+/// This function makes it easy to toggle logging in the test. If
+/// called, and if the `RUST_LOG` environment variable is set, the value is used as a filter for tracing. For instance, to have the logs dumped during the tests one can do:
+///
+/// ```no_rust
+/// TEST_LOGS=trace cargo test
+/// ```
+pub fn enable_logging() {
+    ::std::env::var("TEST_LOGS").ok().map(|filter| {
+        logging::configure(LoggingSettings {
+            telemetry: None,
+            filter: EnvFilter::try_new(filter).unwrap(),
+        });
+    });
+}
+
+/// Sleep for the given amount of time, in milliseconds. Note that in
+/// tokio tests, we MUST NOT call `::std::thread::sleep` because it
+/// blocks the event loop.
+pub async fn sleep_ms(ms: u64) {
+    delay_for(Duration::from_millis(ms)).await
+}

--- a/rust/src/tests/lib/rpc/aggregator.rs
+++ b/rust/src/tests/lib/rpc/aggregator.rs
@@ -1,0 +1,75 @@
+use crate::common::client::Credentials;
+use futures::future;
+use mockall::mock;
+use std::{
+    io,
+    sync::{Arc, Mutex, MutexGuard},
+};
+use tarpc::{client::Config, context::Context, rpc::Transport};
+
+mock! {
+    pub NewClient {
+        fn spawn(self) -> io::Result<Client>;
+    }
+}
+
+mock! {
+    pub Client {
+        fn new<T: Transport<(), ()> + 'static>(config: Config, transport: T) -> MockNewClient;
+
+        fn select(&mut self, ctx: Context, credentials: Credentials) -> future::Ready<io::Result<Result<(), ()>>>;
+
+        fn aggregate(&mut self, ctx: Context) -> future::Ready<io::Result<Result<(), ()>>>;
+    }
+}
+
+/// A clonable and thread safe mock for `aggregator::rpc::Client`.
+///
+/// We cannot directly use `MockClient` for two reasons:
+///
+/// - internally, the coordinator service clones the RPC client, so we
+///   would have to set expectations for each clone.
+/// - the coordinator service runs in its own task, and `MockClient`
+///   is not thread safe, so we cannot control it directly.
+///
+/// Therefore, we wrap one `MockClient` instance in a
+/// `Arc<Mutex<MockClient>>`, such that each clone of `Client` is
+/// actually a reference to the same `MockClient` instance and we can
+/// have references to it in multiple threads at the same time.
+///
+/// Note that using a Mutex is sub-optimal because locking blocks all
+/// the tasks running in the same thread than the current task, but it
+/// is good enough for testing.
+#[derive(Clone)]
+pub struct Client(pub Arc<Mutex<MockClient>>);
+
+impl Client {
+    pub fn new<T: Transport<(), ()> + 'static>(_: Config, _: T) -> MockNewClient {
+        MockNewClient::default()
+    }
+
+    /// Get the inner `MockClient`'s `select` method.
+    pub fn select(
+        &mut self,
+        ctx: Context,
+        credentials: Credentials,
+    ) -> future::Ready<io::Result<Result<(), ()>>> {
+        self.mock().select(ctx, credentials)
+    }
+
+    /// Get the inner `MockClient`'s `aggregate` method.
+    pub fn aggregate(&mut self, ctx: Context) -> future::Ready<io::Result<Result<(), ()>>> {
+        self.mock().aggregate(ctx)
+    }
+
+    /// Get the inner `MockClient`.
+    pub fn mock(&self) -> MutexGuard<MockClient> {
+        self.0.lock().unwrap()
+    }
+}
+
+impl From<MockClient> for Client {
+    fn from(mock: MockClient) -> Self {
+        Self(Arc::new(Mutex::new(mock)))
+    }
+}

--- a/rust/src/tests/lib/rpc/mod.rs
+++ b/rust/src/tests/lib/rpc/mod.rs
@@ -1,0 +1,1 @@
+pub mod aggregator;

--- a/rust/src/tests/mod.rs
+++ b/rust/src/tests/mod.rs
@@ -1,0 +1,2 @@
+mod coordinator;
+pub mod lib;


### PR DESCRIPTION
The main tasks, _ie_ that tasks that implement most of the business
logic are `aggregator::Service` for the aggregator and
`coordinator::Service` for the coordinator. This commit implements a
first tests for `coordinator::core::Service`.

In order to test the service, we need to control its inputs and
outputs

There are three source:

- an RPC server that receives requests from the network and sends back responses
- an RPC client that sends requests to the network and receives responses back
- an REST API that receives requests from the network, and sends back responses

However, two of these are not _direct_ sources of the `Service`. The
API and RPC server layers are already isolated and run in their own
task. They communicate with the `Service` via a `Handle` as
illustrated below:

```
                                           +-------------+
                                           |     API     |
                                           | +------+    |
    +---------------------------+      +----->Handle|    <---+
    |           Service         |      |   | +------+    |   |
    | +----------+   +--------+ |      |   +-------------+   |
  +--->RPC client|   |Receiver<--------+   +-------------+   |
  | | +----------+   +--------+ |      |   |  RPC server |   |
  | +---------------------------+      |   | +------+    |   |
  |                                    +----->Handle|    <---+
  |                                        | +------+    |   |
  |                                        +-------------+   |
  |                                                          |
  |                   +---------+                            |
  |                   |         |                            |
  +-------------------> Network <----------------------------+
                      |         |
                      +---------+
```

We already control these handles and we can use them to send requests
to the service. Thus, there is no need to mock the API and RPC server
and our system under test can already be simplified:

```
                                           +------+
  +---------------------------+      +----->Handle|
  |           Service         |      |     +------+
  | +----------+   +--------+ |      |
+--->RPC client|   |Receiver<--------+
| | +----------+   +--------+ |      |
| +---------------------------+      |     +------+
|                                    +----->Handle|
|                                          +------+
|
|
|                   +---------+
|                   |         |
+-------------------> Network |
                    |         |
                    +---------+
```

The RPC client is the only remaining piece, and the idea of the PR is
to mock it away so that our system under test is finally fully under
our control:

```
                                         +------+
+---------------------------+      +----->Handle|
|           Service         |      |     +------+
| +----------+   +--------+ |      |
| |  Mock    |   |Receiver<--------+
| +----------+   +--------+ |      |
+---------------------------+      |     +------+
                                   +----->Handle|
                                         +------+
```

For the mocking itself, we use the `mockall` crate. The idea is to
leverage rust's conditional compilation to replace the `rpc::Client`
by our mock when running `cargo test`. For this, we use the
`#[cfg(test)]` and `#[cfg(not(test))]` attributes.

The mock itself doesn't expose the exact same API than the
`rpc::Client`: the types in some of the function signatures are
slightly simpler. That's works well in Rust because most APIs are
designed around traits.

For instance the real `rpc::Client::select` method looks like this:

```
pub fn select(
    &mut self,
    ctx: Context,
    credentials: Credentials
) -> impl Future<Output = Result<Result<(), ()>>> + '_
```

Thus, the return type is _some type that implements
`Future<Output=io::Result<Result<(), ()>>>`, and an anonymous
lifetime (the `'_` part). But in our mock, the return type is an
actual concrete type:

```
fn select(&mut self, ctx: Context, credentials: Credentials) -> future::Ready<io::Result<Result<(), ()>>>;
```

It works, because that concrete type satisfies the
`Future<Output = Result<Result<(), ()>>> + '_`
trait bound.

In the coordinator binary, we use a random selector. In order to keep
full control of the selection, we defined a very simple selector
`MaxSelector` that selects all the waiting clients. For more
sophisticated tests, we could define other `Selector` implementors.

These tests are require quite a lot of boilerplate code, so it would
be nice to keep them out of `src/` in their own `tests/`
directory. Unfortunately, this doesn't work well with the RPC client
mock, which must be compiled with the rest of the crate.

Therefore we created a `tests/` directory inside `src/`. `tests/lib/`
contains code that can easily be re-used as well as mocks. When
compiling the tests, some module may `use` symbols from
`tests::lib`. For instance in `aggregator/rpc.rs` we have:

```rust
use crate::tests::lib::rpc::aggregator::Client;
```
