### PR TITLE
PB-670 C API for FL

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -56,6 +56,7 @@ pub struct Client {
     pub(crate) global_model: Option<SerializedGlobalModel>,
     pub(crate) cached_model: Option<PrimitiveModel>,
     pub(crate) has_new_global_model_since_last_check: bool,
+    pub(crate) has_new_global_model_since_last_cache: bool,
     pub(crate) local_model: Option<Model>,
 
     id: u32, // NOTE identifier for client for testing; may remove later
@@ -79,6 +80,7 @@ impl Client {
             global_model: None,
             cached_model: None,
             has_new_global_model_since_last_check: false,
+            has_new_global_model_since_last_cache: false,
             local_model: None,
             id: 0,
         })
@@ -101,6 +103,7 @@ impl Client {
             global_model: None,
             cached_model: None,
             has_new_global_model_since_last_check: false,
+            has_new_global_model_since_last_cache: false,
             local_model: None,
             id,
         })
@@ -127,13 +130,13 @@ impl Client {
                     if let Some(ref old_global_model) = self.global_model {
                         if !Arc::ptr_eq(new_global_model, old_global_model) {
                             self.global_model = Some(new_global_model.clone());
-                            self.cached_model = None;
                             self.has_new_global_model_since_last_check = true;
+                            self.has_new_global_model_since_last_cache = true;
                         }
                     } else {
                         self.global_model = Some(new_global_model.clone());
-                        self.cached_model = None;
                         self.has_new_global_model_since_last_check = true;
+                        self.has_new_global_model_since_last_cache = true;
                     }
                 }
                 // new round parameters at the beginning of the next round

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,6 +13,7 @@ pub mod crypto;
 pub mod mask;
 pub mod message;
 pub mod participant;
+pub mod sdk;
 pub mod service;
 
 use std::collections::HashMap;

