### PR TITLE
networking over HTTP

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -38,9 +38,27 @@ checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
 name = "autocfg"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
+
+[[package]]
+name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
+name = "base64"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d1ccbaf7d9ec9537465a97bf19edc1a4e158ecb49fc16178202238c569cc42"
 
 [[package]]
 name = "bincode"
@@ -57,6 +75,49 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
+name = "buf_redux"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b953a6887648bb07a535631f2bc00fbdb2a2216f135552cb3f534ed136b9c07f"
+dependencies = [
+ "memchr",
+ "safemem",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -94,6 +155,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +200,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "dtoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
 name = "filetime"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +246,27 @@ name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -239,6 +376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,12 +396,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b7246d7e4b979c03fa093da39cfb3617a96bbeee6310af63991668d7e843ff"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "log 0.4.8",
+ "slab",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+dependencies = [
+ "base64 0.12.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime 0.3.16",
+ "sha-1",
+ "time",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "httparse"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "hyper"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e7655b9594024ad0ee439f3b5a7299369dc2a3f459b47c696f9ff676f9aa1f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "log 0.4.8",
+ "pin-project",
+ "socket2",
+ "time",
+ "tokio",
+ "tower-service",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
+dependencies = [
+ "autocfg 1.0.0",
+]
+
+[[package]]
+name = "input_buffer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -272,6 +555,15 @@ name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
+name = "js-sys"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kernel32-sys"
@@ -323,6 +615,15 @@ dependencies = [
 
 [[package]]
 name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.8",
+]
+
+[[package]]
+name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -340,10 +641,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "mime"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
+dependencies = [
+ "log 0.3.9",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "1.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216929a5ee4dd316b1702eedf5e74548c123d370f47841ceaac38ca154690ca3"
+dependencies = [
+ "mime 0.2.6",
+ "phf",
+ "phf_codegen",
+ "unicase 1.4.2",
+]
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime 0.3.16",
+ "unicase 2.6.0",
+]
 
 [[package]]
 name = "mio"
@@ -357,7 +701,7 @@ dependencies = [
  "iovec",
  "kernel32-sys",
  "libc",
- "log",
+ "log 0.4.8",
  "miow",
  "net2",
  "slab",
@@ -385,6 +729,42 @@ dependencies = [
  "net2",
  "winapi 0.2.8",
  "ws2_32-sys",
+]
+
+[[package]]
+name = "multipart"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136eed74cadb9edd2651ffba732b19a450316b680e4f48d6c79e905799e19d01"
+dependencies = [
+ "buf_redux",
+ "httparse",
+ "log 0.4.8",
+ "mime 0.2.6",
+ "mime_guess 1.8.8",
+ "quick-error",
+ "rand 0.6.5",
+ "safemem",
+ "tempfile",
+ "twoway",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log 0.4.8",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -418,7 +798,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
  "serde",
@@ -430,7 +810,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
  "serde",
 ]
@@ -441,7 +821,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-traits",
 ]
 
@@ -451,7 +831,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-integer",
  "num-traits",
 ]
@@ -462,7 +842,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -475,7 +855,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
- "autocfg",
+ "autocfg 1.0.0",
 ]
 
 [[package]]
