### PR TITLE
PB-664 Client

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -7,6 +7,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8716408b8bc624ed7f65d223ddb9ac2d044c0547b6fa4b0d554f3a9540496ada"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +81,17 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "chrono"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
 
 [[package]]
 name = "crc32fast"
@@ -239,6 +268,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +328,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -565,10 +609,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "regex"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "ryu"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "serde"
@@ -591,6 +669,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,6 +703,12 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "smallvec"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "sodiumoxide"
@@ -664,6 +768,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -727,6 +850,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d53c40489aa69c9aed21ff483f26886ca8403df33bdc2d2f87c60c1617826d2"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -810,6 +974,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1.0.16"
 anyhow = "1.0.28"
 bitflags = "1.2.1"
 paste = "0.1.12"
+tracing-subscriber = "0.2.5"
 
 [[bin]]
 name = "coordinator"

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -1,15 +1,22 @@
 use xain_fl::client::{Client, ClientError};
 use xain_fl::participant::Task;
 use xain_fl::service::Service;
+use tracing_subscriber::*;
+
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
+    let _fmt_subscriber = FmtSubscriber::builder()
+        .with_ansi(true)
+        .init();
 
-    let (_svc, hdl) = Service::new().unwrap();
+
+    let (svc, hdl) = Service::new().unwrap();
+    let _svc_jh = tokio::spawn(svc);
 
     let mut tasks = vec![];
