### PR TITLE
PB-840 switch to stable rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: cargo fmt
         working-directory: ./rust
-        run: cargo fmt --all -- --check
+        run: cargo +nightly fmt --all -- --check
 
   check:
     name: rust-build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           components: rustfmt
 
       - name: Cache cargo registry
@@ -46,11 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -84,11 +84,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           components: clippy
 
       - name: Cache cargo registry
@@ -122,11 +122,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@v1
@@ -167,11 +167,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install nightly
+      - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
 
       - name: Cache cargo registry
         uses: actions/cache@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Install stable
+      - name: Install nightly
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
 
       - name: Cache cargo registry
@@ -34,7 +34,7 @@ jobs:
 
       - name: cargo fmt
         working-directory: ./rust
-        run: cargo +nightly fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   check:
     name: rust-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,9 +31,6 @@ docker logs docker_aggregator_1
 
 ### Building the project manually
 
-The project currently requires rust nightly so the nightly toolchain
-must be installed to compile the project.
-
 The `cargo` command can be run either from the `./rust` directory, or
 from the repository's root, in which case the `--manifest-path` must
 be specified.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # https://github.com/rust-lang/docker-rust-nightly/blob/master/buster/Dockerfile
 FROM buildpack-deps:stable-curl AS builder
 
-# Install Rust nightly
+# Install Rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,7 +1,7 @@
 # https://github.com/rust-lang/docker-rust-nightly/blob/master/buster/Dockerfile
 FROM buildpack-deps:stable-curl AS builder
 
-# Install Rust nightly
+# Install Rust
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH

--- a/docker/install_rust.sh
+++ b/docker/install_rust.sh
@@ -14,7 +14,7 @@ apt install -y --no-install-recommends \
 wget "https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init"
 chmod +x rustup-init
 
-./rustup-init -y --no-modify-path --default-toolchain nightly
+./rustup-init -y --no-modify-path --default-toolchain stable
 chmod -R a+w $RUSTUP_HOME $CARGO_HOME
 
 rustup --version

--- a/rust/rust-toolchain
+++ b/rust/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -1,3 +1,4 @@
+# requires unstable rustfmt until the options are stabilized
+format_code_in_doc_comments = true
 imports_layout = "HorizontalVertical"
 merge_imports = true
-format_code_in_doc_comments = true

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -25,7 +25,11 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use self::crypto::{
-    PublicEncryptKey, PublicSigningKey, SecretEncryptKey, SecretSigningKey, Signature,
+    PublicEncryptKey,
+    PublicSigningKey,
+    SecretEncryptKey,
+    SecretSigningKey,
+    Signature,
 };
 
 #[derive(Error, Debug)]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(bool_to_option)]
-
 #[macro_use]
 extern crate serde;
 
@@ -27,11 +25,7 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use self::crypto::{
-    PublicEncryptKey,
-    PublicSigningKey,
-    SecretEncryptKey,
-    SecretSigningKey,
-    Signature,
+    PublicEncryptKey, PublicSigningKey, SecretEncryptKey, SecretSigningKey, Signature,
 };
 
 #[derive(Error, Debug)]

--- a/rust/src/message/buffer.rs
+++ b/rust/src/message/buffer.rs
@@ -3,8 +3,7 @@ use std::ops::{Range, RangeFrom};
 
 use crate::{
     message::{utils::range, DecodeError, Flags, LengthValueBuffer},
-    CoordinatorPublicKey,
-    ParticipantPublicKey,
+    CoordinatorPublicKey, ParticipantPublicKey,
 };
 
 pub(crate) fn header_length(certificate_length: usize) -> usize {
@@ -140,13 +139,12 @@ impl<T: AsRef<[u8]>> MessageBuffer<T> {
     }
 
     fn payload_range(&self) -> RangeFrom<usize> {
-        let certificate_length = self
-            .has_certificate()
-            .then(|| {
-                let bytes = &self.inner.as_ref()[PARTICIPANT_PK_RANGE.end..];
-                LengthValueBuffer::new(bytes).unwrap().length() as usize
-            })
-            .unwrap_or(0);
+        let certificate_length = if self.has_certificate() {
+            let bytes = &self.inner.as_ref()[PARTICIPANT_PK_RANGE.end..];
+            LengthValueBuffer::new(bytes).unwrap().length() as usize
+        } else {
+            0
+        };
         let payload_start = PARTICIPANT_PK_RANGE.end + certificate_length;
         payload_start..
     }
@@ -166,10 +164,12 @@ impl<'a, T: AsRef<[u8]> + ?Sized> MessageBuffer<&'a T> {
     /// Get a slice to the certificate. If the header doesn't contain
     /// any certificate, `None` is returned.
     pub fn certificate(&self) -> Option<LengthValueBuffer<&'a [u8]>> {
-        self.has_certificate().then(|| {
+        if self.has_certificate() {
             let bytes = &self.inner.as_ref()[PARTICIPANT_PK_RANGE.end..];
-            LengthValueBuffer::new_unchecked(bytes)
-        })
+            Some(LengthValueBuffer::new_unchecked(bytes))
+        } else {
+            None
+        }
     }
 
     /// Get the coordinator public key field

--- a/rust/src/message/buffer.rs
+++ b/rust/src/message/buffer.rs
@@ -3,7 +3,8 @@ use std::ops::{Range, RangeFrom};
 
 use crate::{
     message::{utils::range, DecodeError, Flags, LengthValueBuffer},
-    CoordinatorPublicKey, ParticipantPublicKey,
+    CoordinatorPublicKey,
+    ParticipantPublicKey,
 };
 
 pub(crate) fn header_length(certificate_length: usize) -> usize {


### PR DESCRIPTION
**References**
- [PB-840](https://xainag.atlassian.net/browse/PB-840)

**Summary**
- rewrite the two occurrences of unstable feature usage
- set the rust toolchain, github ci and dockerfiles to rust stable

As soon as this is merged, please make sure that you are using stable rust as well, otherwise it might cause conflicts when pushing merge requests to the CI. Therefore please check that:
- the `RUSTUP_TOOLCHAIN` env variable is either not set or set to stable
- `rustup override list` doesn't show any nightly overrides for the `xain_fl` directory (can for example be wiped via `rustup override unset` and `rustup override unset --nonexistent`)
- either the default toolchain is set to stable or the toolchain for the `xain_fl` directory is set to stable (can for example be set via `rustup default stable` and checked via `rustup toolchain list`)
- the active toolchain for the `xain_fl` directory is stable (can be checked via `rustup show`)

All `rustfmt` features that we are currently using require nightly. since code formatting doesn't affect stability of the code at all, i'm strongly arguing in favor of using nightly formatting. this doesn't affect the rest of the toolchain, which can of course stay stable. When formatting the code locally please check that:
- `rustfmt` is called as nightly from the CLI like `cargo +nightly fmt`
- `rustfmt` is called with the additional argument `+nightly` from an IDE like VSCode (`"rust-analyzer.rustfmt.extraArgs": ["+nightly"],`)