### PR TITLE
PB-598: refactor error handling in the aggregator

### DIFF
--- a/rust/src/aggregator/rpc.rs
+++ b/rust/src/aggregator/rpc.rs
@@ -1,17 +1,117 @@
-use crate::{aggregator::service::ServiceHandle, common::client::Credentials};
-use std::{future::Future, io, iter, pin::Pin, time::Duration};
-use stubborn_io::{ReconnectOptions, StubbornTcpStream};
-use tarpc::{
-    client::Config,
-    rpc::server::{BaseChannel, Channel},
-    serde_transport::{tcp::listen, Transport},
+#![cfg_attr(test, allow(unused_imports))]
+use crate::{
+    aggregator::service::{Aggregator, ServiceError, ServiceHandle},
+    common::client::Credentials,
 };
+use futures::future::{self, TryFutureExt};
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+    future::Future,
+    io, iter,
+    pin::Pin,
+    time::Duration,
+};
+use stubborn_io::{ReconnectOptions, StubbornTcpStream};
+use tarpc::{client::Config, context::Context, serde_transport::Transport};
+use tarpc::{
+    rpc::server::{BaseChannel, Channel},
+    serde_transport::tcp::listen,
+};
+use thiserror::Error;
 use tokio::{net::ToSocketAddrs, stream::StreamExt};
 use tokio_serde::formats::Json;
 use tracing_futures::Instrument;
 
