### PR TITLE
WIP fix to poll round params data

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,5 +1,4 @@
 use crate::{
-    coordinator::RoundParameters,
     crypto::ByteObject,
     participant::{Participant, Task},
     service::Handle,
@@ -49,7 +48,7 @@ pub struct Client {
     interval: time::Interval,
 
     /// Coordinator public key
-    _coordinator_pk: CoordinatorPublicKey,
+    coordinator_pk: CoordinatorPublicKey,
 
     id: u32, // NOTE identifier for client for testing; may remove later
 }
@@ -67,7 +66,7 @@ impl Client {
             handle,
             participant,
             interval: time::interval(Duration::from_secs(period)),
-            _coordinator_pk: CoordinatorPublicKey::zeroed(),
+            coordinator_pk: CoordinatorPublicKey::zeroed(),
             id: 0,
         })
     }
@@ -84,7 +83,7 @@ impl Client {
             handle,
             participant,
             interval: time::interval(Duration::from_secs(period)),
-            _coordinator_pk: CoordinatorPublicKey::zeroed(),
+            coordinator_pk: CoordinatorPublicKey::zeroed(),
             id,
         })
     }
@@ -103,25 +102,23 @@ impl Client {
 
     /// [`Client`] duties within a round
     pub async fn during_round(&mut self) -> Result<Task, ClientError> {
-        let round_params_data = loop {
+        loop {
             if let Some(round_params_data) = self.handle.get_round_parameters().await {
-                break round_params_data;
+                if let Some(ref round_params) = round_params_data.round_parameters {
+                    self.coordinator_pk = round_params.pk;
+                    debug!(client_id = %self.id, "computing sigs and checking task");
+                    let round_seed = round_params.seed.as_slice();
+                    self.participant.compute_signatures(round_seed);
+                    let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
+                    break match self.participant.check_task(sum_frac, upd_frac) {
+                        Task::Sum    => self.summer(round_params.pk).await,
+                        Task::Update => self.updater(round_params.pk).await,
+                        Task::None   => self.unselected().await,
+                    }
+                }
             }
-            debug!(client_id = %self.id, "round params not ready, retrying.");
+            debug!(client_id = %self.id, "new round params not ready, retrying.");
             self.interval.tick().await;
-        };
-        let round_params: &RoundParameters = round_params_data
-            .round_parameters
-            .as_ref()
-            .ok_or(ClientError::GeneralErr)?;
-        let round_seed: &[u8] = round_params.seed.as_slice();
-        debug!(client_id = %self.id, "computing sigs and checking task");
-        self.participant.compute_signatures(round_seed);
-        let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-        match self.participant.check_task(sum_frac, upd_frac) {
-            Task::Sum => self.summer(round_params.pk).await,
-            Task::Update => self.updater(round_params.pk).await,
-            Task::None => self.unselected().await,
         }
     }
 

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -117,7 +117,7 @@ impl Client {
                             Task::Sum => self.summer().await,
                             Task::Update => self.updater().await,
                             Task::None => self.unselected().await,
-                        }
+                        };
                     }
                 }
             }
@@ -191,7 +191,9 @@ impl Client {
             ClientError::DeserialiseErr(e)
         })?;
         debug!(client_id = %self.id, "sum dictionary received, sending update message.");
-        let upd_msg: Vec<u8> = self.participant.compose_update_message(self.coordinator_pk, &sum_dict);
+        let upd_msg: Vec<u8> = self
+            .participant
+            .compose_update_message(self.coordinator_pk, &sum_dict);
         self.handle.send_message(upd_msg).await;
 
         info!(client_id = %self.id, "update participant completed a round");


### PR DESCRIPTION
**update**. This addresses a break in the build introduced in https://github.com/xainag/xain-fl/pull/397

- now compatible with the changes around round parameters introduced in https://github.com/xainag/xain-fl/pull/411
- [PB-783](https://xainag.atlassian.net/browse/PB-783)

--------------------
This compiles, but isn't quite as it should be. In the loop of `during_round`, we poll for `round_params_data`. Now the "old" `round_params` are inside, and also `Option`al. So really we should be polling until `round_params` is _also_ available. What we'd really like is something like
```rust
// doesn't compile!
let round_params = loop {
    if let Some(round_params_data) = self.handle.get_round_parameters().await {
        if let Some(round_params) = round_params_data.round_parameters {
            break round_params;
        }
    }
    // interval tick...
};
```
But the `Arc` around `round_params_data` makes it problematic to do...
```rust
error[E0507]: cannot move out of an `Arc`
   --> src/client.rs:108:45
    |
108 |                 if let Some(round_params) = round_params_data.round_parameters {
    |                             ------------    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider borrowing here: `&round_params_data.round_parameters`
    |                             |
    |                             data moved here
    |                             move occurs because `round_params` has type `coordinator::RoundParameters`, which does not implement the `Copy` trait
```