### PR TITLE
DO-105 :pencil: Remove telemetry flag from release image. Update compose

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -10,7 +10,7 @@ RUN bash ./install_rust.sh
 COPY rust/Cargo.lock .
 COPY rust/Cargo.toml .
 COPY rust/src src
-RUN cargo build --release --features=telemetry,influx_metrics
+RUN cargo build --release --features=influx_metrics
 
 
 FROM python:3.7.6-slim-buster

--- a/docker/docker-compose-release.yml
+++ b/docker/docker-compose-release.yml
@@ -27,6 +27,9 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.release
+      args:
+        RELEASE_BUILD: "true"
+
     image: docker_coordinator:release
     depends_on:
       - influxdb
@@ -43,6 +46,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.release
+      args:
+        RELEASE_BUILD: "true"
     image: docker_aggregator:release
     depends_on:
       - influxdb

--- a/docker/docker-compose-release.yml
+++ b/docker/docker-compose-release.yml
@@ -1,5 +1,26 @@
 version: "3.7"
+
+volumes:
+  influxdb-data: {}
+
+networks:
+  xain-fl-rs:
+
 services:
+
+  influxdb:
+    image: influxdb:1.7 # current stable version, v2 is in Beta
+    hostname: influxdb
+    environment:
+      INFLUXDB_DB: metrics
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+    networks:
+      - xain-fl-rs
+    ports:
+      - "8086:8086"
+    labels:
+      org.label-schema.group: "monitoring"
 
   coordinator:
     command: coordinator -c /bin/config.toml
@@ -22,8 +43,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.release
-      args:
-          RELEASE_BUILD: "true"
     image: docker_aggregator:release
     depends_on:
       - influxdb


### PR DESCRIPTION
This PR fixes `docker-compose-release.yaml` and removes the `telemetry` flag from the release builds