### PR TITLE
Service implementation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -91,6 +91,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "bincode"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2033,7 @@ name = "xain-fl"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "bytes",
  "chrono",
  "clap",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,6 +37,7 @@ chrono = { version = "0.4", features = ["serde"], optional = true }
 opentelemetry = { version = "0.2.0", optional = true }
 tracing-opentelemetry = { version = "0.2.0", optional = true }
 opentelemetry-jaeger = { version = "0.1.0", optional = true }
+bincode = "1.2.1"
 
 [dev-dependencies]
 mockall = "0.6.0"

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -1,1 +1,7 @@
-fn main() {}
+use xain_fl::service::Service;
+
+#[tokio::main]
+async fn main() {
+    let (service, _handle) = Service::new().unwrap();
+    service.await;
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 #![feature(or_patterns)]
 #![feature(const_fn)]
+#![feature(stmt_expr_attributes)]
 
 #[macro_use]
 extern crate tracing;
@@ -24,10 +25,7 @@ use crate::mask::EncrMaskSeed;
 #[derive(Debug, PartialEq)]
 /// PET protocol errors.
 pub enum PetError {
-    InsufficientSystemEntropy,
     InvalidMessage,
-    InsufficientParticipants,
-    AmbiguousMasks,
 }
 
 pub mod crypto;
@@ -84,3 +82,12 @@ type LocalSeedDict = HashMap<SumParticipantPublicKey, EncrMaskSeed>;
 /// built from the local seed dictionaries sent by the update participants. It maps each sum
 /// participant to the encrypted masking seeds of all the update participants.
 type SeedDict = HashMap<SumParticipantPublicKey, HashMap<UpdateParticipantPublicKey, EncrMaskSeed>>;
+
+/// A 32-byte hash that identifies a model mask computed by a sum participant.
+pub type MaskHash = sodiumoxide::crypto::hash::sha256::Digest;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+#[error("initialization failed: insufficient system entropy to generate secrets")]
+pub struct InitError;

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -59,7 +59,7 @@ impl TryFrom<&[u8]> for MaskSeed {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 /// An encrypted mask seed.
 pub struct EncrMaskSeed(Vec<u8>);
 

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -9,6 +9,7 @@ use crate::{
     message::{sum::SumMessage, sum2::Sum2Message, update::UpdateMessage},
     utils::is_eligible,
     CoordinatorPublicKey,
+    InitError,
     LocalSeedDict,
     ParticipantPublicKey,
     ParticipantSecretKey,
@@ -70,9 +71,9 @@ impl Default for Participant {
 
 impl Participant {
     /// Create a participant. Fails if there is insufficient system entropy to generate secrets.
-    pub fn new() -> Result<Self, PetError> {
+    pub fn new() -> Result<Self, InitError> {
         // crucial: init must be called before anything else in this module
-        sodiumoxide::init().or(Err(PetError::InsufficientSystemEntropy))?;
+        sodiumoxide::init().or(Err(InitError))?;
         let (pk, sk) = generate_signing_key_pair();
         Ok(Self {
             pk,

--- a/rust/src/service.rs
+++ b/rust/src/service.rs
@@ -1,4 +1,5 @@
 use crate::coordinator::{Coordinator, RoundParameters};
+use derive_more::From;
 use sodiumoxide::crypto::box_;
 use std::{
     collections::HashMap,
@@ -63,6 +64,7 @@ impl Service {
 }
 
 /// An event handled by the coordinator
+#[derive(From)]
 pub enum Event {
     /// A message from a participant.
     Message(Message),
@@ -79,27 +81,6 @@ pub enum Event {
     /// A request to retrieve the masking seeds dictionary for the
     /// given participant.
     SeedDict(SeedDictRequest),
-}
-
-impl From<RoundParametersRequest> for Event {
-    fn from(req: RoundParametersRequest) -> Self {
-        Self::RoundParameters(req)
-    }
-}
-impl From<SumDictRequest> for Event {
-    fn from(req: SumDictRequest) -> Self {
-        Self::SumDict(req)
-    }
-}
-impl From<SeedDictRequest> for Event {
-    fn from(req: SeedDictRequest) -> Self {
-        Self::SeedDict(req)
-    }
-}
-impl From<Message> for Event {
-    fn from(msg: Message) -> Self {
-        Self::Message(msg)
-    }
 }
 
 /// Event for an incoming message from a participant

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -47,6 +47,9 @@ pub enum PhaseData {
 }
 
 impl PhaseData {
+    /// Return the current sum dictionary if it is available. The
+    /// availability of the sum dictionary depends on the current
+    /// coordinatore state.
     pub fn sum_dict(&self) -> Option<SerializedSumDict> {
         if let PhaseData::Update(data) = self {
             Some(data.serialized_sum_dict.clone())
@@ -55,6 +58,9 @@ impl PhaseData {
         }
     }
 
+    /// Return the current seed dictionary if it is available. The
+    /// availability of the seed dictionary depends on the current
+    /// coordinatore state.
     pub fn seed_dict(
         &mut self,
         pk: SumParticipantPublicKey,

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -1,0 +1,191 @@
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::{
+    coordinator::{Coordinator, ProtocolEvent, RoundParameters},
+    service::handle::{SerializedSeedDict, SerializedSumDict},
+    MaskHash,
+    SeedDict,
+    SumDict,
+    SumParticipantPublicKey,
+};
+use derive_more::From;
+use sodiumoxide::crypto::box_;
+use std::{collections::HashMap, sync::Arc};
+
+/// Data that the service keeps track of.
+#[derive(From, Default)]
+pub struct Data {
+    /// Parameters of the current round. If there is no round in
+    /// progress, this is `None`.
+    pub round_parameters: Option<Arc<RoundParameters>>,
+    /// Data relevant to the current phase of the protocol. During the
+    /// update phase, this contains the sum dictionary to be sent to
+    /// the update participants for instance, while during the sum2
+    /// phase it contains the seed dictionaries.
+    pub phase_data: Option<PhaseData>,
+}
+
+/// Data held by the service in specific phases
+#[derive(From)]
+pub enum PhaseData {
+    /// Data held by the service during the sum phase
+    #[from]
+    Sum(SumData),
+
+    /// Data held by the service during the update phase
+    #[from]
+    Update(UpdateData),
+
+    /// Data held by the service during the sum2 phase
+    #[from]
+    Sum2(Sum2Data),
+
+    /// Data held by the service during the aggregation phase
+    #[from]
+    Aggregation(AggregationData),
+}
+
+impl PhaseData {
+    pub fn sum_dict(&self) -> Option<SerializedSumDict> {
+        if let PhaseData::Update(data) = self {
+            Some(data.serialized_sum_dict.clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn seed_dict(
+        &mut self,
+        pk: SumParticipantPublicKey,
+    ) -> Result<Option<SerializedSeedDict>, DataUpdateError> {
+        if let PhaseData::Sum2(data) = self {
+            data.get_seed_dict(pk)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Error returned when the state cannot be updated.
+#[derive(Debug, Error)]
+pub enum DataUpdateError {
+    #[error("failed to serialize the sum dictionary: {0}")]
+    SerializeSumDict(String),
+    #[error("failed to serialize a seed dictionary: {0}")]
+    SerializeSeedDict(String),
+}
+
+impl Data {
+    pub fn new() -> Self {
+        Data::default()
+    }
+
+    /// Handle the given event and update the state accordingly
+    pub fn update(&mut self, event: ProtocolEvent) -> Result<(), DataUpdateError> {
+        match event {
+            ProtocolEvent::StartSum(round_parameters) => {
+                self.round_parameters = Some(Arc::new(round_parameters));
+                self.phase_data = Some(SumData.into());
+            }
+            ProtocolEvent::StartUpdate(sum_dict) => {
+                let serialized_sum_dict = bincode::serialize(&sum_dict)
+                    .map_err(|e| DataUpdateError::SerializeSumDict(e.to_string()))?;
+                let update_data = UpdateData {
+                    serialized_sum_dict: Arc::new(serialized_sum_dict),
+                };
+                self.phase_data = Some(update_data.into());
+            }
+            ProtocolEvent::StartSum2(seed_dict) => {
+                let sum2_data = Sum2Data {
+                    seed_dict,
+                    serialized_seed_dict: HashMap::new(),
+                };
+                self.phase_data = Some(sum2_data.into());
+            }
+            ProtocolEvent::EndRound(Some(mask_hash)) => {
+                self.round_parameters = None;
+                self.phase_data = Some(AggregationData { mask_hash }.into());
+            }
+            ProtocolEvent::EndRound(None) => {
+                self.round_parameters = None;
+                self.phase_data = None;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn round_parameters(&self) -> Option<Arc<RoundParameters>> {
+        self.round_parameters.clone()
+    }
+
+    pub fn sum_dict(&self) -> Option<SerializedSumDict> {
+        self.phase_data.as_ref()?.sum_dict()
+    }
+
+    pub fn seed_dict(
+        &mut self,
+        pk: SumParticipantPublicKey,
+    ) -> Result<Option<SerializedSeedDict>, DataUpdateError> {
+        match self.phase_data.as_mut() {
+            Some(data) => data.seed_dict(pk),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Service data specific to the sum phase
+pub struct SumData;
+
+/// Service data specific to the update phase
+pub struct UpdateData {
+    /// The sum dictionary, already serialized so that it can direclty
+    /// be sent to the clients that request it
+    pub serialized_sum_dict: SerializedSeedDict,
+}
+
+/// Service data specific to the sum2 phase
+pub struct Sum2Data {
+    /// The seed dictionary produced by the update phase.
+    pub seed_dict: SeedDict,
+    /// The seed dictionary with serialized values that can directly
+    /// be sent to the clients that request it.
+    pub serialized_seed_dict: HashMap<SumParticipantPublicKey, SerializedSeedDict>,
+}
+
+impl Sum2Data {
+    /// Retrieve a serialized seed dictionary that corresponds to the
+    /// given public key.
+    fn get_seed_dict(
+        &mut self,
+        pk: SumParticipantPublicKey,
+    ) -> Result<Option<SerializedSeedDict>, DataUpdateError> {
+        // If we already serialized the dictionary for the given
+        // public key, just return it
+        if let Some(value) = self.serialized_seed_dict.get(&pk) {
+            return Ok(Some(value.clone()));
+        }
+
+        // Otherwise, check if we have a dictionary for the requested
+        // public key. If so, serialize and store it, in case it is
+        // requested again in the future.
+        if let Some(dict) = self.seed_dict.remove(&pk) {
+            // FIXME: if we have many participants these
+            // serializations will have a non-negligible cost. We may
+            // have to offload that.
+            let serialized = bincode::serialize(&dict)
+                .map_err(|e| DataUpdateError::SerializeSeedDict(e.to_string()))?;
+            let value = Arc::new(serialized);
+            self.serialized_seed_dict.insert(pk, value.clone());
+            return Ok(Some(value));
+        }
+
+        // We don't have a seed dictionary for the given key
+        Ok(None)
+    }
+}
+
+/// Service data specific to the aggregation phase
+pub struct AggregationData {
+    pub mask_hash: MaskHash,
+}

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -84,7 +84,8 @@ impl Handle {
     }
 
     /// Send a [`Event::RoundParameters`] event to retrieve the
-    /// current round parameters.
+    /// current round parameters. The availability of the round
+    /// parameters depends on the current coordinator state.
     pub async fn get_round_parameters(&self) -> Option<Arc<RoundParameters>> {
         let (tx, rx) = oneshot::channel::<Option<Arc<RoundParameters>>>();
         self.send_event(RoundParametersRequest { response_tx: tx });
@@ -92,7 +93,8 @@ impl Handle {
     }
 
     /// Send a [`Event::SumDict`] event to retrieve the current sum
-    /// dictionary, in its serialized form.
+    /// dictionary, in its serialized form. The availability of the
+    /// sum dictionary depends on the current coordinator state.
     pub async fn get_sum_dict(&self) -> Option<SerializedSumDict> {
         let (tx, rx) = oneshot::channel::<Option<SerializedSumDict>>();
         self.send_event(SumDictRequest { response_tx: tx });
@@ -100,7 +102,9 @@ impl Handle {
     }
 
     /// Send a [`Event::SeedDict`] event to retrieve the current seed
-    /// dictionary for the given sum participant public key.
+    /// dictionary for the given sum participant public key. The
+    /// availability of the seed dictionary depends on the current
+    /// coordinator state.
     pub async fn get_seed_dict(&self, key: SumParticipantPublicKey) -> Option<SerializedSeedDict> {
         let (tx, rx) = oneshot::channel::<Option<SerializedSeedDict>>();
         let event = SeedDictRequest {

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -1,6 +1,5 @@
-use crate::coordinator::{Coordinator, RoundParameters};
+use crate::{coordinator::RoundParameters, SumParticipantPublicKey};
 use derive_more::From;
-use sodiumoxide::crypto::box_;
 use std::{
     collections::HashMap,
     pin::Pin,
@@ -14,54 +13,6 @@ use tokio::{
         oneshot,
     },
 };
-
-/// The `Service` is the task that drives the PET protocol. It reacts
-/// to the various messages from the participants and drives the
-/// protocol.
-pub struct Service {
-    /// The coordinator holds the protocol state: crypto material, sum
-    /// and update dictionaries, configuration, etc.
-    coordinator: Coordinator,
-
-    /// Events to handle
-    events: EventStream,
-
-    /// Cache for the data the service needs to serve
-    cache: ServiceCache,
-}
-
-/// Cache for the data served by the service. There are some
-/// potentially large datastructures that the coordinator needs to be
-/// able to serve, so the cache provides two optimizations for some of
-/// them:
-///
-/// - they are wrapped reference counted pointers
-/// - they are already serialized
-struct ServiceCache {
-    /// Current round parameters
-    round_parameters: Arc<RoundParameters>,
-
-    /// Serialized sum dictionary
-    sum_dict: Option<Arc<Vec<u8>>>,
-
-    /// Serialized seeds dictionaries
-    seed_dict: Option<HashMap<box_::PublicKey, Vec<u8>>>,
-}
-
-impl Service {
-    /// Dispatch the given event to the appropriate handler
-    fn dispatch_event(&mut self, event: Event) {
-        match event {
-            Event::Message(Message { buffer }) => self.handle_message(buffer),
-            _ => unimplemented!(),
-        }
-    }
-
-    /// Handle a message
-    fn handle_message(&mut self, buffer: Vec<u8>) {
-        let _ = self.coordinator.handle_message(&buffer[..]);
-    }
-}
 
 /// An event handled by the coordinator
 #[derive(From)]
@@ -86,29 +37,33 @@ pub enum Event {
 /// Event for an incoming message from a participant
 pub struct Message {
     /// Encrypted message
-    buffer: Vec<u8>,
+    pub buffer: Vec<u8>,
     // FIXME: there should be a channel to send a response back
 }
 
 /// Event for a request to retrieve the round parameters
 pub struct RoundParametersRequest {
     /// Channel for sending the round parameters back
-    response_tx: oneshot::Sender<Option<Arc<RoundParameters>>>,
+    pub response_tx: oneshot::Sender<Option<Arc<RoundParameters>>>,
 }
+
+pub type SerializedSumDict = Arc<Vec<u8>>;
 
 /// Event for a request to retrieve the sum dictionary
 pub struct SumDictRequest {
     /// Channel for sending the sum dictionary back
-    response_tx: oneshot::Sender<Option<Arc<Vec<u8>>>>,
+    pub response_tx: oneshot::Sender<Option<SerializedSumDict>>,
 }
+
+pub type SerializedSeedDict = Arc<Vec<u8>>;
 
 /// Event for a request to retrieve the seed dictionary
 pub struct SeedDictRequest {
     /// Public key of the sum participant that
-    public_key: box_::PublicKey,
+    pub public_key: SumParticipantPublicKey,
 
     /// Channel for sending the seeds dictionary back
-    response_tx: oneshot::Sender<Option<Arc<Vec<u8>>>>,
+    pub response_tx: oneshot::Sender<Option<Arc<Vec<u8>>>>,
 }
 
 /// A handle to send events to be handled by [`Service`]
@@ -132,21 +87,28 @@ impl Handle {
     /// current round parameters.
     pub async fn get_round_parameters(&self) -> Option<Arc<RoundParameters>> {
         let (tx, rx) = oneshot::channel::<Option<Arc<RoundParameters>>>();
-        let event = RoundParametersRequest { response_tx: tx };
-        self.send_event(event);
+        self.send_event(RoundParametersRequest { response_tx: tx });
         rx.await.unwrap()
     }
 
     /// Send a [`Event::SumDict`] event to retrieve the current sum
     /// dictionary, in its serialized form.
-    pub async fn get_sum_dict(&self) -> Option<Arc<Vec<u8>>> {
-        unimplemented!()
+    pub async fn get_sum_dict(&self) -> Option<SerializedSumDict> {
+        let (tx, rx) = oneshot::channel::<Option<SerializedSumDict>>();
+        self.send_event(SumDictRequest { response_tx: tx });
+        rx.await.unwrap()
     }
 
     /// Send a [`Event::SeedDict`] event to retrieve the current seed
-    /// dictionary, in its serialized form.
-    pub async fn get_seed_dict(&self) -> Option<Arc<Vec<u8>>> {
-        unimplemented!()
+    /// dictionary for the given sum participant public key.
+    pub async fn get_seed_dict(&self, key: SumParticipantPublicKey) -> Option<SerializedSeedDict> {
+        let (tx, rx) = oneshot::channel::<Option<SerializedSeedDict>>();
+        let event = SeedDictRequest {
+            public_key: key,
+            response_tx: tx,
+        };
+        self.send_event(event);
+        rx.await.unwrap()
     }
 
     fn send_event<T: Into<Event>>(&self, event: T) {

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -1,0 +1,142 @@
+use crate::{
+    coordinator::{Coordinator, RoundParameters},
+    InitError,
+};
+use derive_more::From;
+use futures::ready;
+use sodiumoxide::crypto::box_;
+use std::{
+    collections::HashMap,
+    error::Error,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{
+    stream::Stream,
+    sync::{
+        mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+        oneshot,
+    },
+};
+
+mod data;
+mod handle;
+
+pub use data::Data;
+pub use handle::{
+    Event,
+    EventStream,
+    Handle,
+    Message,
+    RoundParametersRequest,
+    SeedDictRequest,
+    SumDictRequest,
+};
+
+/// The `Service` is the task that drives the PET protocol. It reacts
+/// to the various messages from the participants and drives the
+/// protocol.
+pub struct Service {
+    /// The coordinator holds the protocol state: crypto material, sum
+    /// and update dictionaries, configuration, etc.
+    coordinator: Coordinator,
+
+    /// Events to handle
+    events: EventStream,
+
+    /// Data the service currently holds.
+    data: Data,
+}
+
+impl Service {
+    /// Instantiate a new [`Service`] and return it along with the
+    /// corresponding [`Handle`].
+    pub fn new() -> Result<(Self, Handle), InitError> {
+        let (handle, events) = Handle::new();
+        let service = Self {
+            events,
+            coordinator: Coordinator::new()?,
+            data: Data::new(),
+        };
+        Ok((service, handle))
+    }
+
+    /// Dispatch the given event to the appropriate handler
+    fn dispatch_event(&mut self, event: Event) {
+        match event {
+            Event::Message(Message { buffer }) => self.handle_message(buffer),
+            Event::RoundParameters(req) => self.handle_round_parameters_request(req),
+            Event::SumDict(req) => self.handle_sum_dict_request(req),
+            Event::SeedDict(req) => self.handle_seed_dict_request(req),
+        }
+        self.process_protocol_events();
+    }
+
+    /// Handler for round parameters requests
+    fn handle_round_parameters_request(&self, req: RoundParametersRequest) {
+        let RoundParametersRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.round_parameters());
+    }
+
+    /// Handler for sum dict requests
+    fn handle_sum_dict_request(&self, req: SumDictRequest) {
+        let SumDictRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.sum_dict());
+    }
+
+    /// Handler for seed dict requests
+    fn handle_seed_dict_request(&mut self, req: SeedDictRequest) {
+        let SeedDictRequest {
+            public_key,
+            response_tx,
+        } = req;
+        let resp = self.data.seed_dict(public_key).unwrap();
+        let _ = response_tx.send(resp);
+    }
+
+    /// Dequeue all the events produced by the coordinator, and handle
+    /// them
+    fn process_protocol_events(&mut self) {
+        while let Some(event) = self.coordinator.next_event() {
+            if let Err(e) = self.data.update(event) {
+                error!(error = %e, "failed to update the service state, cancelling current round");
+                self.coordinator.reset();
+            }
+        }
+    }
+
+    /// Handle a message
+    fn handle_message(&mut self, buffer: Vec<u8>) {
+        let _ = self.coordinator.handle_message(&buffer[..]);
+    }
+
+    /// Handle the incoming requests.
+    fn poll_events(&mut self, cx: &mut Context) -> Poll<()> {
+        trace!("polling requests");
+        loop {
+            match ready!(Pin::new(&mut self.events).poll_next(cx)) {
+                Some(event) => self.dispatch_event(event),
+                None => {
+                    trace!("no more events to handle");
+                    return Poll::Ready(());
+                }
+            }
+        }
+    }
+}
+
+impl Future for Service {
+    type Output = ();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        trace!("polling Service");
+        let pin = self.get_mut();
+
+        if let Poll::Ready(_) = pin.poll_events(cx) {
+            return Poll::Ready(());
+        }
+
+        Poll::Pending
+    }
+}


### PR DESCRIPTION
This commit introduce a service module. The main type is
`service::Service`. It is a Future that handles events (incoming
messages, protocol state changes, etc.), and drives the protocol.

Changes to the protocol state machine
-------------------------------------

To update the state machine, the service calls
`Coordinator::handle_message()` when new messages arrive. The
`Coordinator` updates its state accordingly and emits `ProtocolEvent`
events for the service to handle. Currently, the coordinator emits an
event every time it starts a new phase.

Service state
-------------

The service needs to keep track of some data. This is what
`service::Data` is for. Some data is common to all the protocol
phases, but some is specific to the current protocol phase. The pase
specific data is represented by a `PhaseData` enum.

Service `Handle`
----------------

The service will be running on the tokio event loop, so it won't be
accessible directly. To send events to the service, we defined a
`service::Handle` struct that is just a wrapper around tokio channels.