### PR TITLE
fix python tests in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,11 +54,25 @@ jobs:
           pip install aggregators/
         working-directory: ./python
 
-      - name: cargo test
+      - name: build tests
         working-directory: ./rust
         env:
             RUSTFLAGS: "-D warnings"
-        run: cargo test --features ${{ matrix.features }}
+        run: cargo test --features ${{ matrix.features }} --no-run
+
+      - name: non Python tests
+        working-directory: ./rust
+        env:
+            RUSTFLAGS: "-D warnings"
+        run: cargo test --features ${{ matrix.features }} -- --skip aggregator::py_aggregator
+
+      - name: Python tests
+        working-directory: ./rust
+        env:
+            RUSTFLAGS: "-D warnings"
+        # We have to run the Python tests in a single thread,
+        # because of: https://github.com/PyO3/pyo3/issues/288
+        run: cargo test --features ${{ matrix.features }} -- aggregator::py_aggregator --test-threads=1
 
   clippy:
     name: rust-clippy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,3 +155,16 @@ to reinstall Python with the `--enable-shared` option:
 Next, run `cargo clean` to remove the old build artifacts. After that, all tests should pass.
 
 [You can find more information about the solution here.](https://github.com/PyO3/pyo3/issues/742#issuecomment-577332616)
+
+**`cargo test` fails with SIGSEGV: invalid memory reference**
+
+This is a known issue with `pyo3`: https://github.com/PyO3/pyo3/issues/288
+
+__Solution:__
+
+Run the tests with:
+
+```none
+cargo test -- --test-threads=1
+```
+


### PR DESCRIPTION
This fixes the spurious issue we've been seeing in CI, by running the python tests in a single thread.