### PR TITLE
PB-794 fix mask length

### DIFF
--- a/rust/src/mask/masking.rs
+++ b/rust/src/mask/masking.rs
@@ -63,6 +63,7 @@ impl Into<MaskObject> for Aggregation {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Aggregation {
     pub fn new(config: MaskConfig) -> Self {
         Self {

--- a/rust/src/mask/masking.rs
+++ b/rust/src/mask/masking.rs
@@ -71,6 +71,10 @@ impl Aggregation {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.object.data.len()
+    }
+
     pub fn config(&self) -> MaskConfig {
         self.object.config
     }

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -148,10 +148,10 @@ impl Participant {
         &self,
         pk: CoordinatorPublicKey,
         seed_dict: &UpdateSeedDict,
+        mask_len: usize,
     ) -> Result<Vec<u8>, PetError> {
         let mask_seeds = self.get_seeds(seed_dict)?;
 
-        let mask_len = 3; // dummy
         let mask = self.compute_global_mask(mask_seeds, mask_len, dummy_config())?;
         let payload = Sum2Owned {
             mask,

--- a/rust/src/rest.rs
+++ b/rust/src/rest.rs
@@ -30,7 +30,6 @@ pub async fn serve(addr: impl Into<SocketAddr> + 'static, handle: Handle) {
         .and(part_pk())
         .and(with_hdl(handle.clone()))
         .and_then(handle_seeds);
-        // .recover(handle_reject);
 
     let length = warp::path!("length")
         .and(warp::get())

--- a/rust/src/service/data.rs
+++ b/rust/src/service/data.rs
@@ -77,6 +77,16 @@ impl PhaseData {
             Ok(None)
         }
     }
+
+    /// Return the current model/mask length if available. The availability depends
+    /// on the current coordinator state.
+    pub fn length(&self) -> Option<u64> {
+        if let PhaseData::Sum2(data) = self {
+            Some(data.length)
+        } else {
+            None
+        }
+    }
 }
 
 /// Error returned when the state cannot be updated.
@@ -135,10 +145,11 @@ impl Data {
                 };
                 self.phase_data = Some(update_data.into());
             }
-            ProtocolEvent::StartSum2(seed_dict) => {
+            ProtocolEvent::StartSum2(seed_dict, length) => {
                 let sum2_data = Sum2Data {
                     seed_dict,
                     serialized_seed_dict: HashMap::new(),
+                    length,
                 };
                 self.phase_data = Some(sum2_data.into());
             }
@@ -194,6 +205,10 @@ impl Data {
             None => Ok(None),
         }
     }
+
+    pub fn length(&self) -> Option<u64> {
+        self.phase_data.as_ref()?.length()
+    }
 }
 
 /// Service data specific to the sum phase
@@ -215,6 +230,8 @@ pub struct Sum2Data {
     /// The seed dictionary with serialized values that can directly
     /// be sent to the clients that request it.
     pub serialized_seed_dict: HashMap<SumParticipantPublicKey, SerializedSeedDict>,
+    /// The length of the update participants models/masks.
+    pub length: u64,
 }
 
 impl Sum2Data {

--- a/rust/src/service/mod.rs
+++ b/rust/src/service/mod.rs
@@ -19,6 +19,7 @@ pub use handle::{
     Event,
     EventStream,
     Handle,
+    LengthRequest,
     Message,
     RoundParametersRequest,
     ScalarRequest,
@@ -62,6 +63,7 @@ impl Service {
             Event::SumDict(req) => self.handle_sum_dict_request(req),
             Event::Scalar(req) => self.handle_scalar_request(req),
             Event::SeedDict(req) => self.handle_seed_dict_request(req),
+            Event::Length(req) => self.handle_length_request(req),
         }
         self.process_protocol_events();
     }
@@ -93,6 +95,12 @@ impl Service {
         } = req;
         let resp = self.data.seed_dict(public_key).unwrap();
         let _ = response_tx.send(resp);
+    }
+
+    /// Handler for model/mask length requests.
+    fn handle_length_request(&self, req: LengthRequest) {
+        let LengthRequest { response_tx } = req;
+        let _ = response_tx.send(self.data.length());
     }
 
     /// Dequeue all the events produced by the coordinator, and handle


### PR DESCRIPTION
**References**
- [PB-794](https://xainag.atlassian.net/browse/PB-794)

**Summary**
- add a model/mask length GET request to the rest api
- handle the request by the in-memory handle and the network handle
- adjust the coordinator, participant and client to use the model/mask length information in the sum2 phase