### PR TITLE
PB-774 client async runtime

### DIFF
--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
     crypto::ByteObject,
     mask::model::Model,
     participant::{Participant, Task},
-    sdk::api::PrimitiveModel,
+    sdk::api::CachedModel,
     service::{Handle, SerializedGlobalModel},
     CoordinatorPublicKey,
     InitError,
@@ -36,6 +36,7 @@ pub enum ClientError {
     GeneralErr,
 }
 
+#[derive(Debug)]
 /// A client of the federated learning service
 ///
 /// [`Client`] is responsible for communicating with the service, deserialising
@@ -57,7 +58,7 @@ pub struct Client {
     pub(crate) has_new_coord_pk_since_last_check: bool,
 
     pub(crate) global_model: Option<SerializedGlobalModel>,
-    pub(crate) cached_model: Option<PrimitiveModel>,
+    pub(crate) cached_model: Option<CachedModel>,
     pub(crate) has_new_global_model_since_last_check: bool,
     pub(crate) has_new_global_model_since_last_cache: bool,
     pub(crate) local_model: Option<Model>,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -1,3 +1,8 @@
+use std::{default::Default, sync::Arc, time::Duration};
+
+use thiserror::Error;
+use tokio::time;
+
 use crate::{
     crypto::ByteObject,
     mask::model::Model,
@@ -10,9 +15,6 @@ use crate::{
     SumDict,
     UpdateSeedDict,
 };
-use std::{sync::Arc, time::Duration};
-use thiserror::Error;
-use tokio::time;
 
 /// Client-side errors
 #[derive(Debug, Error)]
@@ -47,6 +49,7 @@ pub struct Client {
     pub(crate) participant: Participant,
 
     /// Interval to poll for service data
+    /// (this is a `Stream` of `Future`s which requires a runtime to create the `Client`)
     interval: time::Interval,
 
     /// Coordinator public key
@@ -62,19 +65,13 @@ pub struct Client {
     id: u32, // NOTE identifier for client for testing; may remove later
 }
 
-impl Client {
-    /// Create a new [`Client`]
-    ///
-    /// `period`: time period at which to poll for service data, in seconds.
-    /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
-    /// Returns `Err(err)` if `ClientError` `err` occurred
-    pub fn new(period: u64) -> Result<Self, ClientError> {
-        let (handle, _events) = Handle::new();
-        let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
-        Ok(Self {
+impl Default for Client {
+    fn default() -> Self {
+        let (handle, _) = Handle::new();
+        Self {
             handle,
-            participant,
-            interval: time::interval(Duration::from_secs(period)),
+            participant: Participant::default(),
+            interval: time::interval(Duration::from_secs(1)),
             coordinator_pk: CoordinatorPublicKey::zeroed(),
             has_new_coord_pk_since_last_check: false,
             global_model: None,
@@ -83,6 +80,21 @@ impl Client {
             has_new_global_model_since_last_cache: false,
             local_model: None,
             id: 0,
+        }
+    }
+}
+
+impl Client {
+    /// Create a new [`Client`]
+    ///
+    /// `period`: time period at which to poll for service data, in seconds.
+    /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
+    /// Returns `Err(err)` if `ClientError` `err` occurred
+    pub fn new(period: u64) -> Result<Self, ClientError> {
+        Ok(Self {
+            participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
+            interval: time::interval(Duration::from_secs(period)),
+            ..Self::default()
         })
     }
 
@@ -93,19 +105,12 @@ impl Client {
     /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
     /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new_with_id(period: u64, handle: Handle, id: u32) -> Result<Self, ClientError> {
-        let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
         Ok(Self {
             handle,
-            participant,
+            participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
             interval: time::interval(Duration::from_secs(period)),
-            coordinator_pk: CoordinatorPublicKey::zeroed(),
-            has_new_coord_pk_since_last_check: false,
-            global_model: None,
-            cached_model: None,
-            has_new_global_model_since_last_check: false,
-            has_new_global_model_since_last_cache: false,
-            local_model: None,
             id,
+            ..Self::default()
         })
     }
 

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -37,6 +37,7 @@ pub enum Task {
     None,
 }
 
+#[derive(Debug)]
 /// A participant in the PET protocol layer.
 pub struct Participant {
     // credentials

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -139,6 +139,7 @@ pub unsafe extern "C" fn new_client(period: c_ulong) -> *mut FFIClient {
 }
 
 #[allow(unused_unsafe)]
+#[allow(clippy::unnecessary_cast)]
 #[no_mangle]
 /// Starts the [`Client`] and executes its tasks in an asynchronous runtime.
 ///

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -311,6 +311,7 @@ pub unsafe extern "C" fn is_update_participant(client: *mut FFIClient) -> bool {
 }
 
 #[allow(unused_unsafe)]
+#[allow(clippy::unnecessary_cast)]
 #[no_mangle]
 /// Gets a mutable slice [`PrimitiveModel`] to a zero-initialized model of given primitive data type
 /// `dtype` and length `len`.
@@ -389,6 +390,7 @@ pub unsafe extern "C" fn new_model(
 }
 
 #[allow(unused_unsafe)]
+#[allow(clippy::unnecessary_cast)]
 #[no_mangle]
 /// Gets a mutable slice [`PrimitiveModel`] to the latest global model converted to the primitive
 /// data type `dtype`.
@@ -562,6 +564,7 @@ pub unsafe extern "C" fn get_model(client: *mut FFIClient, dtype: c_uint) -> Pri
 }
 
 #[allow(unused_unsafe)]
+#[allow(clippy::unnecessary_cast)]
 #[no_mangle]
 /// Registers the cached model as an updated local model.
 ///

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -68,7 +68,7 @@ pub struct SeedDictRequest {
 }
 
 /// A handle to send events to be handled by [`Service`]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Handle(UnboundedSender<Event>);
 
 impl Handle {


### PR DESCRIPTION
**References**
- [PB-774](https://xainag.atlassian.net/browse/PB-774)

**Summary**
- wrap the `Client` and a tokio `Runtime` into a `FFIClient`
- create a custom runtime in `new_client()` and start the client in that runtime in `run_client()`
- remove the callback experiment and replace it with a purposeful callback in `run_client()`
- implement error handling across the FFI boundary
- update docs and tests
- add `new_model()` for a zero-initialized cached primitive model and restrict `update_model()` to take no foreign memory but only cached models
- simplify the type-suffixed functions by removing the suffix and replace it with type flags and void pointers instead