### PR TITLE
Add global model in round parameter

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -387,6 +388,7 @@ checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -420,6 +422,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.104", features = [ "derive" ] }
 bytes = "0.5.4"
 tracing = "0.1.13"
 sodiumoxide = "0.2.5"
-num = { version = "0.2.1" }
+num = { version = "0.2.1", features = ["serde"] }
 bincode = "1.2.1"
 thiserror = "1.0.16"
 anyhow = "1.0.28"

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod config;
 mod masking;
-mod model;
+pub(crate) mod model;
 pub(crate) mod object; //
 mod seed;
 

--- a/rust/src/mask/model.rs
+++ b/rust/src/mask/model.rs
@@ -14,7 +14,7 @@ use num::{
 use thiserror::Error;
 
 /// Represent a model.
-#[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into)]
+#[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into, Serialize)]
 pub struct Model(Vec<Ratio<BigInt>>);
 
 #[allow(clippy::len_without_is_empty)]

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -136,7 +136,7 @@ impl Data {
                             // Something went wrong. Keep the current global model for a new round
                             // but set all other round parameters to None.
                             Some(Arc::new(RoundParametersData::from(
-                                round_parameters_data.clone().global_model.clone(),
+                                round_parameters_data.global_model.clone(),
                             )))
                         }
                     } else {

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -140,7 +140,7 @@ impl Data {
                     } else {
                         // This case should not be possible.
                         // The coordinator cannot get to the step in which the event
-                        // [`End Round`] is emitted, without having any rounding parameters.
+                        // [`End Round`] is emitted, without having any round parameters.
                         panic!("A round was completed without having any round parameters.")
                     };
 

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -123,7 +123,6 @@ impl Data {
                 // The coordinator has ended the round but hasn't yet started a new one.
                 // Therefore, we can only publish the global model and set all other round
                 // parameters to None because the round is already over.
-
                 self.round_parameters_data =
                     if let Some(round_parameters_data) = self.round_parameters_data.take() {
                         // Update the global model and set all other round parameters to None.
@@ -139,8 +138,10 @@ impl Data {
                             )))
                         }
                     } else {
-                        // Normally that case should not be possible.
-                        None
+                        // This case should not be possible.
+                        // The coordinator cannot get to the step in which the event
+                        // [`End Round`] is emitted, without having any rounding parameters.
+                        panic!("A round was completed without having any round parameters.")
                     };
 
                 self.phase_data = None;

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -1,10 +1,9 @@
 use thiserror::Error;
 
 use crate::{
-    coordinator::{ProtocolEvent, RoundParameters, RoundSeed},
+    coordinator::{ProtocolEvent, RoundParameters},
     mask::model::Model,
     service::handle::{SerializedGlobalModel, SerializedSeedDict, SerializedSumDict},
-    CoordinatorPublicKey,
     SeedDict,
     SumParticipantPublicKey,
 };
@@ -222,17 +221,8 @@ impl Sum2Data {
 
 #[derive(Debug, PartialEq, Default)]
 pub struct RoundParametersData {
-    /// The coordinator public key for encryption.
-    pub pk: Option<CoordinatorPublicKey>,
-
-    /// Fraction of participants to be selected for the sum task.
-    pub sum: Option<f64>,
-
-    /// Fraction of participants to be selected for the update task.
-    pub update: Option<f64>,
-
-    /// The random round seed.
-    pub seed: Option<RoundSeed>,
+    /// The round parameters of the current round.
+    pub round_parameters: Option<RoundParameters>,
 
     /// The global model of the previous round.
     pub global_model: Option<SerializedGlobalModel>,
@@ -243,10 +233,7 @@ impl RoundParametersData {
     /// If it is the first round, the value of the global model will be None.
     fn update_round_parameters(&self, round_parameters: RoundParameters) -> RoundParametersData {
         RoundParametersData {
-            pk: Some(round_parameters.pk),
-            sum: Some(round_parameters.sum),
-            update: Some(round_parameters.update),
-            seed: Some(round_parameters.seed),
+            round_parameters: Some(round_parameters),
             global_model: self.global_model.clone(),
         }
     }
@@ -268,10 +255,7 @@ impl RoundParametersData {
 impl From<RoundParameters> for RoundParametersData {
     fn from(round_parameters: RoundParameters) -> RoundParametersData {
         RoundParametersData {
-            pk: Some(round_parameters.pk),
-            sum: Some(round_parameters.sum),
-            update: Some(round_parameters.update),
-            seed: Some(round_parameters.seed),
+            round_parameters: Some(round_parameters),
             ..Default::default()
         }
     }

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -1,4 +1,4 @@
-use crate::{coordinator::RoundParameters, SumParticipantPublicKey};
+use crate::{service::data::RoundParametersData, SumParticipantPublicKey};
 use derive_more::From;
 use std::{
     pin::Pin,
@@ -43,7 +43,7 @@ pub struct Message {
 /// Event for a request to retrieve the round parameters
 pub struct RoundParametersRequest {
     /// Channel for sending the round parameters back
-    pub response_tx: oneshot::Sender<Option<Arc<RoundParameters>>>,
+    pub response_tx: oneshot::Sender<Option<Arc<RoundParametersData>>>,
 }
 
 pub type SerializedSumDict = Arc<Vec<u8>>;
@@ -85,8 +85,8 @@ impl Handle {
     /// Send a [`Event::RoundParameters`] event to retrieve the
     /// current round parameters. The availability of the round
     /// parameters depends on the current coordinator state.
-    pub async fn get_round_parameters(&self) -> Option<Arc<RoundParameters>> {
-        let (tx, rx) = oneshot::channel::<Option<Arc<RoundParameters>>>();
+    pub async fn get_round_parameters(&self) -> Option<Arc<RoundParametersData>> {
+        let (tx, rx) = oneshot::channel::<Option<Arc<RoundParametersData>>>();
         self.send_event(RoundParametersRequest { response_tx: tx });
         rx.await.unwrap()
     }

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -40,6 +40,8 @@ pub struct Message {
     // FIXME: there should be a channel to send a response back
 }
 
+pub type SerializedGlobalModel = Arc<Vec<u8>>;
+
 /// Event for a request to retrieve the round parameters
 pub struct RoundParametersRequest {
     /// Channel for sending the round parameters back


### PR DESCRIPTION
Adds the global model to the round parameters response. 
The response of `get_round_parameters()` will depend on the current round and protocol phase. The possible responses are.

First Round `Idle` phase:
```
round_parameter_data = None
```

First Round `Sum` phase:
```
round_parameter_data = {
	round_parameter: Some(round parameters of the first round)
	global_model: None
}
```
First/Second Round `EndRound/Idle` phase:
```
round_parameter_data = {
	round_parameter: None
	global_model: Some(global model of the first round)
}
```

Second Round `Sum` phase:
```
round_parameter_data = {
	round_parameter: Some(round parameters of the second round)
	global_model: Some(global model of the first round)
}
```

Second/Third Round `EndRound/Idle` phase:
```
round_parameter_data = {
	round_parameter: None
	global_model: Some(global model of the second round)
}
```

In the event that the coordinator cannot create a new model, the parameters are set to None and the current global model stays the same.


The global model is serialized via bincode. 