### PR TITLE
PB-735 ensure mask configuration before unmasking

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(or_patterns)]
 #![feature(const_fn)]
 #![feature(stmt_expr_attributes)]
+#![feature(option_unwrap_none)]
 
 #[macro_use]
 extern crate tracing;

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -86,15 +86,13 @@ pub trait Integers: Sized {
 
 /// Unmasking of vectors of arbitrarily large integers.
 pub trait MaskIntegers<N>: Integers {
-    /// Unmask the masked model with a mask. Fails if the mask configurations or the integer lengths
-    /// don't conform or the number of models is zero.
+    /// Unmask the masked model with a mask. Fails if the mask configuration is violated.
     fn unmask(&self, mask: &Mask, no_models: usize) -> Result<Model<N>, Self::Error>;
 
     /// Cast the ratios as numbers. Fails if a ratio is not representable as `N`.
     fn numbers_from(ratios: Vec<Ratio<BigInt>>) -> Option<Vec<N>>;
 
-    /// Unmask the masked numbers with a mask. Fails if the mask configurations or the integer
-    /// lengths don't conform or the number of models don't conform to the mask configuration.
+    /// Unmask the masked numbers with a mask. Fails if the mask configuration is violated.
     fn unmask_numbers(&self, mask: &Mask, no_models: usize) -> Result<Vec<N>, Self::Error> {
         let max_models = match self.config().name().model_type() {
             ModelType::M3 => 1_000,
@@ -162,8 +160,7 @@ impl Integers for MaskedModel {
 }
 
 impl MaskIntegers<f32> for MaskedModel {
-    /// Unmask the masked model with a mask. Fails if the mask configurations or the integer lengths
-    /// don't conform or the number of models is zero.
+    /// Unmask the masked model with a mask. Fails if the mask configuration is violated.
     fn unmask(&self, mask: &Mask, no_models: usize) -> Result<Model<f32>, PetError> {
         <Self as MaskIntegers<f32>>::unmask_numbers(&self, mask, no_models)?.try_into()
     }
@@ -175,8 +172,7 @@ impl MaskIntegers<f32> for MaskedModel {
 }
 
 impl MaskIntegers<f64> for MaskedModel {
-    /// Unmask the masked model with a mask. Fails if the mask configurations or the integer lengths
-    /// don't conform or the number of models is zero.
+    /// Unmask the masked model with a mask. Fails if the mask configuration is violated.
     fn unmask(&self, mask: &Mask, no_models: usize) -> Result<Model<f64>, PetError> {
         <Self as MaskIntegers<f64>>::unmask_numbers(&self, mask, no_models)?.try_into()
     }
@@ -188,8 +184,7 @@ impl MaskIntegers<f64> for MaskedModel {
 }
 
 impl MaskIntegers<i32> for MaskedModel {
-    /// Unmask the masked model with a mask. Fails if the mask configurations or the integer lengths
-    /// don't conform or the number of models is zero.
+    /// Unmask the masked model with a mask. Fails if the mask configuration is violated.
     fn unmask(&self, mask: &Mask, no_models: usize) -> Result<Model<i32>, PetError> {
         Ok(<Self as MaskIntegers<i32>>::unmask_numbers(&self, mask, no_models)?.into())
     }
@@ -204,8 +199,7 @@ impl MaskIntegers<i32> for MaskedModel {
 }
 
 impl MaskIntegers<i64> for MaskedModel {
-    /// Unmask the masked model with a mask. Fails if the mask configurations or the integer lengths
-    /// don't conform or the number of models is zero.
+    /// Unmask the masked model with a mask. Fails if the mask configuration is violated.
     fn unmask(&self, mask: &Mask, no_models: usize) -> Result<Model<i64>, PetError> {
         Ok(<Self as MaskIntegers<i64>>::unmask_numbers(&self, mask, no_models)?.into())
     }


### PR DESCRIPTION
**References**
- [PB-735](https://xainag.atlassian.net/browse/PB-735)

**Summary**
- fix a bug during unmasking by checking that the given `no_models` actually conforms to the chosen mask configuration. this checks that the `ModelType` of the mask config holds. the `GroupType`, `DataType` and `BoundType` hold because they're enforced via modulus addition.
- casting `numbers_from(ratios)` might fail if a ratio is not representable as the number's data type. this accounts for that the choice of the mask configuration should fit the models and the scalars, but it's not guaranteed to.

If unmasking fails with the new checks in place, then this should only ever happen if the aggregated model isn't representable in the primitive data type in the first place. This can happen due to the choice of the scalar and the model weights. Either way this is considered to be a faulty federated learning setup or attempted model poisoning and lies fully under control of the participants, therefore the current round should be aborted.