+/// Error returned by the RPC server.
+#[derive(Error, Serialize, Deserialize, Debug)]
+pub enum ServerError<E>
+where
+    E: Display + Debug,
+{
+    /// Returned when the aggregator failed to process a request correctly.
+    #[error("failed to process RPC call `{0}`: unknown internal error")]
+    Internal(String),
+
+    /// Returned when the aggregator processed a request correctly,
+    /// but the response to that request is an error.
+    #[error("RPC call `{0}` resulted in an error: {1}")]
+    Request(String, E),
+}
+
+impl<E> ServerError<E>
+where
+    E: Display + Debug,
+{
+    fn stringify(self) -> ServerError<String> {
+        match self {
+            ServerError::Internal(method) => ServerError::Internal(method),
+            ServerError::Request(method, inner) => {
+                ServerError::Request(method, format!("{}", inner))
+            }
+        }
+    }
+}
+
+impl<E> From<(String, ServiceError<E>)> for ServerError<E>
+where
+    E: Error,
+{
+    fn from(err: (String, ServiceError<E>)) -> Self {
+        match err {
+            (method, ServiceError::Handle(_)) => Self::Internal(method),
+            (method, ServiceError::Request(e)) => Self::Request(method, e),
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum ClientError<E>
+where
+    E: Display + Debug,
+{
+    #[error("an error occured in the RPC layer: {0}")]
+    Rpc(#[from] io::Error),
+
+    #[error("the aggregator failed to process the request")]
+    Internal,
+
+    #[error("request failed: {0}")]
+    Request(E),
+}
+
+impl<E> From<ServerError<E>> for ClientError<E>
+where
+    E: Display + Debug,
+{
+    fn from(e: ServerError<E>) -> Self {
+        match e {
+            ServerError::Internal(_) => Self::Internal,
+            ServerError::Request(_, e) => Self::Request(e),
+        }
+    }
+}
+
 mod inner {
-    use super::Credentials;
+    use super::ServerError;
+    use crate::common::client::Credentials;
+    use std::fmt::Debug;
+
+    // Ideally we'd like our trait to be generic over the aggregator,
+    // so that we could directly return the aggregator's error type:
+    //
+    // pub trait Rpc<A>
+    //     where A: Aggregator + 'static
+    // {
+    //     async fn select(credentials: Credentials) -> Result<(), ServerError<A::Error>>;
+    //     async fn aggregate() -> Result<(), ServerError<A::Error>>;
+    // }
+    //
+    // Unfortunately that is currenctly not supported by `tarpc`. See:
+    // https://github.com/google/tarpc/issues/257
+    //
+    // As a result, we convert the aggregator's error to a String
+    // (hence `ServerError::stringify`)
 
     #[tarpc::service]
     /// Definition of the methods exposed by the aggregator RPC service.
@@ -19,12 +119,12 @@ mod inner {
         /// Notify the aggregator that the given client has been selected
         /// and should use the given token to download the global weights
         /// and upload their local weights.
-        async fn select(credentials: Credentials) -> Result<(), ()>;
+        async fn select(credentials: Credentials) -> Result<(), ServerError<String>>;
 
         /// Notify the aggregator that it should clear its pool of client
         /// IDs and tokens. This should be called before starting a new
         /// round.
-        async fn aggregate() -> Result<(), ()>;
+        async fn aggregate() -> Result<(), ServerError<String>>;
     }
 }
 
@@ -32,49 +132,103 @@ pub use inner::Rpc;
 
 #[cfg(test)]
 pub use crate::tests::lib::rpc::aggregator::Client;
+
 #[cfg(not(test))]
-pub use inner::RpcClient as Client;
+#[derive(Clone)]
+pub struct Client(inner::RpcClient);
+
+#[cfg(not(test))]
+impl Client {
+    pub async fn connect<A: ToSocketAddrs + Unpin + Clone + Send + Sync + 'static>(
+        addr: A,
+    ) -> io::Result<Self> {
+        let reconnect_opts = ReconnectOptions::new()
+            .with_exit_if_first_connect_fails(false)
+            .with_retries_generator(|| iter::repeat(Duration::from_secs(1)));
+        let tcp_stream = StubbornTcpStream::connect_with_options(addr, reconnect_opts).await?;
+        let transport = Transport::from((tcp_stream, Json::default()));
+        Ok(Self(
+            inner::RpcClient::new(Config::default(), transport).spawn()?,
+        ))
+    }
+
+    pub fn select(
+        &mut self,
+        ctx: Context,
+        credentials: Credentials,
+    ) -> impl Future<Output = Result<(), ClientError<String>>> + '_ {
+        self.0
+            .select(ctx, credentials)
+            .map_err(ClientError::from)
+            .and_then(|res| future::ready(res.map_err(ClientError::from)))
+    }
+
+    pub fn aggregate(
+        &mut self,
+        ctx: Context,
+    ) -> impl Future<Output = Result<(), ClientError<String>>> + '_ {
+        self.0
+            .aggregate(ctx)
+            .map_err(ClientError::from)
+            .and_then(|res| future::ready(res.map_err(ClientError::from)))
+    }
+}
 
 /// A server that serves a single client. A new `Server` is created
 /// for each new client.
-#[derive(Clone)]
-struct Server(ServiceHandle);
+pub struct Server<A>(ServiceHandle<A>)
+where
+    A: Aggregator;
 
-impl Rpc for Server {
-    type SelectFut = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
-    type AggregateFut = Pin<Box<dyn Future<Output = Result<(), ()>> + Send>>;
+impl<A> Clone for Server<A>
+where
+    A: Aggregator,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<A> Rpc for Server<A>
+where
+    A: Aggregator + 'static,
+{
+    type SelectFut = Pin<Box<dyn Future<Output = Result<(), ServerError<String>>> + Send>>;
+    type AggregateFut = Pin<Box<dyn Future<Output = Result<(), ServerError<String>>> + Send>>;
 
     fn select(self, _: tarpc::context::Context, credentials: Credentials) -> Self::SelectFut {
         debug!("handling select request");
         let span = trace_span!("rpc_select_handler", client_id = %credentials.id());
-        Box::pin(async move { self.0.select(credentials).await }.instrument(span))
+        Box::pin(
+            async move {
+                self.0.select(credentials).await.map_err(|e| {
+                    ServerError::<A::Error>::from((String::from("select"), e)).stringify()
+                })
+            }
+            .instrument(span),
+        )
     }
 
     fn aggregate(self, _: tarpc::context::Context) -> Self::AggregateFut {
         debug!("handling aggregate request");
         let span = trace_span!("rpc_aggregate_handler");
-        Box::pin(async move { self.0.aggregate().await }.instrument(span))
+        Box::pin(
+            async move {
+                self.0.aggregate().await.map_err(|e| {
+                    ServerError::<A::Error>::from((String::from("aggregate"), e)).stringify()
+                })
+            }
+            .instrument(span),
+        )
     }
 }
 
-/// A future that keeps trying to connect to the `AggregatorRpc` at the
-/// given address.
-pub async fn client_connect<A: ToSocketAddrs + Unpin + Clone + Send + Sync + 'static>(
-    addr: A,
-) -> io::Result<Client> {
-    let reconnect_opts = ReconnectOptions::new()
-        .with_exit_if_first_connect_fails(false)
-        .with_retries_generator(|| iter::repeat(Duration::from_secs(1)));
-    let tcp_stream = StubbornTcpStream::connect_with_options(addr, reconnect_opts).await?;
-    let transport = Transport::from((tcp_stream, Json::default()));
-    Client::new(Config::default(), transport).spawn()
-}
-
 /// Run an RPC server that processes only one connection at a time.
-pub async fn serve<A: ToSocketAddrs + Send + Sync + 'static>(
-    addr: A,
-    service_handle: ServiceHandle,
-) -> ::std::io::Result<()> {
+pub async fn serve<A, T>(addr: T, service_handle: ServiceHandle<A>) -> ::std::io::Result<()>
+where
+    A: Aggregator + 'static,
+    T: ToSocketAddrs + Send + Sync + 'static,
+{
     let mut listener = listen(addr, Json::default).await?;
 
     while let Some(accept_result) = listener.next().await {

--- a/rust/src/bin/coordinator.rs
+++ b/rust/src/bin/coordinator.rs
@@ -92,7 +92,7 @@ async fn _main(
     let rpc_server_task_handle = tokio::spawn(rpc_server);
 
     // Start the RPC client
-    let rpc_client = aggregator::rpc::client_connect(rpc.aggregator_address.clone())
+    let rpc_client = aggregator::rpc::Client::connect(rpc.aggregator_address.clone())
         .instrument(trace_span!("rpc_client"))
         .await
         .unwrap();

--- a/rust/src/tests/aggregator.rs
+++ b/rust/src/tests/aggregator.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use futures::future;
 use tokio::task::JoinHandle;
 
-fn start_service() -> (Client, ServiceHandle, JoinHandle<()>) {
+fn start_service() -> (Client, ServiceHandle<ByteAggregator>, JoinHandle<()>) {
     // Make it easy to debug this test by setting the `TEST_LOGS`
     // environment variable
     enable_logging();
@@ -35,7 +35,10 @@ async fn test_aggregation() {
     assert!(res.is_ok());
 
     let data = Bytes::from_static(b"1111");
-    service_handle.upload(client_1_credentials, data).await;
+    service_handle
+        .upload(client_1_credentials, data)
+        .await
+        .unwrap();
 
     rpc_client
         .mock()
@@ -47,7 +50,10 @@ async fn test_aggregation() {
     assert!(res.is_ok());
 
     let data = Bytes::from_static(b"2222");
-    service_handle.upload(client_2_credentials, data).await;
+    service_handle
+        .upload(client_2_credentials, data)
+        .await
+        .unwrap();
 
     rpc_client
         .mock()

--- a/rust/src/tests/coordinator.rs
+++ b/rust/src/tests/coordinator.rs
@@ -50,7 +50,7 @@ async fn full_cycle_1_round_1_participant() {
     rpc_client
         .mock()
         .expect_select()
-        .returning(|_, _| future::ready(Ok(Ok(()))));
+        .returning(|_, _| future::ready(Ok(())));
 
     let (url, _token) = service_handle.start_training_accepted(id).await;
     assert_eq!(&url, AGGREGATOR_URL);
@@ -63,7 +63,7 @@ async fn full_cycle_1_round_1_participant() {
     rpc_client
         .mock()
         .expect_aggregate()
-        .returning(|_| future::ready(Ok(Ok(()))));
+        .returning(|_| future::ready(Ok(())));
 
     service_handle.end_training(id, true).await;
     loop {

--- a/rust/src/tests/lib/aggregator.rs
+++ b/rust/src/tests/lib/aggregator.rs
@@ -1,12 +1,16 @@
 use crate::{
-    aggregator::service::{Aggregator, ServiceHandle as InnerServiceHandle, ServiceRequests},
+    aggregator::service::{
+        Aggregator, DownloadError, ServiceError, ServiceHandle as InnerServiceHandle,
+        ServiceRequests, UploadError,
+    },
     common::client::Credentials,
 };
 use bytes::Bytes;
 use futures::future;
+use thiserror::Error;
 
 #[derive(Clone)]
-pub struct ServiceHandle(InnerServiceHandle);
+pub struct ServiceHandle<A: Aggregator>(InnerServiceHandle<A>);
 
 pub struct ByteAggregator {
     weights: Vec<u8>,
@@ -18,11 +22,15 @@ impl ByteAggregator {
     }
 }
 
-impl Aggregator for ByteAggregator {
-    type Error = ();
+#[derive(Debug, Error)]
+#[error("dummy error")]
+pub struct ByteAggregatorError;
 
-    type AddWeightsFut = future::Ready<Result<(), ()>>;
-    type AggregateFut = future::Ready<Result<Bytes, ()>>;
+impl Aggregator for ByteAggregator {
+    type Error = ByteAggregatorError;
+
+    type AddWeightsFut = future::Ready<Result<(), Self::Error>>;
+    type AggregateFut = future::Ready<Result<Bytes, Self::Error>>;
 
     fn add_weights(&mut self, weights: Bytes) -> Self::AddWeightsFut {
         self.weights.extend(weights.into_iter());
@@ -36,25 +44,35 @@ impl Aggregator for ByteAggregator {
     }
 }
 
-impl ServiceHandle {
-    pub fn new() -> (Self, ServiceRequests) {
+impl<A> ServiceHandle<A>
+where
+    A: Aggregator + 'static,
+{
+    pub fn new() -> (Self, ServiceRequests<A>) {
         let (inner, requests) = InnerServiceHandle::new();
         (Self(inner), requests)
     }
 
-    pub async fn download(&self, credentials: Credentials) -> Option<Bytes> {
+    pub async fn download(
+        &self,
+        credentials: Credentials,
+    ) -> Result<Bytes, ServiceError<DownloadError>> {
         self.0.download(credentials).await
     }
 
-    pub async fn upload(&self, credentials: Credentials, data: Bytes) {
+    pub async fn upload(
+        &self,
+        credentials: Credentials,
+        data: Bytes,
+    ) -> Result<(), ServiceError<UploadError>> {
         self.0.upload(credentials, data).await
     }
 
-    pub async fn aggregate(&self) -> Result<(), ()> {
+    pub async fn aggregate(&self) -> Result<(), ServiceError<A::Error>> {
         self.0.aggregate().await
     }
 
-    pub async fn select(&self, credentials: Credentials) -> Result<(), ()> {
+    pub async fn select(&self, credentials: Credentials) -> Result<(), ServiceError<A::Error>> {
         self.0.select(credentials).await
     }
 }

--- a/rust/src/tests/lib/rpc/aggregator.rs
+++ b/rust/src/tests/lib/rpc/aggregator.rs
@@ -1,4 +1,4 @@
-use crate::common::client::Credentials;
+use crate::{aggregator::rpc::ServerError, common::client::Credentials};
 use futures::future;
 use mockall::mock;
 use std::{
@@ -17,9 +17,9 @@ mock! {
     pub Client {
         fn new<T: Transport<(), ()> + 'static>(config: Config, transport: T) -> MockNewClient;
 
-        fn select(&mut self, ctx: Context, credentials: Credentials) -> future::Ready<io::Result<Result<(), ()>>>;
+        fn select(&mut self, ctx: Context, credentials: Credentials) -> future::Ready<Result<(), ServerError<String>>>;
 
-        fn aggregate(&mut self, ctx: Context) -> future::Ready<io::Result<Result<(), ()>>>;
+        fn aggregate(&mut self, ctx: Context) -> future::Ready<Result<(), ServerError<String>>>;
     }
 }
 
@@ -53,12 +53,12 @@ impl Client {
         &mut self,
         ctx: Context,
         credentials: Credentials,
-    ) -> future::Ready<io::Result<Result<(), ()>>> {
+    ) -> future::Ready<Result<(), ServerError<String>>> {
         self.mock().select(ctx, credentials)
     }
 
     /// Get the inner `MockClient`'s `aggregate` method.
-    pub fn aggregate(&mut self, ctx: Context) -> future::Ready<io::Result<Result<(), ()>>> {
+    pub fn aggregate(&mut self, ctx: Context) -> future::Ready<Result<(), ServerError<String>>> {
         self.mock().aggregate(ctx)
     }
 


### PR DESCRIPTION
This is the first part of https://xainag.atlassian.net/browse/PB-598.
Second part will be mapping the errors introduced by the PR to HTTP error codes in `warp`.

Summary and motivation
======================

In order to return proper errors to the clients in the API layer, we
need errors to be reported accurately within the service: a mere
`Result<T, ()>` is not good enough. This commit refactors the error
handling in the aggregator service, such that any error (whether it
happens in `PyAggregator`, in the RPC layer, or in the protocol
itself) is propagated back to the `ServiceHandle`, which is the
entrypoint for making requests to the service.

Implementation
==============

`ServiceError<T>`
-----------------

The `ServiceHandle` methods now return a `ServiceError<T>`, where `T`
depends on which method is called. This way, `ServiceError` can
describe both errors that are common to all the methods, and errors
that are specific to certain methods. Thus the `ServiceHandle` now
looks like this:

```rust
impl<A> ServiceHandle<A>
where
  A: Aggregator + 'static,
{
  async fn download(&self, credentials: Credentials) -> Result<Bytes, ServiceError<DownloadError>> {
    // ...
  }
  async fn upload(&self, credentials: Credentials, data: Bytes) -> Result<(), ServiceError<UploadError>> {
    // ...
  }
  async fn aggregate(&self) -> Result<(), ServiceError<A::Error>> {
    // ...
  }
  async fn select(&self, credentials: Credentials) -> Result<(), ServiceError<A::Error>> {
    // ...
  }
  // ...
}
```

Aggregator's error
------------------

Note that `aggregate` and `select`'s error type is tied to the
`Aggregator` associated type `Aggregator::Error`. This is because we
don't want to force implementors of `Aggregator` to use a certain
error type. The downside is that is makes `ServiceHandle` generic over
`A: Aggregator`. We now have:

```rust
pub struct ServiceHandle<A: Aggregator> {
  // ..
}
```

Instead of

```rust
pub struct ServiceHandle {
  // ..
}
```

We could maybe simplify this buy defining `Aggregator` as:

```rust
pub trait Aggregator {
    type Error: Error + Send + 'static + Sync + Into<AggregatorError>;
    type AggregateFut: Future<Output = Result<Bytes, Self::Error>> + Unpin;
    type AddWeightsFut: Future<Output = Result<(), Self::Error>> + Unpin + Send + 'static;
```

where `AggregatorError` is some error that we define. But for now, we
only have one `Aggregator` implementation so it is difficult to
imagine what `AggregatorError` should look like.

For now, our only `Aggregator` implementation, `PyAggregatorHandle`,
uses the following error type:

```rust
pub enum PyAggregatorHandleError {
    #[error("failed to send the request or receive the response")]
    Handle(#[from] ChannelError),

    #[error("error while executing Python code")]
    Python(#[from] PythonError),

    #[error("request failed: {0}")]
    Request(String),
}
```

RPC error
---------

On the RPC side, the error handling was also improved. The improvement
is twofolds:

- The RPC server now returns `Result<T, ServerError>` instead of
  `Result<T, ()>`
- The RPC client returns simpler `Result<T, ClientError>` instead of
  nested results `io::Result<Result<T, ()>>`. The `ClientError` simply
  wraps the `io::Error` and `ServerError` cases.