-    for _ in 0..50 {
-        let mut client = Client::new2(1, hdl.clone())?;
+    for id in 0..20 {
+        let mut client = Client::new2(1, hdl.clone(), id)?;
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move {
@@ -17,7 +24,7 @@ async fn main() -> Result<(), ClientError> {
         });
         tasks.push(join_hdl);
     }
-    println!("spawned 50 clients");
+    println!("spawned 20 clients");
 
     let mut summers = 0;
     let mut updaters = 0;

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -13,7 +13,7 @@ use tracing_subscriber::*;
 /// too few) participants will be selected here! It's currently not possible to
 /// configure or force the selection, hence as a TEMP workaround, these should
 /// be adjusted in coordinator.rs before running this test e.g. 0.2_f64 for sum
-/// and 0.5_f64 for update.
+/// and 0.4_f64 for update.
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
 

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -1,14 +1,26 @@
 use xain_fl::client::{Client, ClientError};
 use xain_fl::participant::Task;
 use xain_fl::service::Service;
-use tracing_subscriber::*;
+// use tracing_subscriber::*;
 
 
+/// Test-drive script of a (completely local) federated learning session,
+/// intended for use as a mini integration test. It spawns a Service and 20
+/// Clients on the tokio event loop.
+///
+/// important NOTE since we only test 20 Clients and by default, the selection
+/// ratios in the Coordinator are relatively small, it is very possible no (or
+/// too few) Participants will be selected here! It's currently not possible to
+/// configure or force the selection, hence as a TEMP workaround, these should
+/// be adjusted in coordinator.rs before running this test e.g. 0.2_f64 for sum
+/// and 0.5_f64 for update.
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
-    let _fmt_subscriber = FmtSubscriber::builder()
-        .with_ansi(true)
-        .init();
+
+    // FIXME logging seems to no longer work
+    // let _fmt_subscriber = FmtSubscriber::builder()
+    //     .with_ansi(true)
+    //     .init();
 
 
     let (svc, hdl) = Service::new().unwrap();
@@ -16,7 +28,7 @@ async fn main() -> Result<(), ClientError> {
 
     let mut tasks = vec![];
     for id in 0..20 {
-        let mut client = Client::new2(1, hdl.clone(), id)?;
+        let mut client = Client::new_with_id(1, hdl.clone(), id)?;
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move {

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -1,0 +1,52 @@
+use xain_fl::client::{Client, ClientError};
+use xain_fl::participant::Task;
+use xain_fl::service::Service;
+
+#[tokio::main]
+async fn main() -> Result<(), ClientError> {
+    // create a largeish number of clients
+    // do this in a loop: in each iteration,
+    // create a client c; spawn a task that runs c.per_round
+    // wait for them to finish
+    // if they all returned () ... that's as good as it gets for now
+    // error case easier to test: spawn too few
+    // "inbetween": dropouts
+
+    // tweak probabilities before actually running this
+    // print statements somehow would be nice
+    // later on it would be good to actually print a value to prove it's working
+    // e.g the global model
+
+//    let mut c = Client::new(1)?;
+//    let jh = tokio::spawn(c.per_round());
+
+    let (_svc, hdl) = Service::new().unwrap();
+
+    let mut tasks = vec![];
+    for _ in 0..50 {
+        let mut client = Client::new2(1, hdl.clone())?;
+        // NOTE give spawn a task that owns client
+        // otherwise it won't live long enough
+        let join_hdl = tokio::spawn(async move {
+            client.per_round().await
+        });
+        tasks.push(join_hdl);
+    }
+    println!("spawned 50 clients");
+
+    let mut summers = 0;
+    let mut updaters = 0;
+    let mut unselecteds = 0;
+    for task in tasks {
+        match task.await.or(Err(ClientError::GeneralErr))?? {
+            Task::Update => updaters    += 1,
+            Task::Sum    => summers     += 1,
+            Task::None   => unselecteds += 1,
+        }
+    }
+
+    println!("{} sum, {} update, {} unselected clients completed a round",
+             summers, updaters, unselecteds);
+
+    Ok(())
+}

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -4,9 +4,9 @@ use xain_fl::service::Service;
 // use tracing_subscriber::*;
 
 
-/// Test-drive script of a (completely local) federated learning session,
-/// intended for use as a mini integration test. It spawns a Service and 20
-/// Clients on the tokio event loop.
+/// Test-drive script of a (completely local) single-round federated learning
+/// session, intended for use as a mini integration test. It spawns a Service
+/// and 20 Clients on the tokio event loop.
 ///
 /// important NOTE since we only test 20 Clients and by default, the selection
 /// ratios in the Coordinator are relatively small, it is very possible no (or

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -4,21 +4,6 @@ use xain_fl::service::Service;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
-    // create a largeish number of clients
-    // do this in a loop: in each iteration,
-    // create a client c; spawn a task that runs c.per_round
-    // wait for them to finish
-    // if they all returned () ... that's as good as it gets for now
-    // error case easier to test: spawn too few
-    // "inbetween": dropouts
-
-    // tweak probabilities before actually running this
-    // print statements somehow would be nice
-    // later on it would be good to actually print a value to prove it's working
-    // e.g the global model
-
-//    let mut c = Client::new(1)?;
-//    let jh = tokio::spawn(c.per_round());
 
     let (_svc, hdl) = Service::new().unwrap();
 

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<(), ClientError> {
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move {
-            client.per_round().await
+            client.during_round().await
         });
         tasks.push(join_hdl);
     }

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -6,14 +6,14 @@ use tracing_subscriber::*;
 
 /// Test-drive script of a (completely local) single-round federated learning
 /// session, intended for use as a mini integration test. It spawns a
-/// [`Service`] and 20 [`Client`]s on the tokio event loop.
+/// [`Service`] and 10 [`Client`]s on the tokio event loop.
 ///
-/// important NOTE since we only test 10 clients and by default, the selection
-/// ratios in the Coordinator are relatively small, it is very possible no (or
-/// too few) participants will be selected here! It's currently not possible to
-/// configure or force the selection, hence as a TEMP workaround, these should
-/// be adjusted in coordinator.rs before running this test e.g. 0.2_f64 for sum
-/// and 0.4_f64 for update.
+/// important NOTE since we only test a few clients and by default, the
+/// selection ratios in the Coordinator are relatively small, it is very
+/// possible no (or too few) participants will be selected here! It's currently
+/// not possible to configure or force the selection, hence as a TEMP
+/// workaround, these should be adjusted in coordinator.rs before running this
+/// test e.g. 0.2_f64 for sum and 0.4_f64 for update.
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
 

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -5,12 +5,12 @@ use tracing_subscriber::*;
 
 
 /// Test-drive script of a (completely local) single-round federated learning
-/// session, intended for use as a mini integration test. It spawns a Service
-/// and 20 Clients on the tokio event loop.
+/// session, intended for use as a mini integration test. It spawns a
+/// [`Service`] and 20 [`Client`]s on the tokio event loop.
 ///
-/// important NOTE since we only test 20 Clients and by default, the selection
+/// important NOTE since we only test 10 clients and by default, the selection
 /// ratios in the Coordinator are relatively small, it is very possible no (or
-/// too few) Participants will be selected here! It's currently not possible to
+/// too few) participants will be selected here! It's currently not possible to
 /// configure or force the selection, hence as a TEMP workaround, these should
 /// be adjusted in coordinator.rs before running this test e.g. 0.2_f64 for sum
 /// and 0.5_f64 for update.
@@ -27,7 +27,7 @@ async fn main() -> Result<(), ClientError> {
     let _svc_jh = tokio::spawn(svc);
 
     let mut tasks = vec![];
-    for id in 0..20 {
+    for id in 0..10 {
         let mut client = Client::new_with_id(1, hdl.clone(), id)?;
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -7,7 +7,9 @@ use xain_fl::{
 
 /// Test-drive script of a (completely local) single-round federated learning
 /// session, intended for use as a mini integration test. It spawns a
-/// [`Service`] and 10 [`Client`]s on the tokio event loop.
+/// [`Service`] and 10 [`Client`]s on the tokio event loop. This serves as a
+/// simple example of getting started with the project, and may later be the
+/// basis for more automated tests.
 ///
 /// important NOTE since we only test a few clients and by default, the
 /// selection ratios in the Coordinator are relatively small, it is very

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -1,7 +1,7 @@
 use xain_fl::client::{Client, ClientError};
 use xain_fl::participant::Task;
 use xain_fl::service::Service;
-// use tracing_subscriber::*;
+use tracing_subscriber::*;
 
 
 /// Test-drive script of a (completely local) single-round federated learning
@@ -17,10 +17,10 @@ use xain_fl::service::Service;
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
 
-    // FIXME logging seems to no longer work
-    // let _fmt_subscriber = FmtSubscriber::builder()
-    //     .with_ansi(true)
-    //     .init();
+    let _fmt_subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(true)
+        .init();
 
 
     let (svc, hdl) = Service::new().unwrap();

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -144,7 +144,7 @@ impl Client {
             .send_message(sum1_msg)
             .await;
 
-        let pk = self.participant.get_encr_pk();
+        let pk = self.participant.pk;
         let seed_dict_ser: Arc<Vec<u8>> = loop {
             if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
                 break seed_dict_ser

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,5 @@
-use extern crate::service::Handle;
-use extern crate::participant::Participant;
+use crate::service::Handle;
+use crate::participant::Participant;
 
 /// TODO
 pub struct Client {

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,71 +1,92 @@
 use crate::service::Handle;
 use crate::participant::{Participant, Task};
-use crate::{CoordinatorPublicKey, SeedDict, SumDict};
+use crate::{CoordinatorPublicKey, SeedDict, SumDict, PetError};
 use sodiumoxide::crypto::box_;
 use std::sync::Arc;
 use std::collections::HashMap;
-
 use std::future::Future;
 use std::pin::Pin;
 
-/// TODO
+
+/// Client-side errors
+pub enum ClientError {
+    /// Error from the underlying `Participant`
+    ParticipantErr(PetError),
+    /// The round is not yet ready
+    RoundNotReady,
+    /// Not all sums are ready
+    SumsNotReady,
+    /// Not all updates are ready
+    UpdatesNotReady,
+}
+
+/// A client of the federated learning service
 pub struct Client {
     handle: Handle,
     particip: Participant,
     // coord_encr_pk: Option<box_::PublicKey>,
+    // TODO global model
 }
 
 impl Client {
+
     /// Create a new `Client`
-    pub fn new() -> Self {
+    pub fn new() -> Result<Self, ClientError> {
         let (handle, _events) = Handle::new();
-        match Participant::new() {
-            Err(err) => panic!(err),
-            Ok(particip) => Self {
-                handle,
-                particip,
-                // coord_encr_pk: None,
+        let particip = Participant::new()
+            .map_err(ClientError::ParticipantErr)?;
+        Ok(Self {
+            handle,
+            particip,
+            // coord_encr_pk: None,
+        })
+    }
+
+    /// Start the `Client`
+    pub async fn start(&mut self) -> Result<(), ClientError> {
+        loop {
+            match self.per_round().await {
+                Ok(()) => continue,
+                // at the moment, any error finishes off the client
+                error  => return error,
             }
         }
     }
 
-    /// TODO
-    pub fn start(&mut self) {
-        // self.pre_round()
-    }
-
-    fn pre_round(&mut self) -> Pin<Box<dyn Future<Output = Option<()>>>> {
-        Box::pin(async move {
-            let round_params = self.handle
-                .get_round_parameters()
-                .await?;
-            let coord_pk = round_params.pk;
-            let round_seed: &[u8] = round_params.seed.as_slice();
-            self.particip
-                .compute_signatures(round_seed);
-            let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-            match self.particip.check_task(sum_frac, upd_frac) {
-                Task::Sum    =>
-                    self.summer(coord_pk)
-                    .await,
-                Task::Update =>
-                    self.updater(coord_pk)
-                    .await,
-                Task::None   =>
-                    self.unselected()
-                    .await,
-            }
-        })
-    }
-
-    async fn unselected(&mut self) -> Option<()> {
-        // TODO await global model; save it
-        // next round
-        self.pre_round()
+    /// Client duties within a round
+    async fn per_round(&mut self) -> Result<(), ClientError> {
+        let round_params = self.handle
+            .get_round_parameters()
             .await
+            .ok_or(ClientError::RoundNotReady)?;
+        let coord_pk = round_params.pk;
+        let round_seed: &[u8] = round_params.seed.as_slice();
+        self.particip
+            .compute_signatures(round_seed);
+        let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
+        match self.particip.check_task(sum_frac, upd_frac) {
+            Task::Sum    =>
+                self.summer(coord_pk)
+                    .await,
+            Task::Update =>
+                self.updater(coord_pk)
+                    .await,
+            Task::None   =>
+                self.unselected()
+                    .await,
+        }
     }
 
-    async fn summer(&mut self, coord_pk: CoordinatorPublicKey) -> Option<()> {
+    /// Duties for unselected clients
+    async fn unselected(&mut self) -> Result<(), ClientError> {
+        // TODO await global model; save it
+        // end of round
+        Ok(())
+    }
+
+    /// Duties for clients selected as summers
+    async fn summer(&mut self, coord_pk: CoordinatorPublicKey)
+                    -> Result<(), ClientError> {
         let sum1_msg: Vec<u8> = self.particip
             .compose_sum_message(&coord_pk);
         self.handle
@@ -74,14 +95,15 @@ impl Client {
         let _pk = self.particip.get_encr_pk();
         let _seed_dict: Arc<Vec<u8>> = self.handle
             .get_seed_dict() // later will need to pass pk
-            .await?;
+            .await
+            .ok_or(ClientError::UpdatesNotReady)?;
         // TODO deserialize the seed_dict
         let dummy_seed_dict: SeedDict = HashMap::new(); // FIXME
         // https://github.com/servo/bincode
         // bincode::deserialize(&seed_dict[..]).unwrap()
         let sum2_msg: Vec<u8> = self.particip
             .compose_sum2_message(&coord_pk, &dummy_seed_dict)
-            .ok()?;
+            .map_err(ClientError::ParticipantErr)?;
         self.handle
             .send_message(sum2_msg)
             .await;
@@ -91,15 +113,18 @@ impl Client {
             .await
     }
 
-    async fn updater(&mut self, coord_pk: CoordinatorPublicKey) -> Option<()> {
+    /// Duties for clients selected as updaters
+    async fn updater(&mut self, coord_pk: CoordinatorPublicKey)
+                     -> Result<(), ClientError> {
         // TODO train a model update...
         let _sum_dict: Arc<Vec<u8>> = self.handle
             .get_sum_dict()
-            .await?;
+            .await
+            .ok_or(ClientError::SumsNotReady)?;
         // TODO deserialise the sum dict
         let dummy_sum_dict: SumDict = HashMap::new(); // FIXME
         let upd_msg: Vec<u8> = self.particip
-            .compose_update_message(&coord_pk, &dummy_sum_dict);
+            .compose_update_message(&coord_pk, &dummy_sum_dict); // why not Result?
         self.handle
             .send_message(upd_msg)
             .await;
@@ -109,3 +134,5 @@ impl Client {
             .await
     }
 }
+
+// TODO main

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -66,7 +66,12 @@ impl Client {
         })
     }
 
-    // may replace new later with this
+    /// Create a new `Client` with ID (useful for testing)
+    ///
+    /// `period`: time period at which to poll for service data, in seconds.
+    /// `id`: an ID to assign to the `Client`.
+    /// Returns `Ok(client)` if `Client` `client` initialised successfully
+    /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new_with_id(period: u64, handle: Handle, id: u32) -> Result<Self, ClientError> {
         let participant = Participant::new()
             .map_err(ClientError::ParticipantInitErr)?;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,45 +1,68 @@
 use crate::service::Handle;
-use crate::participant::Participant;
+use crate::participant::{Participant, Task};
+use sodiumoxide::crypto::box_;
+use std::sync::Arc;
 
 /// TODO
 pub struct Client {
     handle: Handle,
-    participant: Participant,
+    particip: Participant,
+    coord_encr_pk: Option<box_::PublicKey>,
 }
 
 impl Client {
     /// Create a new `Client`
     pub fn new() -> Self {
         let (handle, _events) = Handle::new();
-        let participant = Participant::new();
-        Self {
-            handle,
-            participant,
+        match Participant::new() {
+            Err(err) => panic!(err),
+            Ok(particip) => Self {
+                handle,
+                particip,
+                coord_encr_pk: None,
+            }
         }
     }
 
     /// TODO
     pub fn start(&mut self) {
-        self.pre_round()
+        // self.pre_round()
     }
 
-    fn pre_round(&mut self) {
-        // TODO
-        match self.handle.get_round_parameters().await {
-            Some(round_params) => panic!(),
-            None => panic!(),
+    async fn pre_round(&mut self) -> Option<()> {
+        let round_params = self.handle
+            .get_round_parameters()
+            .await?;
+        self.coord_encr_pk = Some(round_params.encr_pk);
+        let round_seed: &[u8] = round_params.seed.as_slice();
+        self.particip
+            .compute_signatures(round_seed);
+        let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
+        match self.particip.check_task(sum_frac, upd_frac) {
+            Task::Sum    => self.summer().await,
+            Task::Update => self.updater(),
+            Task::None   => self.unselected(),
         }
     }
 
-    fn unselected(&mut self) {
-        // TODO
+    fn unselected(&mut self) -> Option<()> {
+        Some(())
     }
 
-    fn summer(&mut self) {
-        // TODO
+    async fn summer(&mut self) -> Option<()> {
+        let sum1_msg: Vec<u8> = self.particip
+            .compose_message_sum(&self.coord_encr_pk?);
+        self.handle
+            .send_message(sum1_msg)
+            .await;
+        let _pk = self.particip.get_encr_pk();
+        let _seed_dict: Arc<Vec<u8>> = self.handle
+            .get_seed_dict() // pass pk
+            .await?;
+        Some(())
     }
 
-    fn updater(&mut self) {
-        // TODO
+    fn updater(&mut self) -> Option<()> {
+        Some(())
     }
 }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -103,11 +103,11 @@ impl Client {
             {
                 break round_params
             }
-            println!("{}: round params not ready yet, retrying in a sec...", self.id);
+            println!("{}: round params not ready, retrying.", self.id); // TEMP
             self.interval.tick().await;
         };
         let round_seed: &[u8] = round_params.seed.as_slice();
-        println!("computing sigs and checking task");
+        println!("computing sigs and checking task"); // TEMP
         self.participant
             .compute_signatures(round_seed);
         let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
@@ -145,6 +145,7 @@ impl Client {
             if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
                 break seed_dict_ser
             }
+            println!("{}: seed dictionary not ready, retrying.", self.id); // TEMP
             // updates not yet ready, try again later...
             self.interval.tick().await;
         };
@@ -170,6 +171,7 @@ impl Client {
             if let Some(sum_dict_ser) = self.handle.get_sum_dict().await {
                 break sum_dict_ser
             }
+            println!("{}: sum dictionary not ready, retrying.", self.id); // TEMP
             // sums not yet ready, try again later...
             self.interval.tick().await;
         };

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,0 +1,45 @@
+use extern crate::service::Handle;
+use extern crate::participant::Participant;
+
+/// TODO
+pub struct Client {
+    handle: Handle,
+    participant: Participant,
+}
+
+impl Client {
+    /// Create a new `Client`
+    pub fn new() -> Self {
+        let (handle, _events) = Handle::new();
+        let participant = Participant::new();
+        Self {
+            handle,
+            participant,
+        }
+    }
+
+    /// TODO
+    pub fn start(&mut self) {
+        self.pre_round()
+    }
+
+    fn pre_round(&mut self) {
+        // TODO
+        match self.handle.get_round_parameters().await {
+            Some(round_params) => panic!(),
+            None => panic!(),
+        }
+    }
+
+    fn unselected(&mut self) {
+        // TODO
+    }
+
+    fn summer(&mut self) {
+        // TODO
+    }
+
+    fn updater(&mut self) {
+        // TODO
+    }
+}

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,13 +1,18 @@
 use crate::service::Handle;
 use crate::participant::{Participant, Task};
+use crate::{CoordinatorPublicKey, SeedDict, SumDict};
 use sodiumoxide::crypto::box_;
 use std::sync::Arc;
+use std::collections::HashMap;
+
+use std::future::Future;
+use std::pin::Pin;
 
 /// TODO
 pub struct Client {
     handle: Handle,
     particip: Participant,
-    coord_encr_pk: Option<box_::PublicKey>,
+    // coord_encr_pk: Option<box_::PublicKey>,
 }
 
 impl Client {
@@ -19,7 +24,7 @@ impl Client {
             Ok(particip) => Self {
                 handle,
                 particip,
-                coord_encr_pk: None,
+                // coord_encr_pk: None,
             }
         }
     }
@@ -29,40 +34,78 @@ impl Client {
         // self.pre_round()
     }
 
-    async fn pre_round(&mut self) -> Option<()> {
-        let round_params = self.handle
-            .get_round_parameters()
-            .await?;
-        self.coord_encr_pk = Some(round_params.encr_pk);
-        let round_seed: &[u8] = round_params.seed.as_slice();
-        self.particip
-            .compute_signatures(round_seed);
-        let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-        match self.particip.check_task(sum_frac, upd_frac) {
-            Task::Sum    => self.summer().await,
-            Task::Update => self.updater(),
-            Task::None   => self.unselected(),
-        }
+    fn pre_round(&mut self) -> Pin<Box<dyn Future<Output = Option<()>>>> {
+        Box::pin(async move {
+            let round_params = self.handle
+                .get_round_parameters()
+                .await?;
+            let coord_pk = round_params.pk;
+            let round_seed: &[u8] = round_params.seed.as_slice();
+            self.particip
+                .compute_signatures(round_seed);
+            let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
+            match self.particip.check_task(sum_frac, upd_frac) {
+                Task::Sum    =>
+                    self.summer(coord_pk)
+                    .await,
+                Task::Update =>
+                    self.updater(coord_pk)
+                    .await,
+                Task::None   =>
+                    self.unselected()
+                    .await,
+            }
+        })
     }
 
-    fn unselected(&mut self) -> Option<()> {
-        Some(())
+    async fn unselected(&mut self) -> Option<()> {
+        // TODO await global model; save it
+        // next round
+        self.pre_round()
+            .await
     }
 
-    async fn summer(&mut self) -> Option<()> {
+    async fn summer(&mut self, coord_pk: CoordinatorPublicKey) -> Option<()> {
         let sum1_msg: Vec<u8> = self.particip
-            .compose_message_sum(&self.coord_encr_pk?);
+            .compose_sum_message(&coord_pk);
         self.handle
             .send_message(sum1_msg)
             .await;
         let _pk = self.particip.get_encr_pk();
         let _seed_dict: Arc<Vec<u8>> = self.handle
-            .get_seed_dict() // pass pk
+            .get_seed_dict() // later will need to pass pk
             .await?;
-        Some(())
+        // TODO deserialize the seed_dict
+        let dummy_seed_dict: SeedDict = HashMap::new(); // FIXME
+        // https://github.com/servo/bincode
+        // bincode::deserialize(&seed_dict[..]).unwrap()
+        let sum2_msg: Vec<u8> = self.particip
+            .compose_sum2_message(&coord_pk, &dummy_seed_dict)
+            .ok()?;
+        self.handle
+            .send_message(sum2_msg)
+            .await;
+
+        // job done, unselect
+        self.unselected()
+            .await
     }
 
-    fn updater(&mut self) -> Option<()> {
-        Some(())
+    async fn updater(&mut self, coord_pk: CoordinatorPublicKey) -> Option<()> {
+        // TODO train a model update...
+        let _sum_dict: Arc<Vec<u8>> = self.handle
+            .get_sum_dict()
+            .await?;
+        // TODO deserialise the sum dict
+        let dummy_sum_dict: SumDict = HashMap::new(); // FIXME
+        let upd_msg: Vec<u8> = self.particip
+            .compose_update_message(&coord_pk, &dummy_sum_dict);
+        self.handle
+            .send_message(upd_msg)
+            .await;
+
+        // job done, unselect
+        self.unselected()
+            .await
     }
 }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -81,7 +81,6 @@ impl Client {
             }
             self.interval.tick().await;
         };
-        let coord_pk = round_params.pk;
         let round_seed: &[u8] = round_params.seed.as_slice();
         self.particip
             .compute_signatures(round_seed);
@@ -91,9 +90,9 @@ impl Client {
             .check_task(sum_frac, upd_frac)
         {
             Task::Sum    =>
-                self.summer(coord_pk).await,
+                self.summer(round_params.pk).await,
             Task::Update =>
-                self.updater(coord_pk).await,
+                self.updater(round_params.pk).await,
             Task::None   =>
                 self.unselected().await,
         }
@@ -122,6 +121,7 @@ impl Client {
             if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
                 break seed_dict_ser
             }
+            // updates not yet ready, try again later...
             self.interval.tick().await;
         };
         let seed_dict: SeedDict = bincode::deserialize(&seed_dict_ser[..])
@@ -148,6 +148,7 @@ impl Client {
             if let Some(sum_dict_ser) = self.handle.get_sum_dict().await {
                 break sum_dict_ser
             }
+            // sums not yet ready, try again later...
             self.interval.tick().await;
         };
         let sum_dict: SumDict = bincode::deserialize(&sum_dict_ser[..])
@@ -164,3 +165,14 @@ impl Client {
             .await
     }
 }
+
+
+
+
+
+
+
+
+
+
+

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -55,7 +55,8 @@ impl Client {
 
     /// Client duties within a round
     async fn per_round(&mut self) -> Result<(), ClientError> {
-        let round_params = self.handle
+        let round_params = self
+            .handle
             .get_round_parameters()
             .await
             .ok_or(ClientError::RoundNotReady)?;
@@ -66,14 +67,11 @@ impl Client {
         let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
         match self.particip.check_task(sum_frac, upd_frac) {
             Task::Sum    =>
-                self.summer(coord_pk)
-                    .await,
+                self.summer(coord_pk).await,
             Task::Update =>
-                self.updater(coord_pk)
-                    .await,
+                self.updater(coord_pk).await,
             Task::None   =>
-                self.unselected()
-                    .await,
+                self.unselected().await,
         }
     }
 
@@ -117,14 +115,16 @@ impl Client {
     async fn updater(&mut self, coord_pk: CoordinatorPublicKey)
                      -> Result<(), ClientError> {
         // TODO train a model update...
-        let _sum_dict: Arc<Vec<u8>> = self.handle
+        let _sum_dict: Arc<Vec<u8>> = self
+            .handle
             .get_sum_dict()
             .await
             .ok_or(ClientError::SumsNotReady)?;
         // TODO deserialise the sum dict
         let dummy_sum_dict: SumDict = HashMap::new(); // FIXME
-        let upd_msg: Vec<u8> = self.particip
-            .compose_update_message(&coord_pk, &dummy_sum_dict); // why not Result?
+        let upd_msg: Vec<u8> = self
+            .particip
+            .compose_update_message(&coord_pk, &dummy_sum_dict);
         self.handle
             .send_message(upd_msg)
             .await;

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -24,13 +24,15 @@ pub enum ClientError {
 pub struct Client {
     handle: Handle,
     particip: Participant,
-    // coord_encr_pk: Option<box_::PublicKey>,
     // TODO global model
 }
 
 impl Client {
 
     /// Create a new `Client`
+    ///
+    /// Returns `Ok(client)` if `Client` `client` initialised successfully
+    /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new() -> Result<Self, ClientError> {
         let (handle, _events) = Handle::new();
         let particip = Participant::new()
@@ -38,14 +40,16 @@ impl Client {
         Ok(Self {
             handle,
             particip,
-            // coord_encr_pk: None,
         })
     }
 
-    /// Start the `Client`
+    /// Start the `Client` loop
+    ///
+    /// Returns `Err(err)` if `ClientError` `err` occurred
     pub async fn start(&mut self) -> Result<(), ClientError> {
         loop {
             match self.per_round().await {
+                // round completed successfully
                 Ok(()) => continue,
                 // at the moment, any error finishes off the client
                 error  => return error,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,75 +1,95 @@
 use crate::service::Handle;
+use crate::coordinator::RoundParameters;
 use crate::participant::{Participant, Task};
-use crate::{CoordinatorPublicKey, SeedDict, SumDict, PetError};
+use crate::{CoordinatorPublicKey, SeedDict, SumDict, PetError, InitError};
 use sodiumoxide::crypto::box_;
 use std::sync::Arc;
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use tokio::time;
+use std::time::Duration;
 
 
 /// Client-side errors
 pub enum ClientError {
+    /// Error starting the underlying `Participant`
+    ParticipantInitErr(InitError),
+
     /// Error from the underlying `Participant`
     ParticipantErr(PetError),
-    /// The round is not yet ready
-    RoundNotReady,
-    /// Not all sums are ready
-    SumsNotReady,
-    /// Not all updates are ready
-    UpdatesNotReady,
+
+    /// Error deserialising service data
+    DeserialiseErr(bincode::Error),
 }
 
 /// A client of the federated learning service
+///
+/// `Client` is responsible for communicating with the service, deserialising
+/// its messages and delegating their processing to the underlying `Participant`.
 pub struct Client {
+    /// Handle to the federated learning `Service`
     handle: Handle,
+
+    /// The underlying `Participant`
     particip: Participant,
+
+    /// Interval to poll for service data
+    interval: time::Interval,
+
     // TODO global model
 }
 
 impl Client {
-
     /// Create a new `Client`
     ///
+    /// `period`: time period at which to poll for service data, in seconds.
     /// Returns `Ok(client)` if `Client` `client` initialised successfully
     /// Returns `Err(err)` if `ClientError` `err` occurred
-    pub fn new() -> Result<Self, ClientError> {
+    pub fn new(period: u64) -> Result<Self, ClientError> {
         let (handle, _events) = Handle::new();
         let particip = Participant::new()
-            .map_err(ClientError::ParticipantErr)?;
+            .map_err(ClientError::ParticipantInitErr)?;
         Ok(Self {
             handle,
             particip,
+            interval: time::interval(Duration::from_secs(period)),
         })
     }
 
     /// Start the `Client` loop
     ///
     /// Returns `Err(err)` if `ClientError` `err` occurred
+    /// NOTE in the future this may iterate only a fixed number of times, at the
+    /// end of which this returns `Ok(())`
     pub async fn start(&mut self) -> Result<(), ClientError> {
         loop {
-            match self.per_round().await {
-                // round completed successfully
-                Ok(()) => continue,
-                // at the moment, any error finishes off the client
-                error  => return error,
+            // any error that bubbles up will finish off the client
+            if let Err(e) = self.per_round().await {
+                break Err(e)
             }
         }
     }
 
     /// Client duties within a round
     async fn per_round(&mut self) -> Result<(), ClientError> {
-        let round_params = self
-            .handle
-            .get_round_parameters()
-            .await
-            .ok_or(ClientError::RoundNotReady)?;
+        let round_params: Arc<RoundParameters> = loop {
+            if let Some(round_params) =
+                self.handle.get_round_parameters().await
+            {
+                break round_params
+            }
+            self.interval.tick().await;
+        };
         let coord_pk = round_params.pk;
         let round_seed: &[u8] = round_params.seed.as_slice();
         self.particip
             .compute_signatures(round_seed);
         let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-        match self.particip.check_task(sum_frac, upd_frac) {
+        match self
+            .particip
+            .check_task(sum_frac, upd_frac)
+        {
             Task::Sum    =>
                 self.summer(coord_pk).await,
             Task::Update =>
@@ -88,23 +108,27 @@ impl Client {
 
     /// Duties for clients selected as summers
     async fn summer(&mut self, coord_pk: CoordinatorPublicKey)
-                    -> Result<(), ClientError> {
-        let sum1_msg: Vec<u8> = self.particip
+                    -> Result<(), ClientError>
+    {
+        let sum1_msg: Vec<u8> = self
+            .particip
             .compose_sum_message(&coord_pk);
         self.handle
             .send_message(sum1_msg)
             .await;
-        let _pk = self.particip.get_encr_pk();
-        let _seed_dict: Arc<Vec<u8>> = self.handle
-            .get_seed_dict() // later will need to pass pk
-            .await
-            .ok_or(ClientError::UpdatesNotReady)?;
-        // TODO deserialize the seed_dict
-        let dummy_seed_dict: SeedDict = HashMap::new(); // FIXME
-        // https://github.com/servo/bincode
-        // bincode::deserialize(&seed_dict[..]).unwrap()
-        let sum2_msg: Vec<u8> = self.particip
-            .compose_sum2_message(&coord_pk, &dummy_seed_dict)
+
+        let pk = self.particip.get_encr_pk();
+        let seed_dict_ser: Arc<Vec<u8>> = loop {
+            if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
+                break seed_dict_ser
+            }
+            self.interval.tick().await;
+        };
+        let seed_dict: SeedDict = bincode::deserialize(&seed_dict_ser[..])
+            .map_err(ClientError::DeserialiseErr)?;
+        let sum2_msg: Vec<u8> = self
+            .particip
+            .compose_sum2_message(&coord_pk, &seed_dict)
             .map_err(ClientError::ParticipantErr)?;
         self.handle
             .send_message(sum2_msg)
@@ -117,18 +141,20 @@ impl Client {
 
     /// Duties for clients selected as updaters
     async fn updater(&mut self, coord_pk: CoordinatorPublicKey)
-                     -> Result<(), ClientError> {
+                     -> Result<(), ClientError>
+    {
         // TODO train a model update...
-        let _sum_dict: Arc<Vec<u8>> = self
-            .handle
-            .get_sum_dict()
-            .await
-            .ok_or(ClientError::SumsNotReady)?;
-        // TODO deserialise the sum dict
-        let dummy_sum_dict: SumDict = HashMap::new(); // FIXME
+        let sum_dict_ser: Arc<Vec<u8>> = loop {
+            if let Some(sum_dict_ser) = self.handle.get_sum_dict().await {
+                break sum_dict_ser
+            }
+            self.interval.tick().await;
+        };
+        let sum_dict: SumDict = bincode::deserialize(&sum_dict_ser[..])
+            .map_err(ClientError::DeserialiseErr)?;
         let upd_msg: Vec<u8> = self
             .particip
-            .compose_update_message(&coord_pk, &dummy_sum_dict);
+            .compose_update_message(&coord_pk, &sum_dict);
         self.handle
             .send_message(upd_msg)
             .await;
@@ -138,5 +164,3 @@ impl Client {
             .await
     }
 }
-
-// TODO main

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,14 +1,17 @@
-use crate::crypto::ByteObject;
-use crate::service::Handle;
-use crate::coordinator::RoundParameters;
-use crate::participant::{Participant, Task};
-use crate::{CoordinatorPublicKey, SumDict, PetError, InitError};
-use crate::UpdateSeedDict;
-use std::sync::Arc;
-use tokio::time;
-use std::time::Duration;
+use crate::{
+    coordinator::RoundParameters,
+    crypto::ByteObject,
+    participant::{Participant, Task},
+    service::Handle,
+    CoordinatorPublicKey,
+    InitError,
+    PetError,
+    SumDict,
+    UpdateSeedDict,
+};
+use std::{sync::Arc, time::Duration};
 use thiserror::Error;
-
+use tokio::time;
 
 /// Client-side errors
 #[derive(Debug, Error)]
@@ -56,8 +59,7 @@ impl Client {
     /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new(period: u64) -> Result<Self, ClientError> {
         let (handle, _events) = Handle::new();
-        let participant = Participant::new()
-            .map_err(ClientError::ParticipantInitErr)?;
+        let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
         Ok(Self {
             handle,
             participant,
@@ -73,8 +75,7 @@ impl Client {
     /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
     /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new_with_id(period: u64, handle: Handle, id: u32) -> Result<Self, ClientError> {
-        let participant = Participant::new()
-            .map_err(ClientError::ParticipantInitErr)?;
+        let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
         Ok(Self {
             handle,
             participant,
@@ -98,29 +99,20 @@ impl Client {
     /// [`Client`] duties within a round
     pub async fn during_round(&mut self) -> Result<Task, ClientError> {
         let round_params: Arc<RoundParameters> = loop {
-            if let Some(round_params) =
-                self.handle.get_round_parameters().await
-            {
-                break round_params
+            if let Some(round_params) = self.handle.get_round_parameters().await {
+                break round_params;
             }
             debug!(client_id = %self.id, "round params not ready, retrying.");
             self.interval.tick().await;
         };
         let round_seed: &[u8] = round_params.seed.as_slice();
         debug!(client_id = %self.id, "computing sigs and checking task");
-        self.participant
-            .compute_signatures(round_seed);
+        self.participant.compute_signatures(round_seed);
         let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-        match self
-            .participant
-            .check_task(sum_frac, upd_frac)
-        {
-            Task::Sum    =>
-                self.summer(round_params.pk).await,
-            Task::Update =>
-                self.updater(round_params.pk).await,
-            Task::None   =>
-                self.unselected().await,
+        match self.participant.check_task(sum_frac, upd_frac) {
+            Task::Sum => self.summer(round_params.pk).await,
+            Task::Update => self.updater(round_params.pk).await,
+            Task::None => self.unselected().await,
         }
     }
 
@@ -131,53 +123,42 @@ impl Client {
     }
 
     /// Duties for [`Client`]s selected as summers
-    async fn summer(&mut self, coord_pk: CoordinatorPublicKey)
-                    -> Result<Task, ClientError>
-    {
+    async fn summer(&mut self, coord_pk: CoordinatorPublicKey) -> Result<Task, ClientError> {
         info!(client_id = %self.id, "selected for sum, sending sum message.");
-        let sum1_msg: Vec<u8> = self
-            .participant
-            .compose_sum_message(&coord_pk);
-        self.handle
-            .send_message(sum1_msg)
-            .await;
+        let sum1_msg: Vec<u8> = self.participant.compose_sum_message(&coord_pk);
+        self.handle.send_message(sum1_msg).await;
 
         let pk = self.participant.pk;
         let seed_dict_ser: Arc<Vec<u8>> = loop {
             if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
-                break seed_dict_ser
+                break seed_dict_ser;
             }
             debug!(client_id = %self.id, "seed dictionary not ready, retrying.");
             // updates not yet ready, try again later...
             self.interval.tick().await;
         };
         debug!(client_id = %self.id, "seed dictionary received");
-        let seed_dict: UpdateSeedDict =
-            bincode::deserialize(&seed_dict_ser[..]).map_err(|e| {
-                error!(
-                    "failed to deserialize seed dictionary: {}: {:?}",
-                    e,
-                    &seed_dict_ser[..],
-                );
-                ClientError::DeserialiseErr(e)
-            })?;
+        let seed_dict: UpdateSeedDict = bincode::deserialize(&seed_dict_ser[..]).map_err(|e| {
+            error!(
+                "failed to deserialize seed dictionary: {}: {:?}",
+                e,
+                &seed_dict_ser[..],
+            );
+            ClientError::DeserialiseErr(e)
+        })?;
         debug!(client_id = %self.id, "sending sum2 message");
         let sum2_msg: Vec<u8> = self
             .participant
             .compose_sum2_message(coord_pk, &seed_dict)
             .map_err(ClientError::ParticipantErr)?;
-        self.handle
-            .send_message(sum2_msg)
-            .await;
+        self.handle.send_message(sum2_msg).await;
 
         info!(client_id = %self.id, "sum participant completed a round");
         Ok(Task::Sum)
     }
 
     /// Duties for [`Client`]s selected as updaters
-    async fn updater(&mut self, coord_pk: CoordinatorPublicKey)
-                     -> Result<Task, ClientError>
-    {
+    async fn updater(&mut self, coord_pk: CoordinatorPublicKey) -> Result<Task, ClientError> {
         info!(client_id = %self.id, "selected to update");
 
         // currently, models are not yet supported fully; later on, we should
@@ -185,28 +166,23 @@ impl Client {
 
         let sum_dict_ser: Arc<Vec<u8>> = loop {
             if let Some(sum_dict_ser) = self.handle.get_sum_dict().await {
-                break sum_dict_ser
+                break sum_dict_ser;
             }
             debug!(client_id = %self.id, "sum dictionary not ready, retrying.");
             // sums not yet ready, try again later...
             self.interval.tick().await;
         };
-        let sum_dict: SumDict = bincode::deserialize(&sum_dict_ser[..])
-            .map_err(|e| {
-                error!(
-                    "failed to deserialize sum dictionary: {}: {:?}",
-                    e,
-                    &sum_dict_ser[..],
-                );
-                ClientError::DeserialiseErr(e)
-            })?;
+        let sum_dict: SumDict = bincode::deserialize(&sum_dict_ser[..]).map_err(|e| {
+            error!(
+                "failed to deserialize sum dictionary: {}: {:?}",
+                e,
+                &sum_dict_ser[..],
+            );
+            ClientError::DeserialiseErr(e)
+        })?;
         debug!(client_id = %self.id, "sum dictionary received, sending update message.");
-        let upd_msg: Vec<u8> = self
-            .participant
-            .compose_update_message(coord_pk, &sum_dict);
-        self.handle
-            .send_message(upd_msg)
-            .await;
+        let upd_msg: Vec<u8> = self.participant.compose_update_message(coord_pk, &sum_dict);
+        self.handle.send_message(upd_msg).await;
 
         info!(client_id = %self.id, "update participant completed a round");
         Ok(Task::Update)

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -93,12 +93,12 @@ impl Client {
     pub async fn start(&mut self) -> Result<(), ClientError> {
         loop {
             // any error that bubbles up will finish off the client
-            self.per_round().await?;
+            self.during_round().await?;
         }
     }
 
     /// [`Client`] duties within a round
-    pub async fn per_round(&mut self) -> Result<Task, ClientError> {
+    pub async fn during_round(&mut self) -> Result<Task, ClientError> {
         let round_params: Arc<RoundParameters> = loop {
             if let Some(round_params) =
                 self.handle.get_round_parameters().await

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -204,6 +204,8 @@ impl Coordinator {
         }
     }
 
+    // FIXME: we should abort the round if the `handle_xxx` handlers
+    // return an error
     /// Validate and handle a sum, update or sum2 message.
     pub fn handle_message(&mut self, bytes: &[u8]) -> Result<(), PetError> {
         let message = self
@@ -212,11 +214,18 @@ impl Coordinator {
             .map_err(|_| PetError::InvalidMessage)?;
         let participant_pk = message.header.participant_pk;
         match (self.phase, message.payload) {
-            (Phase::Sum, PayloadOwned::Sum(msg)) => self.handle_sum_message(participant_pk, msg),
+            (Phase::Sum, PayloadOwned::Sum(msg)) => {
+                debug!("handling sum message");
+                self.handle_sum_message(participant_pk, msg)
+            }
             (Phase::Update, PayloadOwned::Update(msg)) => {
+                debug!("handling update message");
                 self.handle_update_message(participant_pk, msg)
             }
-            (Phase::Sum2, PayloadOwned::Sum2(msg)) => self.handle_sum2_message(participant_pk, msg),
+            (Phase::Sum2, PayloadOwned::Sum2(msg)) => {
+                debug!("handling sum2 message");
+                self.handle_sum2_message(participant_pk, msg)
+            }
             _ => Err(PetError::InvalidMessage),
         }?;
         // HACK possibly not relevant now - in an earlier version at least, this
@@ -248,16 +257,31 @@ impl Coordinator {
             local_seed_dict,
             masked_model,
         } = message;
-        self.validate_update_task(&pk, &sum_signature, &update_signature)?;
+        debug!("validating signature for the update task");
+        if self
+            .validate_update_task(&pk, &sum_signature, &update_signature)
+            .is_err()
+        {
+            warn!("invalid signature for update task, ignoring update message");
+            return Ok(());
+        }
 
         // Try to update local seed dict first. If this fail, we do
         // not want to aggregate the model.
-        self.add_local_seed_dict(&pk, &local_seed_dict)?;
+        debug!("updating the global seed dictionary");
+        if self.add_local_seed_dict(&pk, &local_seed_dict).is_err() {
+            warn!("invalid local seed dictionary, ignoring update message");
+            return Ok(());
+        }
 
         // Check if aggregation can be performed, and do it.
+        debug!("aggregating masked model");
         self.aggregation
             .validate_aggregation(&masked_model)
-            .map_err(|_| PetError::InvalidMessage)?;
+            .map_err(|e| {
+                warn!("aggregation error: {}", e);
+                PetError::InvalidMessage
+            })?;
         self.aggregation.aggregate(masked_model);
         Ok(())
     }
@@ -434,6 +458,7 @@ impl Coordinator {
             }
             Phase::Sum => {
                 if self.has_enough_sums() {
+                    info!("enough sum participants to proceed to the update phase");
                     self.proceed_update_phase();
                     self.try_phase_transition();
                 }

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -140,8 +140,8 @@ impl Default for Coordinator {
     fn default() -> Self {
         let pk = CoordinatorPublicKey::zeroed();
         let sk = CoordinatorSecretKey::zeroed();
-        let sum = 0.01_f64;
-        let update = 0.1_f64;
+        let sum = 0.2_f64;
+        let update = 0.5_f64;
         let seed = RoundSeed::zeroed();
         let min_sum = 1_usize;
         let min_update = 3_usize;

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -141,7 +141,7 @@ impl Default for Coordinator {
         let pk = CoordinatorPublicKey::zeroed();
         let sk = CoordinatorSecretKey::zeroed();
         let sum = 0.2_f64;
-        let update = 0.5_f64;
+        let update = 0.4_f64;
         let seed = RoundSeed::zeroed();
         let min_sum = 1_usize;
         let min_update = 3_usize;

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -140,8 +140,8 @@ impl Default for Coordinator {
     fn default() -> Self {
         let pk = CoordinatorPublicKey::zeroed();
         let sk = CoordinatorSecretKey::zeroed();
-        let sum = 0.2_f64;
-        let update = 0.4_f64;
+        let sum = 0.01_f64;
+        let update = 0.1_f64;
         let seed = RoundSeed::zeroed();
         let min_sum = 1_usize;
         let min_update = 3_usize;

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -218,7 +218,11 @@ impl Coordinator {
             }
             (Phase::Sum2, PayloadOwned::Sum2(msg)) => self.handle_sum2_message(participant_pk, msg),
             _ => Err(PetError::InvalidMessage),
-        }
+        }?;
+        // HACK possibly not relevant now - in an earlier version at least, this
+        // was neceassary to "kickstart" the transitioning
+        self.try_phase_transition();
+        Ok(())
     }
 
     /// Validate and handle a sum message.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -89,5 +89,7 @@ pub type LocalSeedDict = HashMap<SumParticipantPublicKey, mask::EncryptedMaskSee
 /// A dictionary created during the update phase of the protocol. The global seed dictionary is
 /// built from the local seed dictionaries sent by the update participants. It maps each sum
 /// participant to the encrypted masking seeds of all the update participants.
-pub type SeedDict =
-    HashMap<SumParticipantPublicKey, HashMap<UpdateParticipantPublicKey, mask::EncryptedMaskSeed>>;
+pub type SeedDict = HashMap<SumParticipantPublicKey, UpdateSeedDict>;
+
+/// Values of [`SeedDict`]. Sent to sum participants.
+pub type UpdateSeedDict = HashMap<UpdateParticipantPublicKey, mask::EncryptedMaskSeed>;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -7,6 +7,7 @@ extern crate serde;
 extern crate tracing;
 
 pub mod certificate;
+pub mod client;
 pub mod coordinator;
 pub mod crypto;
 pub mod mask;

--- a/rust/src/message/message.rs
+++ b/rust/src/message/message.rs
@@ -133,7 +133,7 @@ impl<'a, 'b> MessageSeal<'a, 'b> {
     {
         let signed_payload_length = message.buffer_length() + Signature::LENGTH;
 
-        let mut buffer = Vec::with_capacity(signed_payload_length);
+        let mut buffer = vec![0; signed_payload_length];
         message.to_bytes(&mut &mut buffer[Signature::LENGTH..]);
 
         let signature = self.sender_sk.sign_detached(&buffer[Signature::LENGTH..]);

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -90,6 +90,7 @@ impl Participant {
         })
     }
 
+    /// Get encryption public key.
     pub fn get_encr_pk(&self) -> ParticipantPublicKey {
        self.pk
     }

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -30,9 +30,9 @@ use crate::{
     SumParticipantEphemeralSecretKey,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 /// Tasks of a participant.
-enum Task {
+pub enum Task {
     Sum,
     Update,
     None,
@@ -90,6 +90,10 @@ impl Participant {
         })
     }
 
+    pub fn get_encr_pk(&self) -> ParticipantPublicKey {
+       self.pk
+    }
+
     /// Compute the sum and update signatures.
     pub fn compute_signatures(&mut self, round_seed: &[u8]) {
         self.sum_signature = self.sk.sign_detached(&[round_seed, b"sum"].concat());
@@ -97,7 +101,7 @@ impl Participant {
     }
 
     /// Check eligibility for a task.
-    pub fn check_task(&mut self, round_sum: f64, round_update: f64) {
+    pub fn check_task(&mut self, round_sum: f64, round_update: f64) -> Task {
         if self.sum_signature.is_eligible(round_sum) {
             self.task = Task::Sum;
         } else if self.update_signature.is_eligible(round_update) {
@@ -105,6 +109,7 @@ impl Participant {
         } else {
             self.task = Task::None;
         }
+        self.task
     }
 
     /// Compose a sum message.

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -41,7 +41,7 @@ pub enum Task {
 /// A participant in the PET protocol layer.
 pub struct Participant {
     // credentials
-    pk: ParticipantPublicKey,                  // 32 bytes
+    pub(crate) pk: ParticipantPublicKey,       // 32 bytes
     sk: ParticipantSecretKey,                  // 64 bytes
     ephm_pk: SumParticipantEphemeralPublicKey, // 32 bytes
     ephm_sk: SumParticipantEphemeralSecretKey, // 32 bytes
@@ -88,11 +88,6 @@ impl Participant {
             sk,
             ..Default::default()
         })
-    }
-
-    /// Get encryption public key.
-    pub fn get_encr_pk(&self) -> ParticipantPublicKey {
-        self.pk
     }
 
     /// Compute the sum and update signatures.

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -1,4 +1,4 @@
-use std::{default::Default};
+use std::default::Default;
 
 use crate::{
     certificate::Certificate,

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -177,7 +177,7 @@ impl Participant {
 
     /// Generate a mask seed and mask a local model (dummy).
     fn mask_model() -> (MaskSeed, MaskObject) {
-        let model = Model::from_primitives(vec![0_i32, 1_i32, 2_i32, 3_i32].into_iter()).unwrap();
+        let model = Model::from_primitives(vec![0_f32, 1_f32, 2_f32, 3_f32].into_iter()).unwrap();
         let masker = Masker::new(dummy_config());
         let (seed, masked_model) = masker.mask(0.5, model);
         (seed, masked_model)
@@ -370,9 +370,9 @@ mod tests {
 
 fn dummy_config() -> MaskConfig {
     MaskConfig {
-        group_type: GroupType::Integer,
-        data_type: DataType::I32,
-        bound_type: BoundType::Bmax,
+        group_type: GroupType::Prime,
+        data_type: DataType::F32,
+        bound_type: BoundType::B0,
         model_type: ModelType::M3,
     }
 }

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -173,7 +173,7 @@ impl Participant {
 
     /// Generate a mask seed and mask a local model (dummy).
     fn mask_model() -> (MaskSeed, MaskObject) {
-        let model = Model::from_primitives(vec![0_f32, 1_f32, 2_f32, 3_f32].into_iter()).unwrap();
+        let model = Model::from_primitives(vec![0_f32, 1_f32, 0_f32, 1_f32].into_iter()).unwrap();
         let masker = Masker::new(dummy_config());
         let (seed, masked_model) = masker.mask(0.5, model);
         (seed, masked_model)

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -61,7 +61,8 @@ impl Service {
     }
 
     /// Handler for round parameters requests
-    fn handle_round_parameters_request(&self, req: RoundParametersRequest) {
+    fn handle_round_parameters_request(&mut self, req: RoundParametersRequest) {
+        self.coordinator.try_phase_transition(); // HACK get coordinator out of IDLE
         let RoundParametersRequest { response_tx } = req;
         let _ = response_tx.send(self.data.round_parameters());
     }


### PR DESCRIPTION
Introduces `Client` which can be thought of as a wrapper around `Participant`. It deals with the communication with the `Service`. Currently this is designed to only work _locally_ with a running `Service`, hence it works directly with a service `Handle`. Later this will be changed when it becomes fully network-capable. Also, this version does not yet support actual training of models.

This also adds a simple test driver to show clients running alongside a service.

References:
[PB-664](https://xainag.atlassian.net/browse/PB-664) (Participant with PET logic)
[PB-732](https://xainag.atlassian.net/browse/PB-732) (Integration test)