### PR TITLE
add rustfmt.toml

### DIFF
--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true

--- a/rust/src/aggregator/rpc.rs
+++ b/rust/src/aggregator/rpc.rs
@@ -13,10 +13,11 @@ use std::{
     time::Duration,
 };
 use stubborn_io::{ReconnectOptions, StubbornTcpStream};
-use tarpc::{client::Config, context::Context, serde_transport::Transport};
 use tarpc::{
+    client::Config,
+    context::Context,
     rpc::server::{BaseChannel, Channel},
-    serde_transport::tcp::listen,
+    serde_transport::{tcp::listen, Transport},
 };
 use thiserror::Error;
 use tokio::{net::ToSocketAddrs, stream::StreamExt};

--- a/rust/src/coordinator/api.rs
+++ b/rust/src/coordinator/api.rs
@@ -4,8 +4,7 @@ use crate::{
 };
 use tokio::net::TcpListener;
 use tracing_futures::Instrument;
-use warp::http::method::Method;
-use warp::Filter;
+use warp::{http::method::Method, Filter};
 
 pub async fn serve(bind_address: &str, handle: ServiceHandle) {
     let handle = warp::any().map(move || handle.clone());


### PR DESCRIPTION
**Summary**
- reintroduce the `rustfmt.toml` config file, because `merge_imports` is not yet stable and therefore `false` by default (https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports)