### PR TITLE
PB-718 Update CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -127,7 +127,6 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          components: rustfmt, clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -173,7 +172,6 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          components: rustfmt, clippy
 
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -204,10 +202,3 @@ jobs:
       - name: Stop docker-compose
         working-directory: ./docker
         run: docker-compose stop
-
-  test-container:
-    name: rustfmt
-    runs-on: ubuntu-latest
-    container: rustlang/rust:nightly
-    steps:
-      - uses: actions/checkout@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,39 @@ on: [push]
 name: Rust-CI
 
 jobs:
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: install nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: cargo fmt
+        working-directory: ./rust
+        run: cargo fmt --all -- --check
+
   check:
     name: rust-build
     runs-on: ubuntu-latest
@@ -16,48 +49,30 @@ jobs:
       - name: install nightly
         uses: actions-rs/toolchain@v1
         with:
-            profile: minimal
-            toolchain: nightly
+          profile: minimal
+          toolchain: nightly
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo check
         working-directory: ./rust
         env:
-            RUSTFLAGS: "-D warnings"
+          RUSTFLAGS: "-D warnings"
         run: cargo check --features ${{ matrix.features }}
-
-  test:
-    name: rust-test
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        features: [default]
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@master
-
-      - name: install nightly
-        uses: actions-rs/toolchain@v1
-        with:
-            profile: minimal
-            toolchain: nightly
-            components: rustfmt, clippy
-
-      - name: Setup Python 3.6
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.6
-
-      - name: build tests
-        working-directory: ./rust
-        env:
-            RUSTFLAGS: "-D warnings"
-        run: cargo test --features ${{ matrix.features }} --no-run
-
-      - name: run tests
-        working-directory: ./rust
-        env:
-            RUSTFLAGS: "-D warnings"
-        run: cargo test --features ${{ matrix.features }}
 
   clippy:
     name: rust-clippy
@@ -68,21 +83,41 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@master
+
       - name: install nightly
         uses: actions-rs/toolchain@v1
         with:
-            profile: minimal
-            toolchain: nightly
-            components: clippy
+          profile: minimal
+          toolchain: nightly
+          components: clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
       - name: cargo clippy
         working-directory: ./rust
         run: cargo clippy --features ${{ matrix.features }} -- -D warnings
 
-  rustfmt:
-    name: rustfmt
+  test:
+    name: rust-test
     runs-on: ubuntu-latest
+
     strategy:
+      matrix:
+        features: [default]
       fail-fast: true
     steps:
       - uses: actions/checkout@master
@@ -90,10 +125,82 @@ jobs:
       - name: install nightly
         uses: actions-rs/toolchain@v1
         with:
-            profile: minimal
-            toolchain: nightly
-            components: rustfmt
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt, clippy
 
-      - name: cargo fmt
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build tests
         working-directory: ./rust
-        run: cargo fmt --all -- --check
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo test --features ${{ matrix.features }} --no-run
+
+      - name: Run unit tests
+        working-directory: ./rust
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo test --features ${{ matrix.features }}
+
+  smoke-test:
+    name: rust-smoke-test
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        features: [default]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@master
+
+      - name: install nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Start docker-compose
+        working-directory: ./docker
+        run: docker-compose up -d
+
+      - name: Run smoke tests
+        working-directory: ./rust
+        env:
+          RUSTFLAGS: "-D warnings"
+        run: cargo test -- --test-threads=1 --ignored
+
+      - name: Stop docker-compose
+        working-directory: ./docker
+        run: docker-compose stop

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -204,3 +204,10 @@ jobs:
       - name: Stop docker-compose
         working-directory: ./docker
         run: docker-compose stop
+
+  test-container:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    container: rustlang/rust:nightly
+    steps:
+      - uses: actions/checkout@master

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: install nightly
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: install nightly
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: install nightly
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: install nightly
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: install nightly
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,177 +1,20 @@
 version: "3.7"
 services:
-
-  influxdb:
-    image: influxdb:1.7 # current stable version, v2 is in Beta
-    hostname: influxdb
+  minio:
+    image: minio/minio # Stable minio
+    volumes:
+      - minio-data:/data
+    networks:
+      - xain-fl-rs
     environment:
-      INFLUXDB_DB: metrics
-    volumes:
-      - influxdb-data:/var/lib/influxdb
-    networks:
-      - xain-fl-rs
+      MINIO_ACCESS_KEY: minio
+      MINIO_SECRET_KEY: minio123
+    command: server /data
     ports:
-      - "8086:8086"
-    labels:
-      org.label-schema.group: "monitoring"
-
-  coordinator:
-    command: coordinator -c /bin/config.toml
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-    image: docker_coordinator:debug
-    depends_on:
-      - influxdb
-    volumes:
-      - ${PWD}/configs/docker-dev-coordinator.toml:/bin/config.toml
-    networks:
-      - xain-fl-rs
-    ports:
-      - "5555:5555"
-      - "8081:8081"
-
-  aggregator:
-    command: aggregator -c /bin/config.toml
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-    image: docker_aggregator:debug
-    depends_on:
-      - influxdb
-    volumes:
-      - ${PWD}/configs/docker-dev-aggregator.toml:/bin/config.toml
-    networks:
-      - xain-fl-rs
-    ports:
-      - "6666:6666"
-      - "8082:8082"
-
-  prometheus:
-    image: prom/prometheus:v2.16.0
-    container_name: prometheus
-    volumes:
-      - ${PWD}/docker/prometheus:/etc/prometheus
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
-      - '--web.enable-lifecycle'
-    restart: unless-stopped
-    expose:
-      - 9090
-    networks:
-      - xain-fl-rs
-    labels:
-      org.label-schema.group: "monitoring"
-
-  nodeexporter:
-    image: prom/node-exporter:v0.18.1
-    container_name: nodeexporter
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
-    restart: unless-stopped
-    expose:
-      - 9100
-    networks:
-      - xain-fl-rs
-    labels:
-      org.label-schema.group: "monitoring"
-
-  cadvisor:
-    image: gcr.io/google-containers/cadvisor:v0.34.0
-    container_name: cadvisor
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:rw
-      - /sys:/sys:ro
-      - /var/lib/docker:/var/lib/docker:ro
-      #- /cgroup:/cgroup:ro #doesn't work on MacOS only for Linux
-    restart: unless-stopped
-    expose:
-      - 8080
-    networks:
-      - xain-fl-rs
-    labels:
-      org.label-schema.group: "monitoring"
-
-  grafana:
-    image: grafana/grafana:6.6.2
-    container_name: grafana
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ${PWD}/docker/grafana/provisioning:/etc/grafana/provisioning
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-      - GF_USERS_ALLOW_SIGN_UP=false
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    networks:
-      - xain-fl-rs
-    labels:
-      org.label-schema.group: "monitoring"
-
-  pushgateway:
-    image: prom/pushgateway:v1.1.0
-    container_name: pushgateway
-    restart: unless-stopped
-    expose:
-      - 9091
-    networks:
-      - xain-fl-rs
-    labels:
-      org.label-schema.group: "monitoring"
-
-  # https://www.jaegertracing.io/docs/1.17/getting-started/#all-in-one
-  jaeger:
-    image: jaegertracing/all-in-one:1.17
-    environment:
-      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
-    ports:
-      - "5775:5775"
-      - "6831:6831"
-      - "6832:6832"
-      - "5778:5778"
-      - "16686:16686"
-      - "14268:14268"
-      - "14250:14250"
-      - "9411:9411"
-    networks:
-      - xain-fl-rs
-
-  swagger:
-    image: swaggerapi/swagger-ui
-    environment:
-      - SWAGGER_JSON=/coordinator.yml
-    volumes:
-      - ${PWD}/swagger/coordinator.yml:/coordinator.yml
-      # The run script copies the specified file of "SWAGGER_JSON" (in our case coordinator.yml)
-      # to /usr/share/nginx/html. It is not possible to specify a directory here.
-      # (https://github.com/swagger-api/swagger-ui/blob/master/docker/run.sh)
-      # We mount the aggregator.yml directly into this directory so that we can
-      # access both yml files in the swagger ui.
-      - ${PWD}/swagger/aggregator.yml:/usr/share/nginx/html/aggregator.yml
-    ports:
-      - 80:8080
-    networks:
-      - xain-fl-rs
+      - "9000:9000"
 
 volumes:
-  influxdb-data: {}
-  prometheus_data: {}
-  grafana_data: {}
+  minio-data:
 
 networks:
   xain-fl-rs:


### PR DESCRIPTION
**References**

* [PB-718](https://xainag.atlassian.net/browse/PB-718)
* [PB-717](https://xainag.atlassian.net/browse/PB-717)

**Summary**

1. Updated docker-compose file:
   - Removed all existing services
   - Added minio service (I took the same setup we had in the old python repo)
2. Updated Rust CI:
	 - Added a smoke test job which starts all external dependencies (in the moment it is only minio) via docker-compose.
	 - The smoke test job runs tests that are marked with the `[#ignore]` annotation only.
	 - The `[#ignore]` annotation is used to distinguish between simple unit tests and tests that depend on an external service.
	    	- It is the best solution I have been able to find so far. We can also remove the `[#ignore]`  annotation and run them together in one job but I think it will make development easier if we can run just unit test without having to run any external services via docker-compose.
	- Add caching
		- I noticied that the ci is fast with caching enabled but I havn't tested it much.
		- I'm fine removing the cache if it creates to much visual noice.

**Notes:** 
(just some findings I want to share)

### [**`jobs.id.container`**](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer)

`Steps` can run in a docker container.

An example:

Instead of installing rust nightly via a `step` like:

```
      - name: install nightly
        uses: actions-rs/toolchain@v1
        with:
          profile: minimal
          toolchain: nightly
          components: clippy

```

we can specify that we want to run the actual step (e.g. `cargo test`) in the `rustlang/rust:nightly` container.

```diff
 test:
    name: rust-test
    runs-on: ubuntu-latest
+     container: rustlang/rust:nightly
    steps:
      - uses: actions/checkout@master
-     - name: install nightly
-       uses: actions-rs/toolchain@v1
-       with:
-         profile: minimal
-         toolchain: nightly
-         components: clippy

      - name: run unit tests
        working-directory: ./rust
        env:
          RUSTFLAGS: "-D warnings"
        run: cargo test

```

The reason why I decided against this feature is that the pulling of the docker image takes longer than installing the toolchain.



### [**`jobs.id.services`**](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idservices)

> Used to host service containers for a job in a workflow. Service  containers are useful for creating databases or cache services like  Redis. The runner  automatically creates a Docker network and manages  the life cycle of the service containers.

Github workflow has a feature to specify external docker containers as dependencies directly in the workflow file, so that we don't need to call docker-compose manually. An example for minio:

```yml
  test:
    name: rust-test
    runs-on: ubuntu-latest
    container: rustlang/rust:nightly
    # Service containers to run with `container-job`
    services:
      # Label used to access the service container
      minio:
        # Docker Hub image
        image: minio/minio
        env:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
        ports:
          - 9000:9000
        options: --health-cmd "curl -f http://localhost:9000/minio/health/live" --health-interval 10s --health-timeout 5s --health-retries 5
```

I really like that feature but unfortunately it does not work with minio. Minio requires the command `server [volume]` to  run in server mode. Without that command the minio container will immediately quit. [The Github workflow does not yet support the specification of a command argument.]( https://github.community/t5/GitHub-Actions/How-do-I-properly-override-a-service-entrypoint/td-p/44129) 