--- a/rust/src/mask/model.rs
+++ b/rust/src/mask/model.rs
@@ -14,7 +14,7 @@ use num::{
 use thiserror::Error;
 
 /// Represent a model.
-#[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into, Serialize)]
+#[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into, Serialize, Deserialize)]
 pub struct Model(Vec<Ratio<BigInt>>);
 
 #[allow(clippy::len_without_is_empty)]

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -7,7 +7,6 @@ use crate::{
         Aggregation,
         BoundType,
         DataType,
-        FromPrimitives,
         GroupType,
         MaskConfig,
         MaskObject,
@@ -122,8 +121,14 @@ impl Participant {
     }
 
     /// Compose an update message.
-    pub fn compose_update_message(&self, pk: CoordinatorPublicKey, sum_dict: &SumDict) -> Vec<u8> {
-        let (mask_seed, masked_model) = Self::mask_model();
+    pub fn compose_update_message(
+        &self,
+        pk: CoordinatorPublicKey,
+        sum_dict: &SumDict,
+        scalar: f64,
+        local_model: Model,
+    ) -> Vec<u8> {
+        let (mask_seed, masked_model) = Self::mask_model(scalar, local_model);
         let local_seed_dict = Self::create_local_seed_dict(sum_dict, &mask_seed);
 
         let payload = UpdateOwned {
@@ -171,12 +176,10 @@ impl Participant {
         self.ephm_sk = ephm_sk;
     }
 
-    /// Generate a mask seed and mask a local model (dummy).
-    fn mask_model() -> (MaskSeed, MaskObject) {
-        let model = Model::from_primitives(vec![0_f32, 1_f32, 0_f32, 1_f32].into_iter()).unwrap();
-        let masker = Masker::new(dummy_config());
-        let (seed, masked_model) = masker.mask(0.5, model);
-        (seed, masked_model)
+    /// Generate a mask seed and mask a local model.
+    fn mask_model(scalar: f64, local_model: Model) -> (MaskSeed, MaskObject) {
+        // TODO: use proper config
+        Masker::new(dummy_config()).mask(scalar, local_model)
     }
 
     // Create a local seed dictionary from a sum dictionary.
@@ -298,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_create_local_seed_dict() {
-        let (mask_seed, _) = Participant::mask_model();
+        let mask_seed = MaskSeed::generate();
         let ephm_dict = iter::repeat_with(|| generate_encrypt_key_pair())
             .take(1 + randombytes_uniform(10) as usize)
             .collect::<HashMap<SumParticipantEphemeralPublicKey, SumParticipantEphemeralSecretKey>>(

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -51,7 +51,7 @@ pub struct Participant {
     update_signature: ParticipantTaskSignature, // 64 bytes
 
     // round parameters
-    task: Task,
+    pub(crate) task: Task,
 }
 
 impl Default for Participant {

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -76,24 +76,27 @@ PrimModel! {f64, c_double}
 PrimModel! {i32, c_int}
 PrimModel! {i64, c_long}
 
-/// Generates a consuming iterator for the primitive model. The iterator is wrapped in a private
-/// submodule, because safe traits and their safe methods can't be implemented as `unsafe` and this
-/// way we can ensure that the implementation is only ever used in an `unsafe fn`. The argument
-/// `$prim` is the corresponding Rust primitive data type.
-macro_rules! PrimIter {
-    ($prim:ty $(,)?) => {
-        paste::item! {
-            mod [<prim_iter_ $prim>] {
-                use std::{mem, os::raw::c_ulong};
+/// The iterators are wrapped in a private submodule, because safe traits and their safe methods
+/// can't be implemented as `unsafe` and this way we can ensure that the implementation is only
+/// ever used in an `unsafe fn`.
+mod iter {
+    use std::{mem, os::raw::c_ulong};
 
+    /// Generates a consuming iterator for the primitive model.  The argument
+    /// `$prim` is the corresponding Rust primitive data type.
+    macro_rules! PrimIter {
+        ($prim:ty $(,)?) => {
+            paste::item! {
                 use super::[<PrimitiveModel $prim:upper>];
 
+                #[doc(hidden)]
                 /// An iterator that moves out of a primitive model.
                 pub struct [<IntoIter $prim:upper>] {
                     model: [<PrimitiveModel $prim:upper>],
                     count: isize,
                 }
 
+                #[doc(hidden)]
                 impl IntoIterator for [<PrimitiveModel $prim:upper>] {
                     type Item = $prim;
                     type IntoIter = [<IntoIter $prim:upper>];
@@ -107,6 +110,7 @@ macro_rules! PrimIter {
                     }
                 }
 
+                #[doc(hidden)]
                 impl Iterator for [<IntoIter $prim:upper>] {
                     type Item = $prim;
 
@@ -145,14 +149,14 @@ macro_rules! PrimIter {
                     }
                 }
             }
-        }
-    };
-}
+        };
+    }
 
-PrimIter!(f32);
-PrimIter!(f64);
-PrimIter!(i32);
-PrimIter!(i64);
+    PrimIter!(f32);
+    PrimIter!(f64);
+    PrimIter!(i32);
+    PrimIter!(i64);
+}
 
 #[derive(Clone, Debug)]
 /// A primitive model of data type `N` cached on the heap. The pointer `PrimitiveModelN` returned

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -1,0 +1,92 @@
+use std::{
+    cmp::Ordering,
+    iter::FromIterator,
+    os::raw::{c_double, c_float, c_int, c_long},
+    ptr::null,
+};
+
+use num::{bigint::BigInt, rational::Ratio, traits::Zero};
+
+use crate::{
+    mask::model::{FromPrimitives, IntoPrimitives, Model},
+    participant::{Participant, Task},
+};
+
+// TODO: this is a mock, replaced by sth like the `Client` from #397
+pub struct Client {
+    participant: Participant,
+
+    // counting starts from 1, 0 means not seen yet
+    current_round: usize,
+    checked_round: usize,
+
+    // pointer to primitive models are valid for the current round
+    // TODO: set this to None when a new round is observed
+    primitive_model_f32: Option<Vec<f32>>,
+    primitive_model_f64: Option<Vec<f64>>,
+    primitive_model_i32: Option<Vec<i32>>,
+    primitive_model_i64: Option<Vec<i64>>,
+}
+
+macro_rules! get_model {
+    ($suffix:ident, $rust:ty, $c:ty $(,)?) => {
+        paste::item! {
+            #[no_mangle]
+            /// Get a pointer to the latest global model, which is valid until the next round
+            /// starts. Returns a `null` pointer if no global model is available or type casting
+            /// fails.
+            pub extern "C" fn [<get_model $suffix>](&mut self) -> *const $c {
+                // TODO: this is a mock, get the model from the round params when #411 is merged
+                let model = Some(Model::from_iter(
+                    vec![Ratio::<BigInt>::zero(); 10].into_iter(),
+                ));
+
+                if let Some(ref m) = self.[<primitive_model $suffix>] {
+                    return m.as_ptr();
+                }
+                if let Some(m) = model {
+                    self.[<primitive_model $suffix>] = m
+                        .into_primitives()
+                        .map(|res| res.map_err(|_| ()))
+                        .collect::<Result<Vec<$rust>, ()>>()
+                        .ok();
+                    if let Some(ref m) = self.[<primitive_model $suffix>] {
+                        return m.as_ptr();
+                    }
+                }
+                null()
+            }
+        }
+    };
+}
+
+impl Client {
+    #[no_mangle]
+    /// Check if the next round has started.
+    pub extern "C" fn is_next_round(&mut self) -> bool {
+        // TODO: increment the `current_round` if the client sees a new coordinator pk
+        // as a result of `self.handle.get_round_parameters().await`
+        match self.checked_round.cmp(&self.current_round) {
+            // new round since the last check
+            Ordering::Less => {
+                self.checked_round = self.current_round;
+                true
+            }
+            // still same round since the last check
+            Ordering::Equal => false,
+            // should only ever happen if the client is reused for another FL use case
+            Ordering::Greater => panic!("restart the participant for a new FL use case"),
+        }
+    }
+
+    #[no_mangle]
+    /// Check if the current role of the participant is `update`.
+    pub extern "C" fn is_update_participant(&self) -> bool {
+        self.participant.task == Task::Update
+    }
+
+    get_model!(_f32, f32, c_float);
+    get_model!(_f64, f64, c_double);
+    get_model!(_i32, i32, c_int);
+    get_model!(_i64, i64, c_long);
+}

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -110,10 +110,10 @@ PrimModel! {i64, c_long}
 /// A cached primitive model stored on the heap. The mutable slice returned from `get_model_N()`
 /// points to this.
 pub enum PrimitiveModel {
-    F32(Box<Vec<f32>>),
-    F64(Box<Vec<f64>>),
-    I32(Box<Vec<i32>>),
-    I64(Box<Vec<i64>>),
+    F32(Vec<f32>),
+    F64(Vec<f64>),
+    I32(Vec<i32>),
+    I64(Vec<i64>),
 }
 
 /// TODO: this is a mock, replace by sth like the `Client` from #397 or a wrapper around that.
@@ -249,7 +249,7 @@ macro_rules! get_model {
                             .into_primitives()
                             .map(|res| res.map_err(|_| ()))
                             .collect::<Result<Vec<$rust>, ()>>()
-                            .map_or(None, |vec| Some(PrimitiveModel::[<$rust:upper>](Box::new(vec))));
+                            .map_or(None, |vec| Some(PrimitiveModel::[<$rust:upper>](vec)));
                     }
 
                     if let Some(PrimitiveModel::[<$rust:upper>](ref mut model)) = client.model {

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -1,8 +1,9 @@
 use std::{
     cmp::Ordering,
-    iter::FromIterator,
-    os::raw::{c_double, c_float, c_int, c_long},
-    ptr::null,
+    iter::{FromIterator, IntoIterator, Iterator},
+    mem,
+    os::raw::{c_double, c_float, c_int, c_long, c_ulong},
+    ptr,
 };
 
 use num::{bigint::BigInt, rational::Ratio, traits::Zero};
@@ -12,81 +13,269 @@ use crate::{
     participant::{Participant, Task},
 };
 
-// TODO: this is a mock, replaced by sth like the `Client` from #397
-pub struct Client {
-    participant: Participant,
-
-    // counting starts from 1, 0 means not seen yet
-    current_round: usize,
-    checked_round: usize,
-
-    // pointer to primitive models are valid for the current round
-    // TODO: set this to None when a new round is observed
-    primitive_model_f32: Option<Vec<f32>>,
-    primitive_model_f64: Option<Vec<f64>>,
-    primitive_model_i32: Option<Vec<i32>>,
-    primitive_model_i64: Option<Vec<i64>>,
-}
-
-macro_rules! get_model {
-    ($suffix:ident, $rust:ty, $c:ty $(,)?) => {
+/// Generate a struct to hold the C equivalent of `&[N]` for a primitive data type `N` and
+/// implements a consuming iterator for the struct. The arguments `$rust` and `$c` are the
+/// corresponding Rust and C primitive data types.
+macro_rules! Model {
+    ($rust:ty, $c:ty $(,)?) => {
         paste::item! {
-            #[no_mangle]
-            /// Get a pointer to the latest global model, which is valid until the next round
-            /// starts. Returns a `null` pointer if no global model is available or type casting
-            /// fails.
-            pub extern "C" fn [<get_model $suffix>](&mut self) -> *const $c {
-                // TODO: this is a mock, get the model from the round params when #411 is merged
-                let model = Some(Model::from_iter(
-                    vec![Ratio::<BigInt>::zero(); 10].into_iter(),
-                ));
+            #[derive(Clone, Copy)]
+            #[repr(C)]
+            /// A model of primitive data type represented as a C slice. It holds a raw pointer to
+            /// the array of [`[<$rust>]`] values and its length.
+            pub struct [<Model $rust:upper>] {
+                ptr: *mut $c,
+                len: c_ulong,
+            }
 
-                if let Some(ref m) = self.[<primitive_model $suffix>] {
-                    return m.as_ptr();
-                }
-                if let Some(m) = model {
-                    self.[<primitive_model $suffix>] = m
-                        .into_primitives()
-                        .map(|res| res.map_err(|_| ()))
-                        .collect::<Result<Vec<$rust>, ()>>()
-                        .ok();
-                    if let Some(ref m) = self.[<primitive_model $suffix>] {
-                        return m.as_ptr();
+            /// An iterator that moves out of a primitive [`[<Model $rust:upper>]`].
+            pub struct [<IntoIter $rust:upper>] {
+                model: [<Model $rust:upper>],
+                count: isize,
+            }
+
+            impl IntoIterator for [<Model $rust:upper>] {
+                type Item = $rust;
+                type IntoIter = [<IntoIter $rust:upper>];
+
+                /// Creates an [`[<IntoIter $rust:upper>]`] iterator from a primitive
+                /// [`[<Model $rust:upper>]`].
+                fn into_iter(self) -> Self::IntoIter {
+                    Self::IntoIter {
+                        model: self,
+                        count: -1_isize,
                     }
                 }
-                null()
+            }
+
+            impl Iterator for [<IntoIter $rust:upper>] {
+                type Item = $rust;
+
+                /// Advances the iterator and returns the next [<$rust>] value. Returns `None` when
+                /// the iteration is finished.
+                ///
+                /// # Safety
+                /// The iterator iterates over an array by dereferencing from raw pointer and is
+                /// therefore inherently unsafe, even though this can't be indicated in the function
+                /// signature of the trait's method.
+                ///
+                /// # Panic
+                /// The iterator panics if safety checks indicate undefined behavior.
+                fn next(&mut self) -> Option<Self::Item> {
+                    if ((self.count + 1) as c_ulong) < self.model.len {
+                        if self.count < isize::MAX
+                            && (self.model.ptr as isize)
+                                .checked_add((self.count + 2) * mem::size_of::<$rust>() as isize)
+                                .is_some()
+                        {
+                            self.count += 1;
+                        } else {
+                            // TODO: add error handling
+                            panic!("iterating further results in undefined behavior");
+                        }
+                        unsafe {
+                            Some(*self.model.ptr.offset(self.count))
+                        }
+                    } else {
+                        None
+                    }
+                }
             }
         }
     };
 }
 
-impl Client {
-    #[no_mangle]
-    /// Check if the next round has started.
-    pub extern "C" fn is_next_round(&mut self) -> bool {
-        // TODO: increment the `current_round` if the client sees a new coordinator pk
-        // as a result of `self.handle.get_round_parameters().await`
-        match self.checked_round.cmp(&self.current_round) {
-            // new round since the last check
-            Ordering::Less => {
-                self.checked_round = self.current_round;
-                true
-            }
-            // still same round since the last check
-            Ordering::Equal => false,
-            // should only ever happen if the client is reused for another FL use case
-            Ordering::Greater => panic!("restart the participant for a new FL use case"),
-        }
-    }
+Model! {f32, c_float}
+Model! {f64, c_double}
+Model! {i32, c_int}
+Model! {i64, c_long}
 
-    #[no_mangle]
-    /// Check if the current role of the participant is `update`.
-    pub extern "C" fn is_update_participant(&self) -> bool {
-        self.participant.task == Task::Update
-    }
+/// TODO: this is a mock, replace by sth like the `Client` from #397 or a wrapper around that.
+///
+/// The pointer to the cached primitive model, which gets allocated in `get_model()` and is stored
+/// in `model_N`, is valid across the FFI-boundary until one of the following events happen:
+/// - The model memory is freed via a call to `free_model()`.
+/// - The model is updated via a call to `update_model()`.
+/// - The round ends. (TODO: implement this point when a new round is observed)
+pub struct Client {
+    participant: Participant,
 
-    get_model!(_f32, f32, c_float);
-    get_model!(_f64, f64, c_double);
-    get_model!(_i32, i32, c_int);
-    get_model!(_i64, i64, c_long);
+    // counting starts from 1, 0 means not seen yet
+    current_round: u32,
+    checked_round: u32,
+
+    model_f32: Option<Box<Vec<f32>>>,
+    model_f64: Option<Box<Vec<f64>>>,
+    model_i32: Option<Box<Vec<i32>>>,
+    model_i64: Option<Box<Vec<i64>>>,
 }
+
+#[no_mangle]
+/// Check if the next round has started.
+///
+/// # Safety
+/// The method dereferences from the raw pointer arguments. Therefore, the behavior of
+/// the method is undefined if the arguments don't point to valid objects.
+pub unsafe extern "C" fn is_next_round(client: *mut Client) -> bool {
+    if client.is_null() {
+        // TODO: add error handling
+        panic!("invalid client");
+    }
+    let client = &mut *client;
+
+    // TODO: increment the `current_round` if the client sees a new coordinator pk
+    // as a result of `client.handle.get_round_parameters().await`
+    match client.checked_round.cmp(&client.current_round) {
+        // new round since the last check
+        Ordering::Less => {
+            client.checked_round = client.current_round;
+            true
+        }
+        // still same round since the last check
+        Ordering::Equal => false,
+        // should only ever happen if the client is reused for another FL use case
+        Ordering::Greater => panic!("restart the participant for a new FL use case"),
+    }
+}
+
+#[no_mangle]
+/// Check if the current role of the participant is `update`.
+///
+/// # Safety
+/// The method dereferences from the raw pointer arguments. Therefore, the behavior of
+/// the method is undefined if the arguments don't point to valid objects.
+pub unsafe extern "C" fn is_update_participant(client: *mut Client) -> bool {
+    if client.is_null() {
+        // TODO: add error handling
+        panic!("invalid client");
+    }
+    let client = &mut *client;
+
+    client.participant.task == Task::Update
+}
+
+/// Generate a method to get the global model converted to primitives. The arguments `$rust` and
+/// `$c` are the corresponding Rust and C primitive data types.
+macro_rules! get_model {
+    ($rust:ty, $c:ty $(,)?) => {
+        paste::item! {
+            #[no_mangle]
+            /// Get the latest global [`[<Model $rust:upper>]`], which is valid until the current
+            /// round ends. The model can be modified in place, for example for training, to avoid
+            /// needless cloning.
+            ///
+            /// # Errors
+            /// - Returns a [`[<Model $rust:upper>]`] with `null` pointer and `len` zero if no
+            ///   global model is available.
+            /// - Returns a [`[<Model $rust:upper>]`] with `null` pointer and `len` of the global
+            ///   model if type casting fails.
+            ///
+            /// # Safety
+            /// The method dereferences from the raw pointer arguments. Therefore, the behavior of
+            /// the method is undefined if the arguments don't point to valid objects.
+            pub unsafe extern "C" fn [<get_model_ $rust>](
+                client: *mut Client,
+            ) -> [<Model $rust:upper>] {
+                if client.is_null() {
+                    // TODO: add error handling
+                    panic!("invalid client");
+                }
+                let client = &mut *client;
+
+                // TODO: this is a mock, get the model when the client retrieves the round
+                // parameters as a result of `client.handle.get_round_parameters().await`
+                let global_model = Some(Model::from_iter(
+                    vec![Ratio::<BigInt>::zero(); 10].into_iter(),
+                ));
+
+                if let Some(model) = global_model {
+                    // global model available
+                    let len = model.len() as c_ulong;
+                    if client.[<model_ $rust>].is_none() {
+                        // cache the primitive model if needed
+                        client.[<model_ $rust>] = model
+                            .into_primitives()
+                            .map(|res| res.map_err(|_| ()))
+                            .collect::<Result<Vec<$rust>, ()>>()
+                            .map_or(None, |vec| Some(Box::new(vec)));
+                    }
+
+                    if let Some(ref mut model) = client.[<model_ $rust>] {
+                        // conversion succeeded
+                        let ptr = model.as_mut_ptr();
+                        [<Model $rust:upper>] { ptr, len }
+                    } else {
+                        // conversion failed
+                        let ptr = ptr::null_mut();
+                        [<Model $rust:upper>] { ptr, len }
+                    }
+
+                } else {
+                    // global model unavailable
+                    let ptr = ptr::null_mut();
+                    let len = 0_u64 as c_ulong;
+                    [<Model $rust:upper>] { ptr, len }
+                }
+            }
+        }
+    };
+}
+
+get_model!(f32, c_float);
+get_model!(f64, c_double);
+get_model!(i32, c_int);
+get_model!(i64, c_long);
+
+/// Generate a method to register the updated local model. The argument `$rust` is the corresponding
+/// Rust primitive data type.
+macro_rules! update_model {
+    ($rust:ty $(,)?) => {
+        paste::item! {
+            #[no_mangle]
+            /// Register the updated local model.
+            ///
+            /// # Safety
+            /// The method dereferences from the raw pointer arguments. Therefore, the behavior of
+            /// the method is undefined if the arguments don't point to valid objects.
+            ///
+            /// The `model` points to memory which is either allocated by `get_model()` and then
+            /// modified or which isn't allocated by `get_model()`. Therefore, the behavior of the
+            /// method is undefined if any of the [slice safety conditions](https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html#safety)
+            /// are violated.
+            pub unsafe extern "C" fn [<update_model_ $rust>](
+                client: *mut Client,
+                model: [<Model $rust:upper>],
+            ) {
+                if !client.is_null()
+                    && !model.ptr.is_null()
+                    && model.len != 0
+                    && model.len <= usize::MAX as c_ulong
+                    && model.len as usize * mem::size_of::<$rust>() <= usize::MAX
+                {
+                    let client = &mut *client;
+                    if let Some(cached) = client.[<model_ $rust>].take() {
+                        // cached model was updated
+                        if ptr::eq(model.ptr, cached.as_ptr())
+                            && model.len as usize == cached.len()
+                        {
+                            // TODO: use the model when the client sends the update message
+                            let _local_model = Model::from_primitives_bounded(cached.into_iter());
+                        }
+                    } else {
+                        // other model was updated
+                        // TODO: use the model when the client sends the update message
+                        let _local_model = Model::from_primitives_bounded(model.into_iter());
+                    }
+                } else {
+                    // TODO: add error handling
+                    panic!("invalid primitive model");
+                }
+            }
+        }
+    };
+}
+
+update_model!(f32);
+update_model!(f64);
+update_model!(i32);
+update_model!(i64);

--- a/rust/src/sdk/mod.rs
+++ b/rust/src/sdk/mod.rs
@@ -1,0 +1,1 @@
+pub mod api;

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -24,9 +24,9 @@ pub enum Event {
     /// participants.
     RoundParameters(RoundParametersRequest),
 
-    /// A request for retrieving the sum dictionary for the current
+    /// A request for retrieving the sum dictionary and model scalar for the current
     /// round
-    SumDict(SumDictRequest),
+    SumDictAndScalar(SumDictAndScalarRequest),
 
     /// A request to retrieve the masking seeds dictionary for the
     /// given participant.
@@ -51,9 +51,9 @@ pub struct RoundParametersRequest {
 pub type SerializedSumDict = Arc<Vec<u8>>;
 
 /// Event for a request to retrieve the sum dictionary
-pub struct SumDictRequest {
-    /// Channel for sending the sum dictionary back
-    pub response_tx: oneshot::Sender<Option<SerializedSumDict>>,
+pub struct SumDictAndScalarRequest {
+    /// Channel for sending the sum dictionary and model scalar back
+    pub response_tx: oneshot::Sender<Option<(SerializedSumDict, f64)>>,
 }
 
 pub type SerializedSeedDict = Arc<Vec<u8>>;
@@ -94,11 +94,11 @@ impl Handle {
     }
 
     /// Send a [`Event::SumDict`] event to retrieve the current sum
-    /// dictionary, in its serialized form. The availability of the
-    /// sum dictionary depends on the current coordinator state.
-    pub async fn get_sum_dict(&self) -> Option<SerializedSumDict> {
-        let (tx, rx) = oneshot::channel::<Option<SerializedSumDict>>();
-        self.send_event(SumDictRequest { response_tx: tx });
+    /// dictionary, in its serialized form, and the model scalar. The availability of the
+    /// sum dictionary and model scalar depends on the current coordinator state.
+    pub async fn get_sum_dict_and_scalar(&self) -> Option<(SerializedSumDict, f64)> {
+        let (tx, rx) = oneshot::channel::<Option<(SerializedSumDict, f64)>>();
+        self.send_event(SumDictAndScalarRequest { response_tx: tx });
         rx.await.unwrap()
     }
 

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -18,7 +18,8 @@ pub use handle::{
     Message,
     RoundParametersRequest,
     SeedDictRequest,
-    SumDictRequest,
+    SerializedGlobalModel,
+    SumDictAndScalarRequest,
 };
 
 /// The `Service` is the task that drives the PET protocol. It reacts
@@ -54,7 +55,7 @@ impl Service {
         match event {
             Event::Message(Message { buffer }) => self.handle_message(buffer),
             Event::RoundParameters(req) => self.handle_round_parameters_request(req),
-            Event::SumDict(req) => self.handle_sum_dict_request(req),
+            Event::SumDictAndScalar(req) => self.handle_sum_dict_and_scalar_request(req),
             Event::SeedDict(req) => self.handle_seed_dict_request(req),
         }
         self.process_protocol_events();
@@ -68,9 +69,9 @@ impl Service {
     }
 
     /// Handler for sum dict requests
-    fn handle_sum_dict_request(&self, req: SumDictRequest) {
-        let SumDictRequest { response_tx } = req;
-        let _ = response_tx.send(self.data.sum_dict());
+    fn handle_sum_dict_and_scalar_request(&self, req: SumDictAndScalarRequest) {
+        let SumDictAndScalarRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.sum_dict_and_scalar());
     }
 
     /// Handler for seed dict requests


### PR DESCRIPTION
**References**
- [PB-670](https://xainag.atlassian.net/browse/PB-670)

**Summary**
- ~the `Client` introduced here is just a mock for now, it should be replaced by the networking client or a wrapper around that when that is merged;~ also some of the logic needs to be implemented then marked as `TODO`s
- generics as well as methods can't be exposed to C, therefore most of this code exposes functions for each primitive data type
- implement getters for the global model: the global model is converted to a model of primitive type and cached, a "mutable slice" is returned to the caller
- implement setters for the local model: take a "mutable slice" and convert it's data to a model, ~provides a new iterator for that if the slice doesn't point to the cached model~
- implement a callback: this is currently only in `new_client()` as an experiment/example, but is already quite general in that it is stateful and generic regarding the input (as long as both sides across the FFI-boundary agree on the same structs, the test simulates such a callback)