### PR TITLE
use Borrow to implement messages

### DIFF
--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -8,7 +8,7 @@ use sodiumoxide::{
 };
 
 use crate::{
-    message::{sum::SumMessage, sum2::Sum2Message, update::UpdateMessage},
+    message::{sum::SumMessage, sum2::Sum2Message, update::UpdateMessage, Certificate},
     utils::is_eligible,
     CoordinatorPublicKey, CoordinatorSecretKey, LocalSeedDict, ParticipantTaskSignature, PetError,
     SeedDict, SumDict, SumParticipantEphemeralPublicKey, SumParticipantPublicKey,
@@ -136,8 +136,8 @@ impl Coordinator {
     }
 
     /// Validate a certificate (dummy).
-    fn validate_certificate(certificate: &[u8]) -> Result<(), PetError> {
-        if certificate == b"" {
+    fn validate_certificate(certificate: &Certificate) -> Result<(), PetError> {
+        if certificate.as_ref() == b"" {
             Ok(())
         } else {
             Err(PetError::InvalidMessage)

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![feature(or_patterns)]
+#![feature(const_fn)]
 
 #[macro_use]
 extern crate tracing;

--- a/rust/src/message/mod.rs
+++ b/rust/src/message/mod.rs
@@ -20,6 +20,21 @@ const PART_PK_RANGE: Range<usize> = 97..129; // 32 bytes
 const CERTIFICATE_RANGE: Range<usize> = 129..129; // 0 bytes (dummy)
 const SUM_SIGNATURE_RANGE: Range<usize> = 129..193; // 64 bytes
 
+/// A dummy type that represents a certificate.
+pub struct Certificate(pub Vec<u8>);
+
+impl AsRef<[u8]> for Certificate {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl From<Vec<u8>> for Certificate {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
 /// Access to common message buffer fields.
 pub trait MessageBuffer: Sized {
     /// Get a reference to the message buffer.


### PR DESCRIPTION
Instead of having two blocks:

```rust
impl Foo<&A, &B, &C> {}
impl Foo<A, B, C> {}
```

we can use the `Borrow` trait, which has this precise purpose. To
quote the [book](https://doc.rust-lang.org/1.27.2/book/first-edition/borrow-and-asref.html#which-should-i-use):

> Choose Borrow when you want to abstract over different kinds of
> borrowing, or when you’re building a data structure that treats
> owned and borrowed values in equivalent ways

For convenience, this commit also introduces a `Certificate`
placeholder, just so that we don't have `Vec<u8>` hanging around.

Finally, this commit renames various `Foo:from` methods into
`Foo::new`. By convention, `from()` is kind of reserved for From
implementations. Perhaps we could have `from_parts()` and
`into_parts()` instead.