@@ -486,6 +866,45 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl"
+version = "0.10.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg 1.0.0",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -505,6 +924,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+dependencies = [
+ "phf_shared",
+ "rand 0.6.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
+dependencies = [
+ "siphasher",
+ "unicase 1.4.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75373ff9037d112bb19bc61333a06a159eaeb217660dcfbea7d88e1db823919"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b4b44893d3c370407a1d6a5cfde7c41ae0478e31c516c85f67eb3adc51be6d"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -556,6 +1040,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,15 +1056,44 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.7",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -584,8 +1103,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -598,11 +1132,82 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.7",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -640,6 +1245,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
+dependencies = [
+ "base64 0.12.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.8",
+ "mime 0.3.16",
+ "mime_guess 2.0.3",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tls",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,6 +1298,51 @@ name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "security-framework"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "serde"
@@ -683,6 +1376,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +1419,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +1435,18 @@ name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+
+[[package]]
+name = "socket2"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03088793f677dce356f3ccc2edb1b314ad191ab702a5de3faf49304f7e104918"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi 0.3.8",
+]
 
 [[package]]
 name = "sodiumoxide"
@@ -751,6 +1486,20 @@ dependencies = [
  "libc",
  "redox_syscall",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand 0.7.3",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -804,6 +1553,7 @@ dependencies = [
  "iovec",
  "lazy_static",
  "libc",
+ "memchr",
  "mio",
  "mio-uds",
  "num_cpus",
@@ -824,6 +1574,49 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+dependencies = [
+ "futures",
+ "log 0.4.8",
+ "pin-project",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.8",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
@@ -862,7 +1655,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
- "log",
+ "log 0.4.8",
  "tracing-core",
 ]
 
@@ -897,10 +1690,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+
+[[package]]
+name = "tungstenite"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+dependencies = [
+ "base64 0.11.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "input_buffer",
+ "log 0.4.8",
+ "rand 0.7.3",
+ "sha-1",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "twoway"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "unicase"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
+dependencies = [
+ "version_check 0.1.5",
+]
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check 0.9.2",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
+name = "urlencoding"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df3561629a8bb4c57e5a2e4c43348d9e29c7c29d9b1c4c1f47166deca8f37ed"
+
+[[package]]
+name = "utf-8"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
 name = "vcpkg"
@@ -909,10 +1801,136 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log 0.4.8",
+ "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e95175b7a927258ecbb816bdada3cc469cb68593e7940b96a60f4af366a9970"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "log 0.4.8",
+ "mime 0.3.16",
+ "mime_guess 2.0.3",
+ "multipart",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tower-service",
+ "urlencoding",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log 0.4.8",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
+
+[[package]]
+name = "web-sys"
+version = "0.3.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -949,6 +1967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,14 +1997,16 @@ dependencies = [
  "futures",
  "num",
  "paste",
- "rand",
- "rand_chacha",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "reqwest",
  "serde",
  "sodiumoxide",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,8 @@ anyhow = "1.0.28"
 bitflags = "1.2.1"
 paste = "0.1.12"
 tracing-subscriber = "0.2.5"
+warp = "0.2.3"
+reqwest = "0.10.6"
 
 [[bin]]
 name = "coordinator"

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -1,8 +1,14 @@
 use xain_fl::service::Service;
 use xain_fl::rest;
+use tracing_subscriber::*;
 
 #[tokio::main]
 async fn main() {
+    let _fmt_subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(true)
+        .init();
+
     let (service, handle) = Service::new().unwrap();
 
     tokio::select! {

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -1,6 +1,5 @@
-use xain_fl::service::Service;
-use xain_fl::rest;
 use tracing_subscriber::*;
+use xain_fl::{rest, service::Service};
 
 #[tokio::main]
 async fn main() {

--- a/rust/src/bin/main.rs
+++ b/rust/src/bin/main.rs
@@ -1,7 +1,16 @@
 use xain_fl::service::Service;
+use xain_fl::rest;
 
 #[tokio::main]
 async fn main() {
-    let (service, _handle) = Service::new().unwrap();
-    service.await;
+    let (service, handle) = Service::new().unwrap();
+
+    tokio::select! {
+        _ = service => {
+            println!("shutting down: Service terminated");
+        }
+        _ = rest::serve(([127, 0, 0, 1], 3030), handle.clone()) => {
+            println!("shutting down: REST server terminated");
+        }
+    }
 }

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -25,19 +25,19 @@ async fn main() -> Result<(), ClientError> {
         .with_ansi(true)
         .init();
 
-    let (svc, handle) = Service::new().unwrap();
-    let _svc_jh = tokio::select! {
-        _ = tokio::spawn(svc) => {
-            println!("shutting down: Service terminated");
-        }
-        _ = tokio::spawn(rest::serve(([127, 0, 0, 1], 3030), handle.clone())) => {
-            println!("shutting down: REST server terminated");
-        }
-    };
+    // let (svc, handle) = Service::new().unwrap();
+    // let _svc_jh = tokio::select! {
+    //     _ = svc => {
+    //         println!("shutting down: Service terminated");
+    //     }
+    //     _ = rest::serve(([127, 0, 0, 1], 3030), handle.clone()) => {
+    //         println!("shutting down: REST server terminated");
+    //     }
+    // };
 
     let mut tasks = vec![];
     for id in 0..10 {
-        let mut client = Client::new_with_addr(1, id, "localhost:3030")?;
+        let mut client = Client::new_with_addr(1, id, "http://127.0.0.1:3030")?;
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move { client.during_round().await });

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -1,0 +1,57 @@
+use tracing_subscriber::*;
+use xain_fl::{
+    client::{Client, ClientError},
+    participant::Task,
+    service::Service,
+};
+
+/// Test-drive script of a (completely local) single-round federated learning
+/// session, intended for use as a mini integration test. It spawns a
+/// [`Service`] and 10 [`Client`]s on the tokio event loop. This serves as a
+/// simple example of getting started with the project, and may later be the
+/// basis for more automated tests.
+///
+/// important NOTE since we only test a few clients and by default, the
+/// selection ratios in the Coordinator are relatively small, it is very
+/// possible no (or too few) participants will be selected here! It's currently
+/// not possible to configure or force the selection, hence as a TEMP
+/// workaround, these should be adjusted in coordinator.rs before running this
+/// test e.g. 0.2_f64 for sum and 0.4_f64 for update.
+#[tokio::main]
+async fn main() -> Result<(), ClientError> {
+    let _fmt_subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_ansi(true)
+        .init();
+
+    let (svc, _hdl) = Service::new().unwrap();
+    let _svc_jh = tokio::spawn(svc);
+
+    let mut tasks = vec![];
+    for id in 0..10 {
+        let mut client = Client::new_with_addr(1, id, "localhost:3030")?;
+        // NOTE give spawn a task that owns client
+        // otherwise it won't live long enough
+        let join_hdl = tokio::spawn(async move { client.during_round().await });
+        tasks.push(join_hdl);
+    }
+    println!("spawned 20 clients");
+
+    let mut summers = 0;
+    let mut updaters = 0;
+    let mut unselecteds = 0;
+    for task in tasks {
+        match task.await.or(Err(ClientError::GeneralErr))?? {
+            Task::Update => updaters += 1,
+            Task::Sum => summers += 1,
+            Task::None => unselecteds += 1,
+        }
+    }
+
+    println!(
+        "{} sum, {} update, {} unselected clients completed a round",
+        summers, updaters, unselecteds
+    );
+
+    Ok(())
+}

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -2,8 +2,8 @@ use tracing_subscriber::*;
 use xain_fl::{
     client::{Client, ClientError},
     participant::Task,
-    service::Service,
-    rest,
+//  service::Service,
+//  rest,
 };
 
 /// Test-drive script of a (completely local) single-round federated learning
@@ -43,7 +43,7 @@ async fn main() -> Result<(), ClientError> {
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }
-    println!("spawned 20 clients");
+    println!("spawned 10 clients");
 
     let mut summers = 0;
     let mut updaters = 0;

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -2,15 +2,16 @@ use tracing_subscriber::*;
 use xain_fl::{
     client::{Client, ClientError},
     participant::Task,
-//  service::Service,
-//  rest,
 };
 
-/// Test-drive script of a (completely local) single-round federated learning
-/// session, intended for use as a mini integration test. It spawns a
-/// [`Service`] and 10 [`Client`]s on the tokio event loop. This serves as a
-/// simple example of getting started with the project, and may later be the
-/// basis for more automated tests.
+/// Test-drive script of a (local, but networked) single-round federated
+/// learning session, intended for use as a mini integration test. It assumes
+/// that a [`Service`] is already running and listening to
+/// http://127.0.0.1:3030.
+///
+/// 10 [`Client`]s are spawned on the tokio event loop. This serves as a simple
+/// example of getting started with the project, and may later be the basis for
+/// more automated tests.
 ///
 /// important NOTE since we only test a few clients and by default, the
 /// selection ratios in the Coordinator are relatively small, it is very
@@ -25,21 +26,9 @@ async fn main() -> Result<(), ClientError> {
         .with_ansi(true)
         .init();
 
-    // let (svc, handle) = Service::new().unwrap();
-    // let _svc_jh = tokio::select! {
-    //     _ = svc => {
-    //         println!("shutting down: Service terminated");
-    //     }
-    //     _ = rest::serve(([127, 0, 0, 1], 3030), handle.clone()) => {
-    //         println!("shutting down: REST server terminated");
-    //     }
-    // };
-
     let mut tasks = vec![];
     for id in 0..10 {
         let mut client = Client::new_with_addr(1, id, "http://127.0.0.1:3030")?;
-        // NOTE give spawn a task that owns client
-        // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -1,8 +1,8 @@
 use tracing_subscriber::*;
 use xain_fl::{
     client::{Client, ClientError},
+    mask::{FromPrimitives, Model},
     participant::Task,
-    mask::{Model, FromPrimitives},
 };
 
 /// Test-drive script of a (local, but networked) single-round federated

--- a/rust/src/bin/test-drive-net.rs
+++ b/rust/src/bin/test-drive-net.rs
@@ -2,6 +2,7 @@ use tracing_subscriber::*;
 use xain_fl::{
     client::{Client, ClientError},
     participant::Task,
+    mask::{Model, FromPrimitives},
 };
 
 /// Test-drive script of a (local, but networked) single-round federated
@@ -26,9 +27,13 @@ async fn main() -> Result<(), ClientError> {
         .with_ansi(true)
         .init();
 
+    // dummy local model for clients
+    let model = Model::from_primitives(vec![0_f32, 1_f32, 0_f32, 1_f32].into_iter()).unwrap();
+
     let mut tasks = vec![];
     for id in 0..10 {
         let mut client = Client::new_with_addr(1, id, "http://127.0.0.1:3030")?;
+        client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -29,13 +29,13 @@ async fn main() -> Result<(), ClientError> {
 
     let mut tasks = vec![];
     for id in 0..10 {
-        let mut client = Client::new_with_id(1, hdl.clone(), id)?;
+        let mut client = Client::new_with_hdl(1, hdl.clone(), id)?;
         // NOTE give spawn a task that owns client
         // otherwise it won't live long enough
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }
-    println!("spawned 20 clients");
+    println!("spawned 10 clients");
 
     let mut summers = 0;
     let mut updaters = 0;

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -5,18 +5,18 @@ use xain_fl::{
     service::Service,
 };
 
-/// Test-drive script of a (completely local) single-round federated learning
-/// session, intended for use as a mini integration test. It spawns a
-/// [`Service`] and 10 [`Client`]s on the tokio event loop. This serves as a
-/// simple example of getting started with the project, and may later be the
-/// basis for more automated tests.
+/// Test-drive script of a (local) single-round federated learning session,
+/// intended for use as a mini integration test. It spawns a [`Service`] and 10
+/// [`Client`]s on the tokio event loop. This serves as a simple example of
+/// getting started with the project, and may later be the basis for more
+/// automated tests.
 ///
 /// important NOTE since we only test a few clients and by default, the
 /// selection ratios in the Coordinator are relatively small, it is very
 /// possible no (or too few) participants will be selected here! It's currently
 /// not possible to configure or force the selection, hence as a TEMP
 /// workaround, these should be adjusted in coordinator.rs before running this
-/// test e.g. 0.2_f64 for sum and 0.4_f64 for update.
+/// test e.g. 0.2_f64 for sum and 0.6_f64 for update.
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     let _fmt_subscriber = FmtSubscriber::builder()
@@ -29,9 +29,7 @@ async fn main() -> Result<(), ClientError> {
 
     let mut tasks = vec![];
     for id in 0..10 {
-        let mut client = Client::new_with_hdl(1, hdl.clone(), id)?;
-        // NOTE give spawn a task that owns client
-        // otherwise it won't live long enough
+        let mut client = Client::new_with_hdl(1, id, hdl.clone())?;
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -3,6 +3,7 @@ use xain_fl::{
     client::{Client, ClientError},
     participant::Task,
     service::Service,
+    mask::{Model, FromPrimitives},
 };
 
 /// Test-drive script of a (local) single-round federated learning session,
@@ -27,9 +28,13 @@ async fn main() -> Result<(), ClientError> {
     let (svc, hdl) = Service::new().unwrap();
     let _svc_jh = tokio::spawn(svc);
 
+    // dummy local model for clients
+    let model = Model::from_primitives(vec![0_f32, 1_f32, 0_f32, 1_f32].into_iter()).unwrap();
+
     let mut tasks = vec![];
     for id in 0..10 {
         let mut client = Client::new_with_hdl(1, id, hdl.clone())?;
+        client.local_model = Some(model.clone());
         let join_hdl = tokio::spawn(async move { client.during_round().await });
         tasks.push(join_hdl);
     }

--- a/rust/src/bin/test-drive.rs
+++ b/rust/src/bin/test-drive.rs
@@ -1,9 +1,9 @@
 use tracing_subscriber::*;
 use xain_fl::{
     client::{Client, ClientError},
+    mask::{FromPrimitives, Model},
     participant::Task,
     service::Service,
-    mask::{Model, FromPrimitives},
 };
 
 /// Test-drive script of a (local) single-round federated learning session,

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -156,9 +156,9 @@ impl Client {
         loop {
             if let Some(params_outer) = self.proxy.get_params().await? {
                 // update our global model where necessary
-                match (params_outer.global_model, self.global_model.clone()) {
+                match (params_outer.global_model, &self.global_model) {
                     (Some(new_model), None) => self.set_global_model(new_model),
-                    (Some(new_model), Some(old_model)) if new_model != old_model => {
+                    (Some(new_model), Some(old_model)) if &new_model != old_model => {
                         self.set_global_model(new_model)
                     }
                     (None, _) => trace!(client_id = %self.id, "global model not ready yet"),

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -22,7 +22,6 @@ use tokio::time;
 /// Client-side errors
 #[derive(Debug, Error)]
 pub enum ClientError {
-
     #[error("failed to initialise participant: {0}")]
     ParticipantInitErr(InitError),
 
@@ -49,7 +48,6 @@ pub enum ClientError {
 /// its messages and delegating their processing to the underlying
 /// [`Participant`].
 pub struct Client {
-
     /// The underlying [`Participant`]
     pub(crate) participant: Participant,
 
@@ -249,7 +247,7 @@ impl Client {
                 self.proxy.post_message(sum2_msg).await?;
 
                 info!(client_id = %self.id, "sum participant completed a round");
-                break Ok(Task::Sum)
+                break Ok(Task::Sum);
             }
             // None case
             debug!(client_id = %self.id, "seed dict not ready, retrying.");
@@ -306,4 +304,3 @@ impl Client {
         }
     }
 }
-

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -10,16 +10,15 @@ use crate::{
     request::ClientReq,
     sdk::api::CachedModel,
     service::{Handle, data::RoundParametersData, SerializedGlobalModel},
+    request::Proxy,
     CoordinatorPublicKey,
     InitError,
     PetError,
-    SumDict,
     UpdateSeedDict,
 };
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use thiserror::Error;
 use tokio::time;
-use reqwest::Error;
 
 /// Client-side errors
 #[derive(Debug, Error)]
@@ -37,7 +36,10 @@ pub enum ClientError {
     DeserialiseErr(bincode::Error),
 
     #[error("network-related error: {0}")]
-    NetworkError(reqwest::Error),
+    NetworkErr(reqwest::Error),
+
+    #[error("service data not ready for receiving")]
+    DataNotReady,
 
     /// General client errors
     #[error("unexpected client error")]
@@ -51,6 +53,7 @@ pub enum ClientError {
 /// its messages and delegating their processing to the underlying
 /// [`Participant`].
 pub struct Client {
+    // TODO REMOVE
     /// Handle to the federated learning [`Service`]
     handle: Handle,
 
@@ -73,7 +76,10 @@ pub struct Client {
 
     id: u32, // NOTE identifier for client for testing; may remove later
 
+    // TODO replace with Proxy
     request: ClientReq,
+
+    proxy: Proxy,
 }
 
 impl Default for Client {
@@ -109,6 +115,23 @@ impl Client {
             ..Self::default()
         })
     }
+    // /// Create a new [`Client`]
+    // ///
+    // /// `period`: time period at which to poll for service data, in seconds.
+    // /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
+    // /// Returns `Err(err)` if `ClientError` `err` occurred
+    // pub fn new(period: u64, addr: &'static str) -> Result<Self, ClientError> {
+    //     let (handle, _events) = Handle::new(); // dummy
+    //     let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
+    //     Ok(Self {
+    //         handle,
+    //         participant,
+    //         interval: time::interval(Duration::from_secs(period)),
+    //         coordinator_pk: CoordinatorPublicKey::zeroed(),
+    //         id: 0,
+    //         request: ClientReq::new(addr),
+    //     })
+    // }
 
     /// Create a new [`Client`] with ID (useful for testing)
     ///
@@ -122,7 +145,8 @@ impl Client {
             participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
             interval: time::interval(Duration::from_secs(period)),
             id,
-            request: ClientReq::new(""),
+            request: ClientReq::new(""), // TODO remove later
+            proxy: Proxy::from(handle),
             ..Self::default()
         })
     }
@@ -136,7 +160,8 @@ impl Client {
             interval: time::interval(Duration::from_secs(period)),
             coordinator_pk: CoordinatorPublicKey::zeroed(),
             id,
-            request: ClientReq::new(addr),
+            request: ClientReq::new(addr), // TODO remove later
+            proxy: Proxy::new(addr),
         })
     }
 
@@ -215,49 +240,50 @@ impl Client {
 
     /// Duties for unselected [`Client`]s
     async fn unselected(&mut self) -> Result<Task, ClientError> {
-        info!(client_id = %self.id, "not selected for this round");
+        debug!(client_id = %self.id, "not selected");
         Ok(Task::None)
     }
 
     /// Duties for [`Client`]s selected as summers
     async fn summer(&mut self) -> Result<Task, ClientError> {
-        info!(client_id = %self.id, "selected for sum, sending sum message.");
-        let sum1_msg: Vec<u8> = self.participant.compose_sum_message(&self.coordinator_pk);
-        self.handle.send_message(sum1_msg).await;
+        info!(client_id = %self.id, "selected to sum");
+        let sum1_msg = self.participant.compose_sum_message(&self.coordinator_pk);
+        self.proxy.post_message(sum1_msg).await?;
 
-        let pk = self.participant.pk;
-        let seed_dict_ser = loop {
-            if let Ok(seed_dict_ser) = self.request.get_seeds(pk).await {
-//          if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
-                break seed_dict_ser;
+        debug!(client_id = %self.id, "sum message sent, polling for seed dict.");
+        let ppk = self.participant.pk;
+        loop {
+            if let Some(seeds) = self.proxy.get_seeds(ppk).await? {
+                debug!(client_id = %self.id, "seed dict received, sending sum2 message.");
+                let sum2_msg = self
+                    .participant
+                    .compose_sum2_message(self.coordinator_pk, &seeds)
+                    .map_err(|e| {
+                        error!("failed to compose sum2 message with seeds: {:?}", &seeds);
+                        ClientError::ParticipantErr(e)
+                    })?;
+                self.proxy.post_message(sum2_msg).await?;
+
+                info!(client_id = %self.id, "sum participant completed a round");
+                break Ok(Task::Sum)
             }
-            debug!(client_id = %self.id, "seed dictionary not ready, retrying.");
-            // updates not yet ready, try again later...
+            // None case
+            debug!(client_id = %self.id, "seed dict not ready, retrying.");
             self.interval.tick().await;
-        };
-        debug!(client_id = %self.id, "seed dictionary received");
-        let seed_dict: UpdateSeedDict = bincode::deserialize(&seed_dict_ser[..]).map_err(|e| {
-            error!(
-                "failed to deserialize seed dictionary: {}: {:?}",
-                e,
-                &seed_dict_ser[..],
-            );
-            ClientError::DeserialiseErr(e)
-        })?;
-        debug!(client_id = %self.id, "sending sum2 message");
-        let sum2_msg: Vec<u8> = self
-            .participant
-            .compose_sum2_message(self.coordinator_pk, &seed_dict)
-            .map_err(ClientError::ParticipantErr)?;
-        self.handle.send_message(sum2_msg).await;
-
-        info!(client_id = %self.id, "sum participant completed a round");
-        Ok(Task::Sum)
+        }
     }
 
     /// Duties for [`Client`]s selected as updaters
     async fn updater(&mut self) -> Result<Task, ClientError> {
         info!(client_id = %self.id, "selected to update");
+        debug!(client_id = %self.id, "polling for sum dict");
+        loop {
+            if let Some(sums) = self.proxy.get_sums().await? {
+                debug!(client_id = %self.id, "sum dict received, sending update message.");
+                let upd_msg = self
+                    .participant
+                    .compose_update_message(self.coordinator_pk, &sums);
+                self.proxy.post_message(upd_msg).await?;
 
         loop {
             if let Some(local_model) = self.local_model.take() {
@@ -296,3 +322,112 @@ impl Client {
         }
     }
 }
+
+
+    // async fn _updater(&mut self) -> Result<Task, ClientError> {
+    //     info!(client_id = %self.id, "selected to update");
+
+    //     // currently, models are not yet supported fully; later on, we should
+    //     // train a model here before polling for the sum dictionary
+
+    //     let sum_dict_ser = loop {
+    //         if let Ok(sum_dict_ser) = self.request._get_sums().await {
+    //             break sum_dict_ser;
+    //         }
+    //         debug!(client_id = %self.id, "sum dictionary not ready, retrying.");
+    //         // sums not yet ready, try again later...
+    //         self.interval.tick().await;
+    //     };
+    //     let sum_dict: crate::SumDict = bincode::deserialize(&sum_dict_ser[..]).map_err(|e| {
+    //         error!(
+    //             "failed to deserialize sum dictionary: {}: {:?}",
+    //             e,
+    //             &sum_dict_ser[..],
+    //         );
+    //         ClientError::DeserialiseErr(e)
+    //     })?;
+    //     debug!(client_id = %self.id, "sum dictionary received, sending update message.");
+    //     let upd_msg: Vec<u8> = self
+    //         .participant
+    //         .compose_update_message(self.coordinator_pk, &sum_dict);
+    //     self.handle.send_message(upd_msg).await;
+
+    //     info!(client_id = %self.id, "update participant completed a round");
+    //     Ok(Task::Update)
+    // }
+
+
+//     async fn _summer(&mut self) -> Result<Task, ClientError> {
+//         info!(client_id = %self.id, "selected for sum, sending sum message.");
+//         let sum1_msg: Vec<u8> = self.participant.compose_sum_message(&self.coordinator_pk);
+//         self.handle.send_message(sum1_msg).await;
+// //        let sc = self.request.post_message(sum1_msg).await.map_err(|e| {
+// //            warn!("error sending sum message: {}", e);
+// //            ClientError::NetworkError(e)
+// //        })?;
+// //        debug!(client_id = %self.id, "status code from sending sum message: {}", sc);
+
+//         let pk = self.participant.pk;
+
+//         // *** keep trying until we get seeds
+//         // let _seeds_ser = loop {
+//         //     let reply = self.request.get_seeds(pk).await;
+//         //     if let Ok(seeds_ser) = &reply {
+//         //         break seeds_ser;
+//         //     }
+//         //     // safe unwrap: it's an Err
+//         //     let _err = reply.unwrap_err();
+//         //     // log err
+//         //     // delay for a bit
+//         // };
+//         // ***
+
+//         let seed_dict_ser = loop {
+//             if let Ok(seed_dict_ser) = self.request.get_seeds(pk).await {
+// //          if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
+//                 break seed_dict_ser;
+//             }
+//             debug!(client_id = %self.id, "seed dictionary not ready, retrying.");
+//             // updates not yet ready, try again later...
+//             self.interval.tick().await;
+//         };
+//         debug!(client_id = %self.id, "seed dictionary received");
+//         let seed_dict: UpdateSeedDict = bincode::deserialize(&seed_dict_ser[..]).map_err(|e| {
+//             error!(
+//                 "failed to deserialize seed dictionary: {}: {:?}",
+//                 e,
+//                 &seed_dict_ser[..],
+//             );
+//             ClientError::DeserialiseErr(e)
+//         })?;
+//         debug!(client_id = %self.id, "sending sum2 message");
+//         let sum2_msg: Vec<u8> = self
+//             .participant
+//             .compose_sum2_message(self.coordinator_pk, &seed_dict)
+//             .map_err(ClientError::ParticipantErr)?;
+//         self.handle.send_message(sum2_msg).await;
+
+//         info!(client_id = %self.id, "sum participant completed a round");
+//         Ok(Task::Sum)
+//     }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -16,6 +16,10 @@ use crate::{
     SumDict,
     UpdateSeedDict,
 };
+use std::{sync::Arc, time::Duration};
+use thiserror::Error;
+use tokio::time;
+use reqwest::Error;
 
 /// Client-side errors
 #[derive(Debug, Error)]
@@ -31,6 +35,9 @@ pub enum ClientError {
     /// Error deserialising service data
     #[error("failed to deserialise service data: {0}")]
     DeserialiseErr(bincode::Error),
+
+    #[error("network-related error: {0}")]
+    NetworkError(reqwest::Error),
 
     /// General client errors
     #[error("unexpected client error")]
@@ -148,7 +155,8 @@ impl Client {
     /// [`Client`] duties within a round
     pub async fn during_round(&mut self) -> Result<Task, ClientError> {
         loop {
-            if let Some(round_params_data_ser) = self.handle.get_round_parameters().await {
+            if let Ok(round_params_data_ser) = self.request.get_params().await {
+//          if let Some(round_params_data_ser) = self.handle.get_round_parameters().await {
                 let round_params_data: RoundParametersData = bincode::deserialize(&round_params_data_ser[..])
                     .map_err(|e| {
                         error!(
@@ -209,8 +217,9 @@ impl Client {
         self.handle.send_message(sum1_msg).await;
 
         let pk = self.participant.pk;
-        let seed_dict_ser: Arc<Vec<u8>> = loop {
-            if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
+        let seed_dict_ser = loop {
+            if let Ok(seed_dict_ser) = self.request.get_seeds(pk).await {
+//          if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
                 break seed_dict_ser;
             }
             debug!(client_id = %self.id, "seed dictionary not ready, retrying.");

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -120,14 +120,15 @@ impl Client {
         })
     }
 
-    pub fn new_with_addr(period: u64, handle: Handle, addr: &'static str) -> Result<Self, ClientError> {
+    pub fn new_with_addr(period: u64, id: u32, addr: &'static str) -> Result<Self, ClientError> {
         let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
+        let (handle, _events) = Handle::new(); // dummy
         Ok(Self {
             handle,
             participant,
             interval: time::interval(Duration::from_secs(period)),
             coordinator_pk: CoordinatorPublicKey::zeroed(),
-            id: 0,
+            id,
             request: ClientReq::new(addr),
         })
     }

--- a/rust/src/client.rs
+++ b/rust/src/client.rs
@@ -14,7 +14,6 @@ use crate::{
     CoordinatorPublicKey,
     InitError,
     PetError,
-//  UpdateSeedDict,
 };
 use std::time::Duration;
 use thiserror::Error;
@@ -23,15 +22,13 @@ use tokio::time;
 /// Client-side errors
 #[derive(Debug, Error)]
 pub enum ClientError {
-    /// Error starting the underlying [`Participant`]
+
     #[error("failed to initialise participant: {0}")]
     ParticipantInitErr(InitError),
 
-    /// Error from the underlying [`Participant`]
     #[error("error arising from participant")]
     ParticipantErr(PetError),
 
-    /// Error deserialising service data
     #[error("failed to deserialise service data: {0}")]
     DeserialiseErr(bincode::Error),
 
@@ -41,7 +38,6 @@ pub enum ClientError {
     #[error("service data not ready for receiving")]
     DataNotReady,
 
-    /// General client errors
     #[error("unexpected client error")]
     GeneralErr,
 }
@@ -53,7 +49,6 @@ pub enum ClientError {
 /// its messages and delegating their processing to the underlying
 /// [`Participant`].
 pub struct Client {
-    //handle: Handle,
 
     /// The underlying [`Participant`]
     pub(crate) participant: Participant,
@@ -72,11 +67,10 @@ pub struct Client {
     pub(crate) has_new_global_model_since_last_cache: bool,
     pub(crate) local_model: Option<Model>,
 
-    id: u32, // NOTE identifier for client for testing; may remove later
+    /// Identifier for this client
+    id: u32,
 
-    // TODO replace with Proxy
-    //request: ClientReq,
-
+    /// Proxy for the service
     proxy: Proxy,
 }
 
@@ -131,35 +125,38 @@ impl Client {
     //     })
     // }
 
-    /// Create a new [`Client`] with ID (useful for testing)
+    /// Create a new [`Client`] with a given service handle.
     ///
     /// `period`: time period at which to poll for service data, in seconds.
     /// `id`: an ID to assign to the [`Client`].
+    /// `handle`: handle for communicating with the (local) service.
     /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
     /// Returns `Err(err)` if `ClientError` `err` occurred
-    // TODO rename to new_with_hdl
-    pub fn new_with_hdl(period: u64, handle: Handle, id: u32) -> Result<Self, ClientError> {
+    pub fn new_with_hdl(period: u64, id: u32, handle: Handle) -> Result<Self, ClientError> {
+        let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
         Ok(Self {
-            //handle: handle.clone(),
             participant: Participant::new().map_err(ClientError::ParticipantInitErr)?,
             interval: time::interval(Duration::from_secs(period)),
             id,
-            //request: ClientReq::new(""), // TODO remove later
             proxy: Proxy::from(handle),
             ..Self::default()
         })
     }
 
+    /// Create a new [`Client`] with a given service address.
+    ///
+    /// `period`: time period at which to poll for service data, in seconds.
+    /// `id`: an ID to assign to the [`Client`].
+    /// `addr`: service address to connect to.
+    /// Returns `Ok(client)` if [`Client`] `client` initialised successfully
+    /// Returns `Err(err)` if `ClientError` `err` occurred
     pub fn new_with_addr(period: u64, id: u32, addr: &'static str) -> Result<Self, ClientError> {
         let participant = Participant::new().map_err(ClientError::ParticipantInitErr)?;
-        //let (handle, _events) = Handle::new(); // dummy
         Ok(Self {
-            //handle,
             participant,
             interval: time::interval(Duration::from_secs(period)),
             coordinator_pk: CoordinatorPublicKey::zeroed(),
             id,
-            //request: ClientReq::new(addr), // TODO remove later
             proxy: Proxy::new(addr),
         })
     }
@@ -309,156 +306,4 @@ impl Client {
         }
     }
 }
-
-
-    // async fn _updater(&mut self) -> Result<Task, ClientError> {
-    //     info!(client_id = %self.id, "selected to update");
-
-    //     // currently, models are not yet supported fully; later on, we should
-    //     // train a model here before polling for the sum dictionary
-
-    //     let sum_dict_ser = loop {
-    //         if let Ok(sum_dict_ser) = self.request._get_sums().await {
-    //             break sum_dict_ser;
-    //         }
-    //         debug!(client_id = %self.id, "sum dictionary not ready, retrying.");
-    //         // sums not yet ready, try again later...
-    //         self.interval.tick().await;
-    //     };
-    //     let sum_dict: crate::SumDict = bincode::deserialize(&sum_dict_ser[..]).map_err(|e| {
-    //         error!(
-    //             "failed to deserialize sum dictionary: {}: {:?}",
-    //             e,
-    //             &sum_dict_ser[..],
-    //         );
-    //         ClientError::DeserialiseErr(e)
-    //     })?;
-    //     debug!(client_id = %self.id, "sum dictionary received, sending update message.");
-    //     let upd_msg: Vec<u8> = self
-    //         .participant
-    //         .compose_update_message(self.coordinator_pk, &sum_dict);
-    //     self.handle.send_message(upd_msg).await;
-
-    //     info!(client_id = %self.id, "update participant completed a round");
-    //     Ok(Task::Update)
-    // }
-
-
-//     async fn _summer(&mut self) -> Result<Task, ClientError> {
-//         info!(client_id = %self.id, "selected for sum, sending sum message.");
-//         let sum1_msg: Vec<u8> = self.participant.compose_sum_message(&self.coordinator_pk);
-//         self.handle.send_message(sum1_msg).await;
-// //        let sc = self.request.post_message(sum1_msg).await.map_err(|e| {
-// //            warn!("error sending sum message: {}", e);
-// //            ClientError::NetworkError(e)
-// //        })?;
-// //        debug!(client_id = %self.id, "status code from sending sum message: {}", sc);
-
-//         let pk = self.participant.pk;
-
-//         // *** keep trying until we get seeds
-//         // let _seeds_ser = loop {
-//         //     let reply = self.request.get_seeds(pk).await;
-//         //     if let Ok(seeds_ser) = &reply {
-//         //         break seeds_ser;
-//         //     }
-//         //     // safe unwrap: it's an Err
-//         //     let _err = reply.unwrap_err();
-//         //     // log err
-//         //     // delay for a bit
-//         // };
-//         // ***
-
-//         let seed_dict_ser = loop {
-//             if let Ok(seed_dict_ser) = self.request.get_seeds(pk).await {
-// //          if let Some(seed_dict_ser) = self.handle.get_seed_dict(pk).await {
-//                 break seed_dict_ser;
-//             }
-//             debug!(client_id = %self.id, "seed dictionary not ready, retrying.");
-//             // updates not yet ready, try again later...
-//             self.interval.tick().await;
-//         };
-//         debug!(client_id = %self.id, "seed dictionary received");
-//         let seed_dict: UpdateSeedDict = bincode::deserialize(&seed_dict_ser[..]).map_err(|e| {
-//             error!(
-//                 "failed to deserialize seed dictionary: {}: {:?}",
-//                 e,
-//                 &seed_dict_ser[..],
-//             );
-//             ClientError::DeserialiseErr(e)
-//         })?;
-//         debug!(client_id = %self.id, "sending sum2 message");
-//         let sum2_msg: Vec<u8> = self
-//             .participant
-//             .compose_sum2_message(self.coordinator_pk, &seed_dict)
-//             .map_err(ClientError::ParticipantErr)?;
-//         self.handle.send_message(sum2_msg).await;
-
-//         info!(client_id = %self.id, "sum participant completed a round");
-//         Ok(Task::Sum)
-//     }
-
-
-//     pub async fn during_round(&mut self) -> Result<Task, ClientError> {
-//         loop {
-//             let response = self.request.get_params().await;
-//             if let Ok(round_params_data_ser) = &response {
-// //          if let Some(round_params_data_ser) = self.handle.get_round_parameters().await {
-//                 // deserialize to round params data
-//                 let round_params_data: RoundParametersData = bincode::deserialize(&round_params_data_ser[..])
-//                     .map_err(|e| {
-//                         error!(
-//                             "failed to deserialize round parameters data: {}: {:?}",
-//                             e,
-//                             &round_params_data_ser[..],
-//                         );
-//                         ClientError::DeserialiseErr(e)
-//                     })?;
-//                 // are there inner params?
-//                 if let Some(ref round_params) = round_params_data.round_parameters {
-//                     // is this a new round?
-//                     if round_params.pk != self.coordinator_pk {
-//                         // new round: save coordinator pk
-//                         self.coordinator_pk = round_params.pk;
-//                         debug!(client_id = %self.id, "computing sigs and checking task");
-//                         let round_seed = round_params.seed.as_slice();
-//                         self.participant.compute_signatures(round_seed);
-//                         let (sum_frac, upd_frac) = (round_params.sum, round_params.update);
-//                         // perform duties as per my role for this round
-//                         break match self.participant.check_task(sum_frac, upd_frac) {
-//                             Task::Sum => self.summer().await,
-//                             Task::Update => self.updater().await,
-//                             Task::None => self.unselected().await,
-//                         };
-//                     }
-//                     trace!(client_id = %self.id, "still the same round");
-//                 }
-//                 // later on, also check presence of round_params_data.global_model
-//             }
-//             if let Err(req_err) = response {
-//                 warn!(client_id = %self.id, "received an error response: {}", req_err);
-//             }
-//             debug!(client_id = %self.id, "new round params not ready, retrying.");
-//             self.interval.tick().await;
-//         }
-//     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -50,7 +50,7 @@ pub enum RoundFailed {
     Unmasking(#[from] UnmaskingError),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 /// A seed for a round.
 pub struct RoundSeed(box_::Seed);
 
@@ -590,7 +590,7 @@ impl Coordinator {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct RoundParameters {
     /// The coordinator public key for encryption.
     pub pk: CoordinatorPublicKey,

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -153,8 +153,8 @@ impl Default for Coordinator {
     fn default() -> Self {
         let pk = CoordinatorPublicKey::zeroed();
         let sk = CoordinatorSecretKey::zeroed();
-        let sum = 0.2_f64;
-        let update = 0.6_f64;
+        let sum = 0.01_f64;
+        let update = 0.1_f64;
         let seed = RoundSeed::zeroed();
         let min_sum = 1_usize;
         let min_update = 3_usize;

--- a/rust/src/coordinator.rs
+++ b/rust/src/coordinator.rs
@@ -153,8 +153,8 @@ impl Default for Coordinator {
     fn default() -> Self {
         let pk = CoordinatorPublicKey::zeroed();
         let sk = CoordinatorSecretKey::zeroed();
-        let sum = 0.01_f64;
-        let update = 0.1_f64;
+        let sum = 0.2_f64;
+        let update = 0.6_f64;
         let seed = RoundSeed::zeroed();
         let min_sum = 1_usize;
         let min_update = 3_usize;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -13,6 +13,8 @@ pub mod crypto;
 pub mod mask;
 pub mod message;
 pub mod participant;
+pub mod request;
+pub mod rest;
 pub mod sdk;
 pub mod service;
 

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -1,0 +1,24 @@
+use reqwest::Client;
+use reqwest::Response;
+use reqwest::Error;
+
+pub struct PetHttp {
+    client: Client,
+    address: &'static str,
+}
+
+impl PetHttp {
+
+    pub fn new(address: &'static str) -> Self {
+        PetHttp {
+            client: Client::new(),
+            address,
+        }
+    }
+
+    pub async fn get_sums(&self) {
+        // TODO append path
+        let response: Response = self.client.get(self.address).send().await?;
+        let _bytes = response.bytes().await?;
+    }
+}

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -1,6 +1,112 @@
 use crate::{crypto::ByteObject, ParticipantPublicKey};
-use bytes::{Buf, Bytes};
-use reqwest::{Client, Error, Response, StatusCode, Url};
+use crate::service::{Handle, data::RoundParametersData};
+// use bytes::Bytes;
+use reqwest::{Client, Error, StatusCode, Response};
+// use reqwest::{Response, Url};
+use crate::request::Proxy::{InMem, Remote};
+use crate::client::ClientError;
+use crate::{SumDict, UpdateSeedDict, SeedDict};
+use bytes::Bytes;
+
+
+/// Proxy for the client to communicate with the service.
+pub enum Proxy {
+    InMem(Handle),
+    Remote(ClientReq),
+}
+
+impl Proxy {
+    pub fn new(addr: &'static str) -> Self {
+        Remote(ClientReq::new(addr))
+    }
+
+    // TODO post_message, get_sums etc.
+
+    pub async fn post_message(&self, msg: Vec<u8>) -> Result<(), ClientError> {
+        match self {
+            InMem(hdl) => {
+                hdl.send_message(msg).await;
+                Ok(())
+            },
+            Remote(req) => {
+                let resp = req.post_message(msg).await.map_err(|e| {
+                    error!("failed to POST message: {}", e);
+                    ClientError::NetworkErr(e)
+                })?;
+                // erroring status codes already caught above
+                let code = resp.status();
+                if code != StatusCode::OK {
+                    warn!("unexpected HTTP status code: {}", code)
+                };
+                Ok(())
+            },
+        }
+    }
+
+    pub async fn get_sums(&self) -> Result<Option<SumDict>, ClientError> {
+        let opt_vec = match self {
+            InMem(hdl) => {
+                let opt_arc = hdl.get_sum_dict().await;
+                opt_arc.map(|arc| (*arc).clone())
+            },
+            Remote(req) => {
+                let opt_bytes = req.get_sums().await.map_err(|e| {
+                    error!("failed to GET sum dict: {}", e);
+                    ClientError::NetworkErr(e)
+                })?;
+                opt_bytes.map(|bytes| bytes.to_vec())
+            },
+        };
+        let opt_sums = opt_vec.map(|vec| {
+            bincode::deserialize(&vec[..]).map_err(|e| {
+                error!("failed to deserialize sum dict: {}: {:?}", e, &vec[..]);
+                ClientError::DeserialiseErr(e)
+            })
+        });
+        opt_sums.transpose()
+    }
+
+    pub async fn get_seeds(&self, pk: ParticipantPublicKey) -> Result<Option<UpdateSeedDict>, ClientError> {
+        let opt_vec = match self {
+            InMem(hdl) => {
+                let opt_arc = hdl.get_seed_dict(pk).await;
+                opt_arc.map(|arc| (*arc).clone())
+            },
+            Remote(req) => {
+                let opt_bytes = req._get_seeds(pk).await.map_err(|e| {
+                    error!("failed to GET seed dict: {}", e);
+                    ClientError::NetworkErr(e)
+                })?;
+                opt_bytes.map(|bytes| bytes.to_vec())
+            },
+        };
+        let opt_seeds = opt_vec.map(|vec| {
+            bincode::deserialize(&vec[..]).map_err(|e| {
+                error!("failed to deserialize seed dict: {}: {:?}", e, &vec[..]);
+                ClientError::DeserialiseErr(e)
+            })
+        });
+        opt_seeds.transpose()
+    }
+
+    // pub async fn get_params(&self) -> Result<Option<RoundParametersData>, ClientError> {
+    //     match self {
+    //         InMem(hdl) => {
+    //             hdl.get_
+    //         },
+    //         Remote(req) => {
+    //         },
+    //     };
+    // }
+
+}
+
+impl From<Handle> for Proxy {
+    fn from(hdl: Handle) -> Self {
+        InMem(hdl)
+    }
+}
+
 
 pub struct ClientReq {
     client: Client,
@@ -15,21 +121,62 @@ impl ClientReq {
         }
     }
 
-    pub async fn post_message(&self, msg: Vec<u8>) -> Result<StatusCode, Error> {
-        let url = format!("{}/{}", self.address, "message");
+    pub async fn _post_message(&self, msg: Vec<u8>) -> Result<StatusCode, Error> {
+        let url = format!("{}/message", self.address);
         let response = self.client.post(&url).body(msg).send().await?;
         Ok(response.status())
     }
 
-    pub async fn get_sums(&self) -> Result<Vec<u8>, Error> {
-        let url = format!("{}/{}", self.address, "sums");
+    pub async fn post_message(&self, msg: Vec<u8>) -> Result<Response, Error> {
+        let url = format!("{}/message", self.address);
+        let response = self.client.post(&url).body(msg).send().await?;
+        response.error_for_status()
+    }
+
+    pub async fn _get_sums(&self) -> Result<Response, Error> {
+        let url = format!("{}/sums", self.address);
         let response = self.client.get(&url).send().await?;
-        let bytes = response.bytes().await?;
-        Ok(bytes.to_vec())
+        response.error_for_status()
+    }
+
+    pub async fn get_sums(&self) -> Result<Option<Bytes>, Error> {
+        let url = format!("{}/sums", self.address);
+        let response = self.client.get(&url).send().await?;
+        let good_resp = response.error_for_status()?;
+        let opt_body = match good_resp.status() {
+            StatusCode::NOT_FOUND => None,
+            StatusCode::OK => Some(good_resp.bytes().await?),
+            sc => {
+                warn!("unexpected HTTP status code: {}", sc);
+                None
+            }
+        };
+        Ok(opt_body)
+    }
+
+    pub async fn _get_seeds(&self, pk: ParticipantPublicKey) -> Result<Option<Bytes>, Error> {
+        let url = format!("{}/seeds", self.address);
+        let response = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/octet-stream")
+            .body(pk.as_slice().to_vec())
+            .send()
+            .await?
+            .error_for_status()?;
+        let opt_body = match response.status() {
+            StatusCode::NOT_FOUND => None,
+            StatusCode::OK => Some(response.bytes().await?),
+            sc => {
+                warn!("unexpected HTTP status code: {}", sc);
+                None
+            }
+        };
+        Ok(opt_body)
     }
 
     pub async fn get_seeds(&self, pk: ParticipantPublicKey) -> Result<Vec<u8>, Error> {
-        let url = format!("{}/{}", self.address, "seeds");
+        let url = format!("{}/seeds", self.address);
         let response = self
             .client
             .get(&url)
@@ -42,9 +189,31 @@ impl ClientReq {
     }
 
     pub async fn get_params(&self) -> Result<Vec<u8>, Error> {
-        let _url = format!("{}/{}", self.address, "params");
-        let response = self.client.get("http://127.0.0.1:3030/params").send().await?;
+        let url = format!("{}/params", self.address);
+        let response = self.client.get(&url).send().await?;
         let bytes = response.bytes().await?;
         Ok(bytes.to_vec())
     }
 }
+
+// pub async fn _get_seeds(&self, pk: ParticipantPublicKey) -> Result<Option<SeedDict>, ClientError> {
+//     let opt_ser_seeds = match self {
+//         InMem(hdl) => {
+//             Ok(hdl.get_seed_dict(pk).await)
+//         },
+//         Remote(ser_seeds) => {
+//             Err(ClientError::GeneralErr)
+//         },
+//     }?;
+//     match opt_ser_seeds {
+//         None => Ok(None),
+//         Some(ser_seeds) => {
+//             let seeds = bincode::deserialize(&ser_seeds[..]).map_err(|e| {
+//                 error!("failed to deserialize seed dict: {}: {:?}", e, &ser_seeds[..]);
+//                 ClientError::DeserialiseErr(e)
+//             })?;
+//             Ok(Some(seeds))
+//         }
+//     }
+// }
+

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -1,24 +1,47 @@
-use reqwest::Client;
-use reqwest::Response;
-use reqwest::Error;
+use crate::{crypto::ByteObject, ParticipantPublicKey};
+use bytes::{Buf, Bytes};
+use reqwest::{Client, Error, Response, StatusCode};
 
-pub struct PetHttp {
+pub struct ClientReq {
     client: Client,
     address: &'static str,
 }
 
-impl PetHttp {
-
+impl ClientReq {
     pub fn new(address: &'static str) -> Self {
-        PetHttp {
+        Self {
             client: Client::new(),
             address,
         }
     }
 
-    pub async fn get_sums(&self) {
+    pub async fn post_message(&self, msg: Vec<u8>) -> Result<StatusCode, Error> {
+        let response = self.client.post(self.address).body(msg).send().await?;
+        Ok(response.status())
+    }
+
+    pub async fn get_sums(&self) -> Result<Vec<u8>, Error> {
         // TODO append path
-        let response: Response = self.client.get(self.address).send().await?;
-        let _bytes = response.bytes().await?;
+        let response = self.client.get(self.address).send().await?;
+        let bytes = response.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+
+    pub async fn get_seeds(&self, pk: ParticipantPublicKey) -> Result<Vec<u8>, Error> {
+        let response = self
+            .client
+            .get(self.address)
+            .header("Content-Type", "application/octet-stream")
+            .body(pk.as_slice().to_vec())
+            .send()
+            .await?;
+        let bytes = response.bytes().await?;
+        Ok(bytes.to_vec())
+    }
+
+    pub async fn get_params(&self) -> Result<Vec<u8>, Error> {
+        let response = self.client.get(self.address).send().await?;
+        let bytes = response.bytes().await?;
+        Ok(bytes.to_vec())
     }
 }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -42,8 +42,8 @@ impl ClientReq {
     }
 
     pub async fn get_params(&self) -> Result<Vec<u8>, Error> {
-        let url = format!("{}/{}", self.address, "params");
-        let response = self.client.get(&url).send().await?;
+        let _url = format!("{}/{}", self.address, "params");
+        let response = self.client.get("http://127.0.0.1:3030/params").send().await?;
         let bytes = response.bytes().await?;
         Ok(bytes.to_vec())
     }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -1,6 +1,6 @@
 use crate::{crypto::ByteObject, ParticipantPublicKey};
 use bytes::{Buf, Bytes};
-use reqwest::{Client, Error, Response, StatusCode};
+use reqwest::{Client, Error, Response, StatusCode, Url};
 
 pub struct ClientReq {
     client: Client,
@@ -16,21 +16,23 @@ impl ClientReq {
     }
 
     pub async fn post_message(&self, msg: Vec<u8>) -> Result<StatusCode, Error> {
-        let response = self.client.post(self.address).body(msg).send().await?;
+        let url = format!("{}/{}", self.address, "message");
+        let response = self.client.post(&url).body(msg).send().await?;
         Ok(response.status())
     }
 
     pub async fn get_sums(&self) -> Result<Vec<u8>, Error> {
-        // TODO append path
-        let response = self.client.get(self.address).send().await?;
+        let url = format!("{}/{}", self.address, "sums");
+        let response = self.client.get(&url).send().await?;
         let bytes = response.bytes().await?;
         Ok(bytes.to_vec())
     }
 
     pub async fn get_seeds(&self, pk: ParticipantPublicKey) -> Result<Vec<u8>, Error> {
+        let url = format!("{}/{}", self.address, "seeds");
         let response = self
             .client
-            .get(self.address)
+            .get(&url)
             .header("Content-Type", "application/octet-stream")
             .body(pk.as_slice().to_vec())
             .send()
@@ -40,7 +42,8 @@ impl ClientReq {
     }
 
     pub async fn get_params(&self) -> Result<Vec<u8>, Error> {
-        let response = self.client.get(self.address).send().await?;
+        let url = format!("{}/{}", self.address, "params");
+        let response = self.client.get(&url).send().await?;
         let bytes = response.bytes().await?;
         Ok(bytes.to_vec())
     }

--- a/rust/src/request.rs
+++ b/rust/src/request.rs
@@ -35,7 +35,7 @@ impl Proxy {
                 if code != StatusCode::OK {
                     warn!("unexpected HTTP status code: {}", code)
                 };
-            },
+            }
         };
         Ok(())
     }
@@ -71,12 +71,14 @@ impl Proxy {
                     error!("failed to GET model scalar: {}", e);
                     ClientError::NetworkErr(e)
                 })?;
-                opt_text.map(|text| {
-                    text.parse().map_err(|e| {
-                        error!("failed to parse model scalar: {}: {:?}", e, text);
-                        ClientError::ParseErr
+                opt_text
+                    .map(|text| {
+                        text.parse().map_err(|e| {
+                            error!("failed to parse model scalar: {}: {:?}", e, text);
+                            ClientError::ParseErr
+                        })
                     })
-                }).transpose()
+                    .transpose()
             }
         }
     }

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -19,7 +19,7 @@ async fn handle_whatever(name: String) -> Result<impl warp::Reply, Rejection> {
 }
 
 pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
-    let route = warp::path!("hello" / String)
+    let _route = warp::path!("hello" / String)
 //      .map(|name| format!("Hello, {}!", name));
         .and_then(handle_whatever);
 
@@ -34,26 +34,25 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
         .and(with_hdl(handle.clone()))
         .and_then(handle_sums);
 
-    // can't take pk as param in the path, as it doesn't impl FromStr...
     let seed_dict = warp::path!("seeds")
         .and(warp::get())
-        // ... so let's assume that it's in the request body
-        // it's not good HTTP 1.1 practice but what can you do
-        .and(warp::body::bytes())
+//      .and(warp::body::bytes())
+        .and(part_pk())
         .and(with_hdl(handle.clone()))
-        .and_then(handle_seeds);
+        .and_then(handle_seeds)
+        .recover(handle_reject);
 
     let round_params = warp::path!("params")
         .and(warp::get())
         .and(with_hdl(handle))
         .and_then(handle_params);
 
-    let _routes = message
+    let routes = message
         .or(sum_dict)
-        .or(seed_dict)
-        .or(round_params);
+        .or(round_params)
+        .or(seed_dict);
 
-    warp::serve(route).run(addr).await
+    warp::serve(routes).run(addr).await
 }
 
 async fn handle_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
@@ -61,21 +60,14 @@ async fn handle_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply,
     Ok(warp::reply())
 }
 
-async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
-    let sum_dict = handle
-        .get_sum_dict()
-        .await
-        .ok_or(warp::reject::not_found())?;
-    let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap(); // HACK
-    Ok(warp::reply::with_header(sum_dict_bytes, "Content-Type", "application/octet-stream"))
+async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    let sums = handle.get_sum_dict().await;
+    Ok(build_response(sums))
 }
 
-async fn _handle_sums(handle: Handle) -> Result<impl warp::Reply, Infallible> {
-    // we'll use a response Builder - the warp::reply convenience functions not
-    // so convenient here as the status / header will vary depending on the
-    // result of get_sum_dict()
+fn build_response(data: Option<Arc<Vec<u8>>>) -> Response<Vec<u8>> {
     let builder = Response::builder();
-    let response = match handle.get_sum_dict().await {
+    match data {
         None => {
             builder
                 .status(StatusCode::NO_CONTENT) // 204
@@ -83,32 +75,78 @@ async fn _handle_sums(handle: Handle) -> Result<impl warp::Reply, Infallible> {
                 .unwrap()
         },
         Some(arc_vec) => {
-            // need inner value of Arc for warp::Reply
-            let vec = (*arc_vec).clone();
+            let vec = (*arc_vec).clone(); // need inner value for warp::Reply
             builder
                 .header("Content-Type", "application/octet-stream")
                 .body(vec)
                 .unwrap()
         },
+    }
+}
+
+async fn handle_seeds(pk: ParticipantPublicKey, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    let seeds = handle.get_seed_dict(pk).await;
+    Ok(build_response(seeds))
+}
+
+async fn handle_params(handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    let params = handle.get_round_parameters().await;
+    Ok(build_response(params))
+}
+
+fn part_pk() -> impl Filter<Extract = (ParticipantPublicKey,), Error = warp::Rejection> + Clone {
+    warp::body::bytes().and_then(|body: Bytes| async move {
+        if let Some(pk) = ParticipantPublicKey::from_slice(body.bytes()) {
+            Ok(pk)
+        } else {
+            Err(warp::reject::custom(InvalidPublicKey))
+        }
+    })
+}
+
+#[derive(Debug)]
+struct InvalidPublicKey;
+
+impl warp::reject::Reject for InvalidPublicKey {}
+
+async fn handle_reject(err: warp::Rejection) -> Result<impl warp::Reply, Infallible> {
+    let code;
+    if err.is_not_found() {
+        code = StatusCode::NOT_FOUND
+    } else if let Some(InvalidPublicKey) = err.find() {
+        code = StatusCode::BAD_REQUEST
+    } else {
+        error!("unhandled rejection: {:?}", err);
+        code = StatusCode::INTERNAL_SERVER_ERROR
     };
-    Ok(response)
-}
-
-// TODO prob want Rejection rather than Infallible since body may not be pk
-async fn handle_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Rejection> {
-    // TODO check key higher up and reject if cannot parse
-    let pk = ParticipantPublicKey::from_slice(body.bytes()).ok_or(warp::reject::reject())?;
-    let seed_dict: Arc<_> = handle.get_seed_dict(pk).await.ok_or(warp::reject::not_found())?;
-    let seed_dict_bytes = Arc::try_unwrap(seed_dict).unwrap();
-    Ok(warp::reply::with_header(seed_dict_bytes, "Content-Type", "application/octet-stream"))
-}
-
-async fn handle_params(handle: Handle) -> Result<impl warp::Reply, Rejection> {
-    let round_params = handle.get_round_parameters().await.ok_or(warp::reject::not_found())?;
-    let round_params_bytes = Arc::try_unwrap(round_params).unwrap();
-    Ok(warp::reply::with_header(round_params_bytes, "Content-Type", "application/octet-stream"))
+    // reply with empty body; the status code is the interesting part
+    Ok(warp::reply::with_status(Vec::with_capacity(0), code))
 }
 
 fn with_hdl(hdl: Handle) -> impl Filter<Extract = (Handle,), Error = Infallible> + Clone {
     warp::any().map(move || hdl.clone())
 }
+
+// TODO prob want Rejection rather than Infallible since body may not be pk
+// async fn handle_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Rejection> {
+//     // TODO check key higher up and reject if cannot parse
+//     let pk = ParticipantPublicKey::from_slice(body.bytes()).ok_or(warp::reject::reject())?;
+//     let seed_dict: Arc<_> = handle.get_seed_dict(pk).await.ok_or(warp::reject::not_found())?;
+//     let seed_dict_bytes = Arc::try_unwrap(seed_dict).unwrap();
+//     Ok(warp::reply::with_header(seed_dict_bytes, "Content-Type", "application/octet-stream"))
+// }
+
+// async fn handle_params(handle: Handle) -> Result<impl warp::Reply, Rejection> {
+//     let round_params = handle.get_round_parameters().await.ok_or(warp::reject::not_found())?;
+//     let round_params_bytes = Arc::try_unwrap(round_params).unwrap();
+//     Ok(warp::reply::with_header(round_params_bytes, "Content-Type", "application/octet-stream"))
+// }
+
+// async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
+//     let sum_dict = handle
+//         .get_sum_dict()
+//         .await
+//         .ok_or(warp::reject::not_found())?;
+//     let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap(); // HACK
+//     Ok(warp::reply::with_header(sum_dict_bytes, "Content-Type", "application/octet-stream"))
+// }

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -71,10 +71,9 @@ async fn handle_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, R
 }
 
 async fn handle_params(handle: Handle) -> Result<impl warp::Reply, Rejection> {
-    let _round_params = handle.get_round_parameters().await.ok_or(warp::reject::not_found())?;
-    //let round_params_bytes = Arc::try_unwrap(round_params).unwrap();
-    //Ok(warp::reply::with_header(round_params_bytes, "Content-Type", "application/octet-stream"));
-    Ok(warp::reply())
+    let round_params = handle.get_round_parameters().await.ok_or(warp::reject::not_found())?;
+    let round_params_bytes = Arc::try_unwrap(round_params).unwrap();
+    Ok(warp::reply::with_header(round_params_bytes, "Content-Type", "application/octet-stream"))
 }
 
 fn with_hdl(hdl: Handle) -> impl Filter<Extract = (Handle,), Error = Infallible> + Clone {

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -1,15 +1,12 @@
-use crate::service::Handle;
-use crate::ParticipantPublicKey;
-use crate::crypto::ByteObject;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use bytes::Bytes;
-use bytes::Buf;
-use warp::Filter;
-use std::convert::Infallible;
-use warp::http::{StatusCode, Response};
+use crate::{crypto::ByteObject, service::Handle, ParticipantPublicKey};
+use bytes::{Buf, Bytes};
+use std::{convert::Infallible, net::SocketAddr, sync::Arc};
+use warp::{
+    http::{Response, StatusCode},
+    Filter,
+};
 
-
+#[rustfmt::skip]
 pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
 
     let message = warp::path!("message")
@@ -53,7 +50,10 @@ async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Infallible> {
     Ok(build_response(sums))
 }
 
-async fn handle_seeds(pk: ParticipantPublicKey, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+async fn handle_seeds(
+    pk: ParticipantPublicKey,
+    handle: Handle,
+) -> Result<impl warp::Reply, Infallible> {
     let seeds = handle.get_seed_dict(pk).await;
     Ok(build_response(seeds))
 }
@@ -73,16 +73,16 @@ fn build_response(data: Option<Arc<Vec<u8>>>) -> Response<Vec<u8>> {
         None => {
             builder
                 .status(StatusCode::NO_CONTENT) // 204
-                .body(Vec::with_capacity(0))    // empty body; won't allocate
+                .body(Vec::with_capacity(0)) // empty body; won't allocate
                 .unwrap()
-        },
+        }
         Some(arc_vec) => {
             let vec = (*arc_vec).clone(); // need inner value for warp::Reply
             builder
                 .header("Content-Type", "application/octet-stream")
                 .body(vec)
                 .unwrap()
-        },
+        }
     }
 }
 
@@ -114,4 +114,3 @@ async fn handle_reject(err: warp::Rejection) -> Result<impl warp::Reply, Infalli
     // reply with empty body; the status code is the interesting part
     Ok(warp::reply::with_status(Vec::with_capacity(0), code))
 }
-

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -18,12 +18,12 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
         .and(warp::post())
         .and(warp::body::bytes())
         .and(with_hdl(handle.clone()))
-        .and_then(send_message);
+        .and_then(handle_message);
 
     let sum_dict = warp::path!("sums")
         .and(warp::get())
         .and(with_hdl(handle.clone()))
-        .and_then(get_sums);
+        .and_then(handle_sums);
 
     // can't take pk as param in the path, as it doesn't impl FromStr...
     let seed_dict = warp::path!("seeds")
@@ -32,12 +32,12 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
         // it's not good HTTP 1.1 practice but what can you do
         .and(warp::body::bytes())
         .and(with_hdl(handle.clone()))
-        .and_then(get_seeds);
+        .and_then(handle_seeds);
 
     let round_params = warp::path!("params")
         .and(warp::get())
         .and(with_hdl(handle))
-        .and_then(get_params);
+        .and_then(handle_params);
 
     let routes = message
         .or(sum_dict)
@@ -47,32 +47,34 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
     warp::serve(routes).run(addr).await
 }
 
-async fn send_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+async fn handle_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
     handle.send_message(body.to_vec()).await;
     Ok(warp::reply())
 }
 
-async fn get_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
+async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
     let sum_dict = handle
         .get_sum_dict()
         .await
         .ok_or(warp::reject::not_found())?;
-    let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap();
+    let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap(); // HACK
     Ok(warp::reply::with_header(sum_dict_bytes, "Content-Type", "application/octet-stream"))
 }
 
 // TODO prob want Rejection rather than Infallible since body may not be pk
-async fn get_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+async fn handle_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Rejection> {
     // TODO check key higher up and reject if cannot parse
-    let pk = ParticipantPublicKey::from_slice(body.bytes()).unwrap();
-    let seed_dict: Arc<_> = handle.get_seed_dict(pk).await.unwrap();
+    let pk = ParticipantPublicKey::from_slice(body.bytes()).ok_or(warp::reject::reject())?;
+    let seed_dict: Arc<_> = handle.get_seed_dict(pk).await.ok_or(warp::reject::not_found())?;
     let seed_dict_bytes = Arc::try_unwrap(seed_dict).unwrap();
     Ok(warp::reply::with_header(seed_dict_bytes, "Content-Type", "application/octet-stream"))
 }
 
-async fn get_params(handle: Handle) -> Result<impl warp::Reply, Infallible> {
-    handle.get_round_parameters().await;
-    Ok(warp::reply()) // TODO
+async fn handle_params(handle: Handle) -> Result<impl warp::Reply, Rejection> {
+    let _round_params = handle.get_round_parameters().await.ok_or(warp::reject::not_found())?;
+    //let round_params_bytes = Arc::try_unwrap(round_params).unwrap();
+    //Ok(warp::reply::with_header(round_params_bytes, "Content-Type", "application/octet-stream"));
+    Ok(warp::reply())
 }
 
 fn with_hdl(hdl: Handle) -> impl Filter<Extract = (Handle,), Error = Infallible> + Clone {

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -1,0 +1,80 @@
+use crate::service::Handle;
+use crate::ParticipantPublicKey;
+use crate::crypto::ByteObject;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use bytes::Bytes;
+use bytes::Buf;
+use warp::Filter;
+use warp::http::{StatusCode, Response};
+use warp::reject::Rejection;
+use std::convert::Infallible;
+
+pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
+    let _route = warp::path!("hello" / String)
+        .map(|name| format!("Hello, {}!", name));
+
+    let message = warp::path!("message")
+        .and(warp::post())
+        .and(warp::body::bytes())
+        .and(with_hdl(handle.clone()))
+        .and_then(send_message);
+
+    let sum_dict = warp::path!("sums")
+        .and(warp::get())
+        .and(with_hdl(handle.clone()))
+        .and_then(get_sums);
+
+    // can't take pk as param in the path, as it doesn't impl FromStr...
+    let seed_dict = warp::path!("seeds")
+        .and(warp::get())
+        // ... so let's assume that it's in the request body
+        // it's not good HTTP 1.1 practice but what can you do
+        .and(warp::body::bytes())
+        .and(with_hdl(handle.clone()))
+        .and_then(get_seeds);
+
+    let round_params = warp::path!("params")
+        .and(warp::get())
+        .and(with_hdl(handle))
+        .and_then(get_params);
+
+    let routes = message
+        .or(sum_dict)
+        .or(seed_dict)
+        .or(round_params);
+
+    warp::serve(routes).run(addr).await
+}
+
+async fn send_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    handle.send_message(body.to_vec()).await;
+    Ok(warp::reply())
+}
+
+async fn get_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
+    let sum_dict = handle
+        .get_sum_dict()
+        .await
+        .ok_or(warp::reject::not_found())?;
+    let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap();
+    Ok(warp::reply::with_header(sum_dict_bytes, "Content-Type", "application/octet-stream"))
+}
+
+// TODO prob want Rejection rather than Infallible since body may not be pk
+async fn get_seeds(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    // TODO check key higher up and reject if cannot parse
+    let pk = ParticipantPublicKey::from_slice(body.bytes()).unwrap();
+    let seed_dict: Arc<_> = handle.get_seed_dict(pk).await.unwrap();
+    let seed_dict_bytes = Arc::try_unwrap(seed_dict).unwrap();
+    Ok(warp::reply::with_header(seed_dict_bytes, "Content-Type", "application/octet-stream"))
+}
+
+async fn get_params(handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    handle.get_round_parameters().await;
+    Ok(warp::reply()) // TODO
+}
+
+fn with_hdl(hdl: Handle) -> impl Filter<Extract = (Handle,), Error = Infallible> + Clone {
+    warp::any().map(move || hdl.clone())
+}

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -6,13 +6,22 @@ use std::sync::Arc;
 use bytes::Bytes;
 use bytes::Buf;
 use warp::Filter;
-use warp::http::{StatusCode, Response};
 use warp::reject::Rejection;
 use std::convert::Infallible;
+use warp::http::{StatusCode, Response};
+
+async fn handle_whatever(name: String) -> Result<impl warp::Reply, Rejection> {
+    match name.len() {
+        2 => Ok(warp::reply()),
+        _default => Err(warp::reject::not_found()),
+    }
+
+}
 
 pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
-    let _route = warp::path!("hello" / String)
-        .map(|name| format!("Hello, {}!", name));
+    let route = warp::path!("hello" / String)
+//      .map(|name| format!("Hello, {}!", name));
+        .and_then(handle_whatever);
 
     let message = warp::path!("message")
         .and(warp::post())
@@ -39,12 +48,12 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
         .and(with_hdl(handle))
         .and_then(handle_params);
 
-    let routes = message
+    let _routes = message
         .or(sum_dict)
         .or(seed_dict)
         .or(round_params);
 
-    warp::serve(routes).run(addr).await
+    warp::serve(route).run(addr).await
 }
 
 async fn handle_message(body: Bytes, handle: Handle) -> Result<impl warp::Reply, Infallible> {
@@ -59,6 +68,30 @@ async fn handle_sums(handle: Handle) -> Result<impl warp::Reply, Rejection> {
         .ok_or(warp::reject::not_found())?;
     let sum_dict_bytes = Arc::try_unwrap(sum_dict).unwrap(); // HACK
     Ok(warp::reply::with_header(sum_dict_bytes, "Content-Type", "application/octet-stream"))
+}
+
+async fn _handle_sums(handle: Handle) -> Result<impl warp::Reply, Infallible> {
+    // we'll use a response Builder - the warp::reply convenience functions not
+    // so convenient here as the status / header will vary depending on the
+    // result of get_sum_dict()
+    let builder = Response::builder();
+    let response = match handle.get_sum_dict().await {
+        None => {
+            builder
+                .status(StatusCode::NO_CONTENT) // 204
+                .body(Vec::with_capacity(0))    // empty body; won't allocate
+                .unwrap()
+        },
+        Some(arc_vec) => {
+            // need inner value of Arc for warp::Reply
+            let vec = (*arc_vec).clone();
+            builder
+                .header("Content-Type", "application/octet-stream")
+                .body(vec)
+                .unwrap()
+        },
+    };
+    Ok(response)
 }
 
 // TODO prob want Rejection rather than Infallible since body may not be pk

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -65,7 +65,7 @@ async fn handle_scalar(handle: Handle) -> Result<impl warp::Reply, Infallible> {
                 .status(StatusCode::NO_CONTENT) // 204
                 .body(String::new()) // empty body; won't allocate
                 .unwrap()
-        },
+        }
     };
     Ok(response)
 }

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -641,7 +641,7 @@ mod tests {
 
     #[test]
     fn test_run_client() {
-        // check that the client panics when running it without a service
+        // check for network error when running client without a service
         let client = unsafe { new_client(10) };
         assert_eq!(unsafe { run_client(client) }, 5);
         unsafe { drop_client(client, 0) };

--- a/rust/src/sdk/api.rs
+++ b/rust/src/sdk/api.rs
@@ -154,7 +154,9 @@ pub unsafe extern "C" fn new_client(period: c_ulong) -> *mut FFIClient {
 /// - `2`: client stopped due to error [`ParticipantInitErr`]
 /// - `3`: client stopped due to error [`ParticipantErr`]
 /// - `4`: client stopped due to error [`DeserialiseErr`]
-/// - `5`: client stopped due to error [`GeneralErr`]
+/// - `5`: client stopped due to error [`NetworkErr`]
+/// - `6`: client stopped due to error [`ParseErr`]
+/// - `7`: client stopped due to error [`GeneralErr`]
 ///
 /// # Safety
 /// The method dereferences from the raw pointer arguments. Therefore, the behavior of the method is
@@ -166,6 +168,8 @@ pub unsafe extern "C" fn new_client(period: c_ulong) -> *mut FFIClient {
 /// [`ParticipantInitErr`]: ../../client/enum.ClientError.html#variant.ParticipantInitErr
 /// [`ParticipantErr`]: ../../client/enum.ClientError.html#variant.ParticipantErr
 /// [`DeserialiseErr`]: ../../client/enum.ClientError.html#variant.DeserialiseErr
+/// [`NetworkErr`]: ../../client/enum.ClientError.html#variant.NetworkErr
+/// [`ParseErr`]: ../../client/enum.ClientError.html#variant.ParseErr
 /// [`GeneralErr`]: ../../client/enum.ClientError.html#variant.GeneralErr
 pub unsafe extern "C" fn run_client(client: *mut FFIClient) -> c_int {
     if client.is_null() {
@@ -195,7 +199,9 @@ pub unsafe extern "C" fn run_client(client: *mut FFIClient) -> c_int {
         Ok(Err(ClientError::ParticipantInitErr(_))) => 2_i32 as c_int,
         Ok(Err(ClientError::ParticipantErr(_))) => 3_i32 as c_int,
         Ok(Err(ClientError::DeserialiseErr(_))) => 4_i32 as c_int,
-        Ok(Err(ClientError::GeneralErr)) => 5_i32 as c_int,
+        Ok(Err(ClientError::NetworkErr(_))) => 5_i32 as c_int,
+        Ok(Err(ClientError::ParseErr)) => 6_i32 as c_int,
+        Ok(Err(ClientError::GeneralErr)) => 7_i32 as c_int,
     }
 }
 
@@ -396,7 +402,7 @@ pub unsafe extern "C" fn new_model(
 /// and void data type immediately.
 ///
 /// Returns a [`PrimitiveModel`] with null pointer, length zero and data type `dtype` if no global
-/// model is available or deserialization of the global model fails.
+/// model is available.
 ///
 /// Returns a [`PrimitiveModel`] with null pointer, length of the global model and data type `dtype`
 /// if the conversion of the global model into the primitive data type fails.
@@ -420,7 +426,7 @@ pub unsafe extern "C" fn get_model(client: *mut FFIClient, dtype: c_uint) -> Pri
     };
 
     // global model available
-    if let Some(ref global_model) = client.global_model {
+    if let Some(global_model) = client.global_model.clone() {
         // global model is already cached as a primitive model
         if !client.has_new_global_model_since_last_cache {
             match dtype {
@@ -464,83 +470,80 @@ pub unsafe extern "C" fn get_model(client: *mut FFIClient, dtype: c_uint) -> Pri
             }
         }
 
-        // deserialize and convert the global model to a primitive model and cache it
+        // convert the global model to a primitive model and cache it
         client.has_new_global_model_since_last_cache = false;
-        if let Ok(deserialized_model) = bincode::deserialize::<Model>(&global_model) {
-            // deserialization succeeded
-            let len = deserialized_model.len() as c_ulong;
-            let ptr = match dtype {
-                1 => {
-                    if let Ok(mut cached_model) = deserialized_model
-                        .into_primitives()
-                        .map(|res| res.map_err(|_| ()))
-                        .collect::<Result<Vec<f32>, ()>>()
-                    {
-                        // conversion succeeded
-                        let ptr = cached_model.as_mut_ptr() as *mut c_void;
-                        client.cached_model = Some(CachedModel::F32(cached_model));
-                        ptr
-                    } else {
-                        // conversion failed
-                        client.cached_model = None;
-                        ptr::null_mut() as *mut c_void
-                    }
+        let len = global_model.len() as c_ulong;
+        let ptr = match dtype {
+            1 => {
+                if let Ok(mut cached_model) = global_model
+                    .into_primitives()
+                    .map(|res| res.map_err(|_| ()))
+                    .collect::<Result<Vec<f32>, ()>>()
+                {
+                    // conversion succeeded
+                    let ptr = cached_model.as_mut_ptr() as *mut c_void;
+                    client.cached_model = Some(CachedModel::F32(cached_model));
+                    ptr
+                } else {
+                    // conversion failed
+                    client.cached_model = None;
+                    ptr::null_mut() as *mut c_void
                 }
-                2 => {
-                    if let Ok(mut cached_model) = deserialized_model
-                        .into_primitives()
-                        .map(|res| res.map_err(|_| ()))
-                        .collect::<Result<Vec<f64>, ()>>()
-                    {
-                        // conversion succeeded
-                        let ptr = cached_model.as_mut_ptr() as *mut c_void;
-                        client.cached_model = Some(CachedModel::F64(cached_model));
-                        ptr
-                    } else {
-                        // conversion failed
-                        client.cached_model = None;
-                        ptr::null_mut() as *mut c_void
-                    }
+            }
+            2 => {
+                if let Ok(mut cached_model) = global_model
+                    .into_primitives()
+                    .map(|res| res.map_err(|_| ()))
+                    .collect::<Result<Vec<f64>, ()>>()
+                {
+                    // conversion succeeded
+                    let ptr = cached_model.as_mut_ptr() as *mut c_void;
+                    client.cached_model = Some(CachedModel::F64(cached_model));
+                    ptr
+                } else {
+                    // conversion failed
+                    client.cached_model = None;
+                    ptr::null_mut() as *mut c_void
                 }
-                3 => {
-                    if let Ok(mut cached_model) = deserialized_model
-                        .into_primitives()
-                        .map(|res| res.map_err(|_| ()))
-                        .collect::<Result<Vec<i32>, ()>>()
-                    {
-                        // conversion succeeded
-                        let ptr = cached_model.as_mut_ptr() as *mut c_void;
-                        client.cached_model = Some(CachedModel::I32(cached_model));
-                        ptr
-                    } else {
-                        // conversion failed
-                        client.cached_model = None;
-                        ptr::null_mut() as *mut c_void
-                    }
+            }
+            3 => {
+                if let Ok(mut cached_model) = global_model
+                    .into_primitives()
+                    .map(|res| res.map_err(|_| ()))
+                    .collect::<Result<Vec<i32>, ()>>()
+                {
+                    // conversion succeeded
+                    let ptr = cached_model.as_mut_ptr() as *mut c_void;
+                    client.cached_model = Some(CachedModel::I32(cached_model));
+                    ptr
+                } else {
+                    // conversion failed
+                    client.cached_model = None;
+                    ptr::null_mut() as *mut c_void
                 }
-                4 => {
-                    if let Ok(mut cached_model) = deserialized_model
-                        .into_primitives()
-                        .map(|res| res.map_err(|_| ()))
-                        .collect::<Result<Vec<i64>, ()>>()
-                    {
-                        // conversion succeeded
-                        let ptr = cached_model.as_mut_ptr() as *mut c_void;
-                        client.cached_model = Some(CachedModel::I64(cached_model));
-                        ptr
-                    } else {
-                        // conversion failed
-                        client.cached_model = None;
-                        ptr::null_mut() as *mut c_void
-                    }
+            }
+            4 => {
+                if let Ok(mut cached_model) = global_model
+                    .into_primitives()
+                    .map(|res| res.map_err(|_| ()))
+                    .collect::<Result<Vec<i64>, ()>>()
+                {
+                    // conversion succeeded
+                    let ptr = cached_model.as_mut_ptr() as *mut c_void;
+                    client.cached_model = Some(CachedModel::I64(cached_model));
+                    ptr
+                } else {
+                    // conversion failed
+                    client.cached_model = None;
+                    ptr::null_mut() as *mut c_void
                 }
-                _ => unreachable!(),
-            };
-            return PrimitiveModel { ptr, len, dtype };
-        }
+            }
+            _ => unreachable!(),
+        };
+        return PrimitiveModel { ptr, len, dtype };
     }
 
-    // global model unavailable or deserialization failed
+    // global model unavailable
     client.cached_model = None;
     PrimitiveModel {
         ptr: ptr::null_mut() as *mut c_void,

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -13,7 +13,7 @@ use std::{collections::HashMap, sync::Arc};
 /// Data that the service keeps track of.
 #[derive(From, Default)]
 pub struct Data {
-    // Parameters of the current round.
+    /// Parameters of the current round.
     pub round_parameters_data: Option<Arc<RoundParametersData>>,
     /// Parameters of the current round, serialized.
     pub round_params_data_serialized: Option<Arc<Vec<u8>>>,

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 use crate::{
     coordinator::{ProtocolEvent, RoundParameters},
     mask::model::Model,
-    service::handle::{SerializedGlobalModel, SerializedSeedDict, SerializedSumDict},
+    service::handle::{SerializedSeedDict, SerializedSumDict},
     SeedDict,
     SumParticipantPublicKey,
 };
@@ -13,14 +13,15 @@ use std::{collections::HashMap, sync::Arc};
 /// Data that the service keeps track of.
 #[derive(From, Default)]
 pub struct Data {
-    /// Parameters of the current round.
+    // Parameters of the current round.
     pub round_parameters_data: Option<Arc<RoundParametersData>>,
+    /// Parameters of the current round, serialized.
+    pub round_params_data_serialized: Option<Arc<Vec<u8>>>,
     /// Data relevant to the current phase of the protocol. During the
     /// update phase, this contains the sum dictionary to be sent to
     /// the update participants for instance, while during the sum2
     /// phase it contains the seed dictionaries.
     pub phase_data: Option<PhaseData>,
-    pub round_params_data_serialized: Option<Arc<Vec<u8>>>,
 }
 
 /// Data held by the service in specific phases
@@ -165,7 +166,6 @@ impl Data {
     }
 
     pub fn round_parameters(&self) -> Option<Arc<Vec<u8>>> {
-        //self.round_parameters_data.clone()
         self.round_params_data_serialized.clone()
     }
 
@@ -243,7 +243,6 @@ pub struct RoundParametersData {
     pub round_parameters: Option<RoundParameters>,
 
     /// The global model of the previous round.
-    //pub global_model: Option<SerializedGlobalModel>,
     pub global_model: Option<Model>,
 }
 
@@ -262,10 +261,7 @@ impl RoundParametersData {
         &self,
         global_model: Model,
     ) -> Result<RoundParametersData, DataUpdateError> {
-        // let serialized = bincode::serialize(&global_model)
-        //     .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
         Ok(RoundParametersData {
-            //            global_model: Some(Arc::new(serialized)),
             global_model: Some(global_model),
             ..Default::default()
         })
@@ -281,19 +277,10 @@ impl From<RoundParameters> for RoundParametersData {
     }
 }
 
-// impl From<Option<SerializedGlobalModel>> for RoundParametersData {
-//     fn from(serialized_global_model: Option<SerializedGlobalModel>) -> RoundParametersData {
-//         RoundParametersData {
-//             global_model: serialized_global_model,
-//             ..Default::default()
-//         }
-//     }
-// }
-
 impl From<Option<Model>> for RoundParametersData {
     fn from(global_model: Option<Model>) -> RoundParametersData {
         RoundParametersData {
-            global_model: global_model,
+            global_model,
             ..Default::default()
         }
     }

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -94,27 +94,27 @@ impl Data {
                 if let Some(round_parameters_data) = self.round_parameters_data.take() {
                     // Round > 1
                     // Update the round parameters. Keep the global model from the previous round.
-                    self.round_parameters_data =
-                        Some(Arc::new(
-                            round_parameters_data.update_round_parameters(round_parameters.clone()),
-                        ));
+                    self.round_parameters_data = Some(Arc::new(
+                        round_parameters_data.update_round_parameters(round_parameters.clone()),
+                    ));
 
-                    let data_unser = round_parameters_data.update_round_parameters(round_parameters);
+                    let data_unser =
+                        round_parameters_data.update_round_parameters(round_parameters);
                     let data_ser = bincode::serialize(&data_unser)
                         .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
                     self.round_params_data_serialized = Some(Arc::new(data_ser))
                 } else {
                     // Round = 1
                     // First round, update the round parameters and set the global model to None.
-                    self.round_parameters_data =
-                        Some(Arc::new(RoundParametersData::from(round_parameters.clone())));
+                    self.round_parameters_data = Some(Arc::new(RoundParametersData::from(
+                        round_parameters.clone(),
+                    )));
 
                     let data_unser = RoundParametersData::from(round_parameters);
                     let data_ser = bincode::serialize(&data_unser)
                         .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
                     self.round_params_data_serialized = Some(Arc::new(data_ser))
                 };
-
 
                 self.phase_data = Some(SumData.into());
             }
@@ -285,4 +285,3 @@ impl From<Option<Model>> for RoundParametersData {
         }
     }
 }
-

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -45,20 +45,28 @@ pub enum PhaseData {
 }
 
 impl PhaseData {
-    /// Return the current sum dictionary and model scalar if they are available. The
-    /// availability of the sum dictionary and model scalar depends on the current
-    /// coordinatore state.
-    pub fn sum_dict_and_scalar(&self) -> Option<(SerializedSumDict, f64)> {
+    /// Return the current sum dictionary if available. The availability depends
+    /// on the current coordinator state.
+    pub fn sum_dict(&self) -> Option<SerializedSumDict> {
         if let PhaseData::Update(data) = self {
-            Some((data.serialized_sum_dict.clone(), data.scalar))
+            Some(data.serialized_sum_dict.clone())
         } else {
             None
         }
     }
 
-    /// Return the current seed dictionary if it is available. The
-    /// availability of the seed dictionary depends on the current
-    /// coordinatore state.
+    /// Return the current model scalar if available. The availability depends
+    /// on the current coordinator state.
+    pub fn scalar(&self) -> Option<f64> {
+        if let PhaseData::Update(data) = self {
+            Some(data.scalar)
+        } else {
+            None
+        }
+    }
+
+    /// Return the current seed dictionary if available. The availability
+    /// depends on the current coordinator state.
     pub fn seed_dict(
         &mut self,
         pk: SumParticipantPublicKey,
@@ -169,8 +177,12 @@ impl Data {
         self.round_params_data_serialized.clone()
     }
 
-    pub fn sum_dict_and_scalar(&self) -> Option<(SerializedSumDict, f64)> {
-        self.phase_data.as_ref()?.sum_dict_and_scalar()
+    pub fn sum_dict(&self) -> Option<SerializedSumDict> {
+        self.phase_data.as_ref()?.sum_dict()
+    }
+
+    pub fn scalar(&self) -> Option<f64> {
+        self.phase_data.as_ref()?.scalar()
     }
 
     pub fn seed_dict(

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -20,6 +20,7 @@ pub struct Data {
     /// the update participants for instance, while during the sum2
     /// phase it contains the seed dictionaries.
     pub phase_data: Option<PhaseData>,
+    pub round_params_data_serialized: Option<Arc<Vec<u8>>>,
 }
 
 /// Data held by the service in specific phases
@@ -89,18 +90,30 @@ impl Data {
     pub fn update(&mut self, event: ProtocolEvent) -> Result<(), DataUpdateError> {
         match event {
             ProtocolEvent::StartSum(round_parameters) => {
-                self.round_parameters_data =
-                    if let Some(round_parameters_data) = self.round_parameters_data.take() {
-                        // Round > 1
-                        // Update the round parameters. Keep the global model from the previous round.
+                if let Some(round_parameters_data) = self.round_parameters_data.take() {
+                    // Round > 1
+                    // Update the round parameters. Keep the global model from the previous round.
+                    self.round_parameters_data =
                         Some(Arc::new(
-                            round_parameters_data.update_round_parameters(round_parameters),
-                        ))
-                    } else {
-                        // Round = 1
-                        // First round, update the round parameters and set the global model to None.
-                        Some(Arc::new(RoundParametersData::from(round_parameters)))
-                    };
+                            round_parameters_data.update_round_parameters(round_parameters.clone()),
+                        ));
+
+                    let data_unser = round_parameters_data.update_round_parameters(round_parameters);
+                    let data_ser = bincode::serialize(&data_unser)
+                        .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
+                    self.round_params_data_serialized = Some(Arc::new(data_ser))
+                } else {
+                    // Round = 1
+                    // First round, update the round parameters and set the global model to None.
+                    self.round_parameters_data =
+                        Some(Arc::new(RoundParametersData::from(round_parameters.clone())));
+
+                    let data_unser = RoundParametersData::from(round_parameters);
+                    let data_ser = bincode::serialize(&data_unser)
+                        .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
+                    self.round_params_data_serialized = Some(Arc::new(data_ser))
+                };
+
 
                 self.phase_data = Some(SumData.into());
             }
@@ -151,8 +164,9 @@ impl Data {
         Ok(())
     }
 
-    pub fn round_parameters(&self) -> Option<Arc<RoundParametersData>> {
-        self.round_parameters_data.clone()
+    pub fn round_parameters(&self) -> Option<Arc<Vec<u8>>> {
+        //self.round_parameters_data.clone()
+        self.round_params_data_serialized.clone()
     }
 
     pub fn sum_dict_and_scalar(&self) -> Option<(SerializedSumDict, f64)> {
@@ -223,13 +237,14 @@ impl Sum2Data {
     }
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct RoundParametersData {
     /// The round parameters of the current round.
     pub round_parameters: Option<RoundParameters>,
 
     /// The global model of the previous round.
-    pub global_model: Option<SerializedGlobalModel>,
+    //pub global_model: Option<SerializedGlobalModel>,
+    pub global_model: Option<Model>,
 }
 
 impl RoundParametersData {
@@ -247,10 +262,11 @@ impl RoundParametersData {
         &self,
         global_model: Model,
     ) -> Result<RoundParametersData, DataUpdateError> {
-        let serialized = bincode::serialize(&global_model)
-            .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
+        // let serialized = bincode::serialize(&global_model)
+        //     .map_err(|e| DataUpdateError::SerializeGlobalModel(e.to_string()))?;
         Ok(RoundParametersData {
-            global_model: Some(Arc::new(serialized)),
+            //            global_model: Some(Arc::new(serialized)),
+            global_model: Some(global_model),
             ..Default::default()
         })
     }
@@ -265,11 +281,21 @@ impl From<RoundParameters> for RoundParametersData {
     }
 }
 
-impl From<Option<SerializedGlobalModel>> for RoundParametersData {
-    fn from(serialized_global_model: Option<SerializedGlobalModel>) -> RoundParametersData {
+// impl From<Option<SerializedGlobalModel>> for RoundParametersData {
+//     fn from(serialized_global_model: Option<SerializedGlobalModel>) -> RoundParametersData {
+//         RoundParametersData {
+//             global_model: serialized_global_model,
+//             ..Default::default()
+//         }
+//     }
+// }
+
+impl From<Option<Model>> for RoundParametersData {
+    fn from(global_model: Option<Model>) -> RoundParametersData {
         RoundParametersData {
-            global_model: serialized_global_model,
+            global_model: global_model,
             ..Default::default()
         }
     }
 }
+

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -45,7 +45,8 @@ pub type SerializedGlobalModel = Arc<Vec<u8>>;
 /// Event for a request to retrieve the round parameters
 pub struct RoundParametersRequest {
     /// Channel for sending the round parameters back
-    pub response_tx: oneshot::Sender<Option<Arc<RoundParametersData>>>,
+    //pub response_tx: oneshot::Sender<Option<Arc<RoundParametersData>>>,
+    pub response_tx: oneshot::Sender<Option<Arc<Vec<u8>>>>,
 }
 
 pub type SerializedSumDict = Arc<Vec<u8>>;
@@ -87,8 +88,10 @@ impl Handle {
     /// Send a [`Event::RoundParameters`] event to retrieve the
     /// current round parameters. The availability of the round
     /// parameters depends on the current coordinator state.
-    pub async fn get_round_parameters(&self) -> Option<Arc<RoundParametersData>> {
-        let (tx, rx) = oneshot::channel::<Option<Arc<RoundParametersData>>>();
+    //pub async fn get_round_parameters(&self) -> Option<Arc<RoundParametersData>> {
+    pub async fn get_round_parameters(&self) -> Option<Arc<Vec<u8>>> {
+        //let (tx, rx) = oneshot::channel::<Option<Arc<RoundParametersData>>>();
+        let (tx, rx) = oneshot::channel::<Option<Arc<Vec<u8>>>>();
         self.send_event(RoundParametersRequest { response_tx: tx });
         rx.await.unwrap()
     }

--- a/rust/src/service/handle.rs
+++ b/rust/src/service/handle.rs
@@ -1,4 +1,4 @@
-use crate::{service::data::RoundParametersData, SumParticipantPublicKey};
+use crate::SumParticipantPublicKey;
 use derive_more::From;
 use std::{
     pin::Pin,
@@ -40,12 +40,9 @@ pub struct Message {
     // FIXME: there should be a channel to send a response back
 }
 
-pub type SerializedGlobalModel = Arc<Vec<u8>>;
-
 /// Event for a request to retrieve the round parameters
 pub struct RoundParametersRequest {
     /// Channel for sending the round parameters back
-    //pub response_tx: oneshot::Sender<Option<Arc<RoundParametersData>>>,
     pub response_tx: oneshot::Sender<Option<Arc<Vec<u8>>>>,
 }
 
@@ -88,9 +85,7 @@ impl Handle {
     /// Send a [`Event::RoundParameters`] event to retrieve the
     /// current round parameters. The availability of the round
     /// parameters depends on the current coordinator state.
-    //pub async fn get_round_parameters(&self) -> Option<Arc<RoundParametersData>> {
     pub async fn get_round_parameters(&self) -> Option<Arc<Vec<u8>>> {
-        //let (tx, rx) = oneshot::channel::<Option<Arc<RoundParametersData>>>();
         let (tx, rx) = oneshot::channel::<Option<Arc<Vec<u8>>>>();
         self.send_event(RoundParametersRequest { response_tx: tx });
         rx.await.unwrap()

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use tokio::stream::Stream;
 
-mod data;
+pub mod data;
 mod handle;
 
 pub use data::Data;

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -18,8 +18,8 @@ pub use handle::{
     Message,
     RoundParametersRequest,
     SeedDictRequest,
-    SerializedGlobalModel,
-    SumDictAndScalarRequest,
+    SumDictRequest,
+    ScalarRequest,
 };
 
 /// The `Service` is the task that drives the PET protocol. It reacts
@@ -55,7 +55,8 @@ impl Service {
         match event {
             Event::Message(Message { buffer }) => self.handle_message(buffer),
             Event::RoundParameters(req) => self.handle_round_parameters_request(req),
-            Event::SumDictAndScalar(req) => self.handle_sum_dict_and_scalar_request(req),
+            Event::SumDict(req) => self.handle_sum_dict_request(req),
+            Event::Scalar(req) => self.handle_scalar_request(req),
             Event::SeedDict(req) => self.handle_seed_dict_request(req),
         }
         self.process_protocol_events();
@@ -69,9 +70,15 @@ impl Service {
     }
 
     /// Handler for sum dict requests
-    fn handle_sum_dict_and_scalar_request(&self, req: SumDictAndScalarRequest) {
-        let SumDictAndScalarRequest { response_tx } = req;
-        let _ = response_tx.send(self.data.sum_dict_and_scalar());
+    fn handle_sum_dict_request(&self, req: SumDictRequest) {
+        let SumDictRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.sum_dict());
+    }
+
+    /// Handler for model scalar requests
+    fn handle_scalar_request(&self, req: ScalarRequest) {
+        let ScalarRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.scalar());
     }
 
     /// Handler for seed dict requests

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -17,9 +17,9 @@ pub use handle::{
     Handle,
     Message,
     RoundParametersRequest,
+    ScalarRequest,
     SeedDictRequest,
     SumDictRequest,
-    ScalarRequest,
 };
 
 /// The `Service` is the task that drives the PET protocol. It reacts


### PR DESCRIPTION
**_update_**. Addresses divergences from a rebase, mostly from the new C API changes.

- separated `get_sum_dict_and_scalar` into two separate endpoints (changes on client and server side).
- updates to the C API to work directly with the global model, rather than in serialised form.
- resolved divergences to `Client` and tidied it a bit
- slight updates to `test-drive`s to make them work post-rebase - at the moment still using just `Client`, w/o the C API for now.

Most of the above in [this commit](https://github.com/xainag/xain-fl/pull/420/commits/81324b160e44a6f68bb34916ca23a588defc43f6).

=====

This merge request enables clients and the service to communicate with each other over HTTP.

### Client-side
On the client-side is a new `Proxy` type in `request.rs`, which a `Client` will use to communicate with the service. To summarise, the `Proxy`
* wraps either a `Handle` (for local comms) or a `ClientReq` (for remote comms over HTTP).
* in the latter case, deals with logging and wrapping of network errors.
* deals with deserialization

`ClientReq` deals with building the HTTP request and extracting the response body. As an example,

```rust
async fn get_sums(&self) -> Result<Option<bytes::Bytes>, reqwest::Error>
```

issues a GET request for the sum dictionary. The return type reflects the presence of networking `Error`s, but also the situation where the dictionary is simply not yet available on the service. That is, the type also reflects the "optionality" of the data availability.

`Proxy` essentially takes this (deserializing the `Bytes` into a `SumDict` while handling `Error`s into `ClientError`s) to expose the overall method

```rust
async fn get_sums(&self) -> Result<Option<SumDict>, ClientError>
```

### Test-drive
A benefit of the above is simpler code in `Client`: it no longer needs to explicitly deal with networking nor deserialization errors, and works with a uniform interface regardless of whether the service is local or remote. The optionality in the types also makes it clear _when_ the client should retry vs giving up.

This means, in particular, that the `test-drive` script (for running a local E2E test) can still work with almost no changes to it. In addition, there is now a `test-drive-net` script which does basically the same thing, but in the networked setting.

### Server-side
On the server-side, the various endpoints are implemented and combined (with `.or`) as `warp` filters (see `rest.rs`):

```rust
message
    .or(sum_dict)
    .or(round_params)
    .or(seed_dict);
```

and runs alongside the main `Service` (see `main.rs`). `message` deals with POST requests containing a PET message. The other 3 deal with GET requests for the "broadcast" data.

A design decision was made early on to respond to requests simply with the raw serialised binary data, rather than (the more conventional) JSON which would have necessitated in base64-encoding overhead, and without really much benefit.

In a similar vein, the `seed_dict` filter assumes that the participant's public key (required as input) is part of the GET request body. While this is perhaps non-standard for HTTP 1.1, given the above re. overhead, and the fact that this API is currently only used internally, this is probably acceptable.

Finally, the round parameters data object has been revised slightly so that the whole object is serialisable (not just the global model part), so that round parameters can be sent back by the `round_params` filter.