### PR TITLE
PB-537 pet tests

### DIFF
--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -13,13 +13,13 @@ use super::{utils::is_eligible, PetError};
 /// A coordinator in the PET protocol layer.
 pub struct Coordinator {
     // credentials
-    encr_pk: box_::PublicKey,
-    encr_sk: box_::SecretKey,
+    pub encr_pk: box_::PublicKey, // 32 bytes
+    encr_sk: box_::SecretKey,     // 32 bytes
 
     // round parameters
     sum: f64,
     update: f64,
-    seed: Vec<u8>,
+    seed: Vec<u8>, // 32 bytes
 }
 
 impl Coordinator {

--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -36,13 +36,13 @@ impl Coordinator {
 
     /// Validate and handle a message.
     pub fn validate_message(&self, message: &[u8]) -> Result<(), PetError> {
-        if let Ok(_) = SumMessage::validate(self, message) {
+        if SumMessage::validate(self, message).is_ok() {
             // placeholder: handle result
             Ok(())
-        } else if let Ok(_) = UpdateMessage::validate(self, message) {
+        } else if UpdateMessage::validate(self, message).is_ok() {
             // placeholder: handle result
             Ok(())
-        } else if let Ok(_) = Sum2Message::validate(self, message) {
+        } else if Sum2Message::validate(self, message).is_ok() {
             // placeholder: handle result
             Ok(())
         } else {

--- a/rust/src/pet/coordinator.rs
+++ b/rust/src/pet/coordinator.rs
@@ -35,16 +35,16 @@ impl Coordinator {
     }
 
     /// Validate and handle a message.
-    pub fn validate_message(&self, message: &[u8]) -> Result<(), PetError> {
+    pub fn validate_message(&self, message: &[u8]) -> Result<usize, PetError> {
         if SumMessage::validate(self, message).is_ok() {
             // placeholder: handle result
-            Ok(())
+            Ok(1)
         } else if UpdateMessage::validate(self, message).is_ok() {
             // placeholder: handle result
-            Ok(())
+            Ok(2)
         } else if Sum2Message::validate(self, message).is_ok() {
             // placeholder: handle result
-            Ok(())
+            Ok(3)
         } else {
             // unknown message type
             Err(PetError::InvalidMessage)

--- a/rust/src/pet/mod.rs
+++ b/rust/src/pet/mod.rs
@@ -2,6 +2,7 @@ pub mod coordinator;
 pub mod participant;
 pub mod utils;
 
+#[derive(Debug, PartialEq)]
 pub enum PetError {
     InvalidMessage,
 }

--- a/rust/src/pet/mod.rs
+++ b/rust/src/pet/mod.rs
@@ -4,5 +4,6 @@ pub mod utils;
 
 #[derive(Debug, PartialEq)]
 pub enum PetError {
+    InsufficientSystemEntropy,
     InvalidMessage,
 }

--- a/rust/src/pet/participant.rs
+++ b/rust/src/pet/participant.rs
@@ -51,18 +51,13 @@ impl Participant {
     }
 
     /// Check eligibility for a task.
-    pub fn check_task(&mut self, round_sum: f64, round_update: f64) -> Result<(), PetError> {
-        if is_eligible(&self.signature_sum, round_sum).ok_or(PetError::InvalidMessage)? {
+    pub fn check_task(&mut self, round_sum: f64, round_update: f64) {
+        if is_eligible(&self.signature_sum, round_sum) {
             self.task = Task::Sum;
-            Ok(())
-        } else if is_eligible(&self.signature_update, round_update)
-            .ok_or(PetError::InvalidMessage)?
-        {
+        } else if is_eligible(&self.signature_update, round_update) {
             self.task = Task::Update;
-            Ok(())
         } else {
             self.task = Task::None;
-            Ok(())
         }
     }
 
@@ -437,16 +432,16 @@ mod tests {
         ]);
         part.signature_sum = sign_ell.clone();
         part.signature_update = sign_inell.clone();
-        part.check_task(0.5_f64, 0.5_f64).unwrap();
+        part.check_task(0.5_f64, 0.5_f64);
         assert_eq!(part.task, Task::Sum);
         part.signature_update = sign_ell.clone();
-        part.check_task(0.5_f64, 0.5_f64).unwrap();
+        part.check_task(0.5_f64, 0.5_f64);
         assert_eq!(part.task, Task::Sum);
         part.signature_sum = sign_inell.clone();
-        part.check_task(0.5_f64, 0.5_f64).unwrap();
+        part.check_task(0.5_f64, 0.5_f64);
         assert_eq!(part.task, Task::Update);
         part.signature_update = sign_inell.clone();
-        part.check_task(0.5_f64, 0.5_f64).unwrap();
+        part.check_task(0.5_f64, 0.5_f64);
         assert_eq!(part.task, Task::None);
     }
 

--- a/rust/src/pet/utils.rs
+++ b/rust/src/pet/utils.rs
@@ -7,10 +7,40 @@ use sodiumoxide::crypto::{hash::sha256, sign::Signature};
 /// Compute the floating point representation of the hashed signature and ensure that it
 /// is below the given threshold: int(hash(signature)) / (2**hashbits - 1) <= threshold.
 pub fn is_eligible(signature: &Signature, threshold: f64) -> Option<bool> {
-    Some(
+    (0_f64 <= threshold && threshold <= 1_f64).then_some(
         Ratio::new(
             BigUint::from_bytes_be(&sha256::hash(&signature.0[..]).0[..]).to_bigint()?,
             BigUint::from_bytes_be(&[255_u8; 32][..]).to_bigint()?,
         ) <= Ratio::from_float(threshold)?,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_eligible() {
+        // eligible signature
+        let sig = Signature([
+            229, 191, 74, 163, 113, 6, 242, 191, 255, 225, 40, 89, 210, 94, 25, 50, 44, 129, 155,
+            241, 99, 64, 25, 212, 157, 235, 102, 95, 115, 18, 158, 115, 253, 136, 178, 223, 4, 47,
+            54, 162, 236, 78, 126, 114, 205, 217, 250, 163, 223, 149, 31, 65, 179, 179, 60, 64, 34,
+            1, 78, 245, 1, 50, 165, 47,
+        ]);
+        assert_eq!(is_eligible(&sig, 0.5_f64), Some(true));
+
+        // ineligible signature
+        let sig = Signature([
+            15, 107, 81, 84, 105, 246, 165, 81, 76, 125, 140, 172, 113, 85, 51, 173, 119, 123, 78,
+            114, 249, 182, 135, 212, 134, 38, 125, 153, 120, 45, 179, 55, 116, 155, 205, 51, 247,
+            37, 78, 147, 63, 231, 28, 61, 251, 41, 48, 239, 125, 0, 129, 126, 194, 123, 183, 11,
+            215, 220, 1, 225, 248, 131, 64, 242,
+        ]);
+        assert_eq!(is_eligible(&sig, 0.5_f64), Some(false));
+
+        // invalid thresholds
+        assert_eq!(is_eligible(&sig, -0.1_f64), None);
+        assert_eq!(is_eligible(&sig, 1.1_f64), None);
+    }
 }

--- a/rust/src/pet/utils.rs
+++ b/rust/src/pet/utils.rs
@@ -2,11 +2,11 @@ use num::{
     bigint::{BigUint, ToBigInt},
     rational::Ratio,
 };
-use sodiumoxide::crypto::{hash::sha256, sign::Signature};
+use sodiumoxide::crypto::{hash::sha256, sign};
 
 /// Compute the floating point representation of the hashed signature and ensure that it
 /// is below the given threshold: int(hash(signature)) / (2**hashbits - 1) <= threshold.
-pub fn is_eligible(signature: &Signature, threshold: f64) -> Option<bool> {
+pub fn is_eligible(signature: &sign::Signature, threshold: f64) -> Option<bool> {
     (0_f64 <= threshold && threshold <= 1_f64).then_some(
         Ratio::new(
             BigUint::from_bytes_be(&sha256::hash(&signature.0[..]).0[..]).to_bigint()?,
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn test_is_eligible() {
         // eligible signature
-        let sig = Signature([
+        let sig = sign::Signature([
             229, 191, 74, 163, 113, 6, 242, 191, 255, 225, 40, 89, 210, 94, 25, 50, 44, 129, 155,
             241, 99, 64, 25, 212, 157, 235, 102, 95, 115, 18, 158, 115, 253, 136, 178, 223, 4, 47,
             54, 162, 236, 78, 126, 114, 205, 217, 250, 163, 223, 149, 31, 65, 179, 179, 60, 64, 34,
@@ -31,7 +31,7 @@ mod tests {
         assert_eq!(is_eligible(&sig, 0.5_f64), Some(true));
 
         // ineligible signature
-        let sig = Signature([
+        let sig = sign::Signature([
             15, 107, 81, 84, 105, 246, 165, 81, 76, 125, 140, 172, 113, 85, 51, 173, 119, 123, 78,
             114, 249, 182, 135, 212, 134, 38, 125, 153, 120, 45, 179, 55, 116, 155, 205, 51, 247,
             37, 78, 147, 63, 231, 28, 61, 251, 41, 48, 239, 125, 0, 129, 126, 194, 123, 183, 11,


### PR DESCRIPTION
**References**
- [PB-537](https://xainag.atlassian.net/browse/PB-537) including [PB-551](https://xainag.atlassian.net/browse/PB-551), [PB-552](https://xainag.atlassian.net/browse/PB-552), [PB-553](https://xainag.atlassian.net/browse/PB-553), [PB-554](https://xainag.atlassian.net/browse/PB-554), [PB-555](https://xainag.atlassian.net/browse/PB-555), [PB-556](https://xainag.atlassian.net/browse/PB-556), [PB-557](https://xainag.atlassian.net/browse/PB-557)

**Summary**
- add unit tests for message composition
- add unit tests for message validation
- add unit tests for utils
- add message wrappers

**Open Tasks**
- follow up task: unify the message buffer structure ([PB-588](https://xainag.atlassian.net/browse/PB-588))