### PR TITLE
PB-875 document crypto module

### DIFF
--- a/rust/src/crypto/encrypt.rs
+++ b/rust/src/crypto/encrypt.rs
@@ -13,7 +13,7 @@ use super::ByteObject;
 /// Number of additional bytes in a ciphertext compared to the corresponding plaintext.
 pub const SEALBYTES: usize = sealedbox::SEALBYTES;
 
-/// Generates a new random key pair for encryption.
+/// Generates a new random `C25519` key pair for encryption.
 pub fn generate_encrypt_key_pair() -> (PublicEncryptKey, SecretEncryptKey) {
     let (pk, sk) = box_::gen_keypair();
     (PublicEncryptKey(pk), SecretEncryptKey(sk))
@@ -47,7 +47,7 @@ impl KeyPair {
     PartialOrd,
     Debug,
 )]
-/// A public key for asymmetric authenticated encryption.
+/// A `C25519` public key for asymmetric authenticated encryption.
 pub struct PublicEncryptKey(box_::PublicKey);
 
 impl ByteObject for PublicEncryptKey {
@@ -65,32 +65,32 @@ impl ByteObject for PublicEncryptKey {
 }
 
 impl PublicEncryptKey {
-    /// Length in bytes of a [`PublicEncryptKey`].
+    /// Length in bytes of this public key.
     pub const LENGTH: usize = box_::PUBLICKEYBYTES;
 
-    /// Encrypts a message `m` with this public key. The resulting
-    /// ciphertext length is [`SEALBYTES`]` + m.len()`.
+    /// Encrypts a message `m` with this public key. The resulting ciphertext length is
+    /// [`SEALBYTES`]` + m.len()`.
     ///
-    /// The function creates a new ephemeral key pair for each message, and
-    /// attaches the public key to the ciphertext. The secret key is
-    /// zeroed out and is not accessible after this function returns.
+    /// The function creates a new ephemeral key pair for each message, and attaches the ephemeral
+    /// public key to the ciphertext. The ephemeral secret key is zeroed out and is not accessible
+    /// after this function returns.
     pub fn encrypt(&self, m: &[u8]) -> Vec<u8> {
         sealedbox::seal(m, self.as_ref())
     }
 }
 
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
-/// A secret key for asymmetric authenticated encryption.
+/// A `C25519` secret key for asymmetric authenticated encryption.
 ///
 /// When this goes out of scope, its contents will be zeroed out.
 pub struct SecretEncryptKey(box_::SecretKey);
 
 impl SecretEncryptKey {
-    /// Length in bytes of a [`SecretEncryptKey`].
+    /// Length in bytes of this secret key.
     pub const LENGTH: usize = box_::SECRETKEYBYTES;
 
-    /// Decrypts the ciphertext `c` using this secret key and the
-    /// associated public key, and returns the decrypted message.
+    /// Decrypts the ciphertext `c` using this secret key and the associated public key, and returns
+    /// the decrypted message.
     ///
     /// # Errors
     /// Returns `Err(())` if decryption fails.
@@ -119,13 +119,13 @@ impl ByteObject for SecretEncryptKey {
 }
 
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone)]
-/// A seed that can be used for encryption key pair generation.
+/// A seed that can be used for `C25519` encryption key pair generation.
 ///
 /// When this goes out of scope, its contents will be zeroed out.
 pub struct EncryptKeySeed(box_::Seed);
 
 impl EncryptKeySeed {
-    /// Length in bytes of a [`EncryptKeySeed`].
+    /// Length in bytes of this seed.
     pub const LENGTH: usize = box_::SEEDBYTES;
 
     /// Deterministically derives a new key pair from this seed.

--- a/rust/src/crypto/encrypt.rs
+++ b/rust/src/crypto/encrypt.rs
@@ -1,13 +1,19 @@
-use super::ByteObject;
+//! Wrappers around some of the [sodiumoxide] encrytion primitives.
+//!
+//! See the [crypto module] documentation since this is a private module anyways.
+//!
+//! [sodiumoxide]: https://docs.rs/sodiumoxide/
+//! [crypto module]: ../index.html
 
 use derive_more::{AsMut, AsRef, From};
 use sodiumoxide::crypto::{box_, sealedbox};
 
-/// Number of additional bytes in a ciphertext compared to the
-/// corresponding plaintext.
+use super::ByteObject;
+
+/// Number of additional bytes in a ciphertext compared to the corresponding plaintext.
 pub const SEALBYTES: usize = sealedbox::SEALBYTES;
 
-/// Generate a new random key pair
+/// Generates a new random key pair for encryption.
 pub fn generate_encrypt_key_pair() -> (PublicEncryptKey, SecretEncryptKey) {
     let (pk, sk) = box_::gen_keypair();
     (PublicEncryptKey(pk), SecretEncryptKey(sk))
@@ -26,7 +32,6 @@ impl KeyPair {
     }
 }
 
-/// Public key for asymmetric authenticated encryption
 #[derive(
     AsRef,
     AsMut,
@@ -42,6 +47,7 @@ impl KeyPair {
     PartialOrd,
     Debug,
 )]
+/// A public key for asymmetric authenticated encryption.
 pub struct PublicEncryptKey(box_::PublicKey);
 
 impl ByteObject for PublicEncryptKey {
@@ -59,37 +65,40 @@ impl ByteObject for PublicEncryptKey {
 }
 
 impl PublicEncryptKey {
-    /// Length in bytes of a [`PublicEncryptKey`]
+    /// Length in bytes of a [`PublicEncryptKey`].
     pub const LENGTH: usize = box_::PUBLICKEYBYTES;
 
-    /// Encrypt a message `m` with this public key. The resulting
-    /// ciphertext length is [`SEALBYTES`] + `m.len()`.
+    /// Encrypts a message `m` with this public key. The resulting
+    /// ciphertext length is [`SEALBYTES`]` + m.len()`.
     ///
-    /// The function creates a new key pair for each message, and
+    /// The function creates a new ephemeral key pair for each message, and
     /// attaches the public key to the ciphertext. The secret key is
-    /// overwritten and is not accessible after this function returns.
+    /// zeroed out and is not accessible after this function returns.
     pub fn encrypt(&self, m: &[u8]) -> Vec<u8> {
         sealedbox::seal(m, self.as_ref())
     }
 }
 
-/// Secret key for asymmetric authenticated encryption
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
+/// A secret key for asymmetric authenticated encryption.
+///
+/// When this goes out of scope, its contents will be zeroed out.
 pub struct SecretEncryptKey(box_::SecretKey);
 
 impl SecretEncryptKey {
-    /// Length in bytes of a [`SecretEncryptKey`]
+    /// Length in bytes of a [`SecretEncryptKey`].
     pub const LENGTH: usize = box_::SECRETKEYBYTES;
 
-    /// Decrypt the ciphertext `c` using this secret key and the
-    /// associated public key, and return the decrypted message.
+    /// Decrypts the ciphertext `c` using this secret key and the
+    /// associated public key, and returns the decrypted message.
     ///
-    /// If decryption fails `Err(())` is returned.
+    /// # Errors
+    /// Returns `Err(())` if decryption fails.
     pub fn decrypt(&self, c: &[u8], pk: &PublicEncryptKey) -> Result<Vec<u8>, ()> {
         sealedbox::open(c, pk.as_ref(), self.as_ref())
     }
 
-    /// Compute the corresponding public key for this secret key
+    /// Computes the corresponding public key for this secret key.
     pub fn public_key(&self) -> PublicEncryptKey {
         PublicEncryptKey(self.0.public_key())
     }
@@ -109,16 +118,17 @@ impl ByteObject for SecretEncryptKey {
     }
 }
 
-/// A seed that can be used for key pair generation. When `KeySeed`
-/// goes out of scope, its contents will be zeroed out.
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone)]
+/// A seed that can be used for encryption key pair generation.
+///
+/// When this goes out of scope, its contents will be zeroed out.
 pub struct EncryptKeySeed(box_::Seed);
 
 impl EncryptKeySeed {
-    /// Length in bytes of a [`EncryptKeySeed`]
+    /// Length in bytes of a [`EncryptKeySeed`].
     pub const LENGTH: usize = box_::SEEDBYTES;
 
-    /// Deterministically derive a new key pair from this seed
+    /// Deterministically derives a new key pair from this seed.
     pub fn derive_encrypt_key_pair(&self) -> (PublicEncryptKey, SecretEncryptKey) {
         let (pk, sk) = box_::keypair_from_seed(self.as_ref());
         (PublicEncryptKey(pk), SecretEncryptKey(sk))

--- a/rust/src/crypto/encrypt.rs
+++ b/rust/src/crypto/encrypt.rs
@@ -1,4 +1,4 @@
-//! Wrappers around some of the [sodiumoxide] encrytion primitives.
+//! Wrappers around some of the [sodiumoxide] encryption primitives.
 //!
 //! See the [crypto module] documentation since this is a private module anyways.
 //!
@@ -69,10 +69,11 @@ impl PublicEncryptKey {
     /// Length in bytes of this public key.
     pub const LENGTH: usize = box_::PUBLICKEYBYTES;
 
-    /// Encrypts a message `m` with this public key. The resulting ciphertext length is
-    /// [`SEALBYTES`]` + m.len()`.
+    /// Encrypts a message `m` with this public key.
     ///
-    /// The function creates a new ephemeral key pair for each message, and attaches the ephemeral
+    /// The resulting ciphertext length is [`SEALBYTES`]` + m.len()`.
+    ///
+    /// The function creates a new ephemeral key pair for the message and attaches the ephemeral
     /// public key to the ciphertext. The ephemeral secret key is zeroed out and is not accessible
     /// after this function returns.
     pub fn encrypt(&self, m: &[u8]) -> Vec<u8> {

--- a/rust/src/crypto/encrypt.rs
+++ b/rust/src/crypto/encrypt.rs
@@ -13,22 +13,23 @@ use super::ByteObject;
 /// Number of additional bytes in a ciphertext compared to the corresponding plaintext.
 pub const SEALBYTES: usize = sealedbox::SEALBYTES;
 
-/// Generates a new random `C25519` key pair for encryption.
-pub fn generate_encrypt_key_pair() -> (PublicEncryptKey, SecretEncryptKey) {
-    let (pk, sk) = box_::gen_keypair();
-    (PublicEncryptKey(pk), SecretEncryptKey(sk))
-}
-
 #[derive(Debug, Clone)]
-pub struct KeyPair {
+/// A `C25519` key pair for asymmetric authenticated encryption.
+pub struct EncryptKeyPair {
+    /// The `C25519` public key.
     pub public: PublicEncryptKey,
+    /// The `C25519` secret key.
     pub secret: SecretEncryptKey,
 }
 
-impl KeyPair {
+impl EncryptKeyPair {
+    /// Generates a new random `C25519` key pair for encryption.
     pub fn generate() -> Self {
-        let (public, secret) = generate_encrypt_key_pair();
-        Self { public, secret }
+        let (pk, sk) = box_::gen_keypair();
+        Self {
+            public: PublicEncryptKey(pk),
+            secret: SecretEncryptKey(sk),
+        }
     }
 }
 

--- a/rust/src/crypto/hash.rs
+++ b/rust/src/crypto/hash.rs
@@ -1,3 +1,10 @@
+//! Wrappers around some of the [sodiumoxide] hashing primitives.
+//!
+//! See the [crypto module] documentation since this is a private module anyways.
+//!
+//! [sodiumoxide]: https://docs.rs/sodiumoxide/
+//! [crypto module]: ../index.html
+
 use super::ByteObject;
 
 use sodiumoxide::crypto::hash::sha256;
@@ -19,6 +26,7 @@ use derive_more::{AsMut, AsRef, From};
     PartialOrd,
     Debug,
 )]
+/// A digest of the `sha256` hash function.
 pub struct Sha256(sha256::Digest);
 
 impl ByteObject for Sha256 {
@@ -36,9 +44,10 @@ impl ByteObject for Sha256 {
 }
 
 impl Sha256 {
-    /// Length in bytes of a [`Sha256`]
+    /// Length in bytes of a [`Sha256`] digest.
     pub const LENGTH: usize = sha256::DIGESTBYTES;
 
+    /// Computes the [`Sha256`] digest of the message `m`.
     pub fn hash(m: &[u8]) -> Self {
         Self(sha256::hash(m))
     }

--- a/rust/src/crypto/hash.rs
+++ b/rust/src/crypto/hash.rs
@@ -26,7 +26,7 @@ use derive_more::{AsMut, AsRef, From};
     PartialOrd,
     Debug,
 )]
-/// A digest of the `sha256` hash function.
+/// A digest of the `SHA256` hash function.
 pub struct Sha256(sha256::Digest);
 
 impl ByteObject for Sha256 {
@@ -44,10 +44,10 @@ impl ByteObject for Sha256 {
 }
 
 impl Sha256 {
-    /// Length in bytes of a [`Sha256`] digest.
+    /// Length in bytes of this digest.
     pub const LENGTH: usize = sha256::DIGESTBYTES;
 
-    /// Computes the [`Sha256`] digest of the message `m`.
+    /// Computes the digest of the message `m`.
     pub fn hash(m: &[u8]) -> Self {
         Self(sha256::hash(m))
     }

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -1,11 +1,11 @@
 //! Wrappers around some of the [sodiumoxide] crypto primitives.
 //!
 //! The wrappers provide methods defined on structs instead of the sodiumoxide functions. This is
-//! done for the encryption and signature key pairs and their corresponding seeds as well as a hash
-//! function. Additionally, some methods for slicing and signature eligibility are made available.
+//! done for the `C25519` encryption and `Ed25519` signature key pairs and their corresponding seeds
+//! as well as the `SHA256` hash function. Additionally, some methods for slicing and signature
+//! eligibility are available.
 //!
 //! # Examples
-//!
 //! ## Encryption of messages
 //! ```
 //! # use xain_fl::crypto::generate_encrypt_key_pair;

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -1,10 +1,36 @@
-//! This module provides wrapper around some `sodiumoxide` crypto
-//! primitives.
+//! Wrappers around some of the [sodiumoxide] crypto primitives.
+//!
+//! The wrappers provide methods defined on structs instead of the sodiumoxide functions. This is
+//! done for the encryption and signature key pairs and their corresponding seeds as well as a hash
+//! function. Additionally, some methods for slicing and signature eligibility are made available.
+//!
+//! # Examples
+//!
+//! ## Encryption of messages
+//! ```
+//! # use xain_fl::crypto::generate_encrypt_key_pair;
+//! let (pk, sk) = generate_encrypt_key_pair();
+//! let message = b"Hello world!".to_vec();
+//! let cipher = pk.encrypt(&message);
+//! assert_eq!(message, sk.decrypt(&cipher, &pk).unwrap());
+//! ```
+//!
+//! ## Signing of messages
+//! ```
+//! # use xain_fl::crypto::generate_signing_key_pair;
+//! let (pk, sk) = generate_signing_key_pair();
+//! let message = b"Hello world!".to_vec();
+//! let signature = sk.sign_detached(&message);
+//! assert!(pk.verify_detached(&signature, &message));
+//! ```
+//!
+//! [sodiumoxide]: https://docs.rs/sodiumoxide/
 
 mod encrypt;
 mod hash;
 mod prng;
 mod sign;
+
 pub use self::{
     encrypt::{
         generate_encrypt_key_pair,
@@ -25,24 +51,24 @@ pub use self::{
     },
 };
 
+/// An interface for slicing into cryptographic byte objects.
 pub trait ByteObject: Sized {
-    /// Create a new object with all the bytes initialized to `0`.
+    /// Creates a new object with all the bytes initialized to `0`.
     fn zeroed() -> Self;
 
-    /// Get the object byte representation
+    /// Gets the object byte representation.
     fn as_slice(&self) -> &[u8];
 
-    /// Create a object from the given buffer. This function will fail
-    /// and return `None` if the length of the byte-slice isn't equal to
-    /// the length of the object.
+    /// Creates an object from the given buffer.
+    ///
+    /// # Errors
+    /// Returns `None` if the length of the byte-slice isn't equal to the length of the object.
     fn from_slice(bytes: &[u8]) -> Option<Self>;
 
-    /// Create a object from the given buffer.
+    /// Creates an object from the given buffer.
     ///
-    /// # Panic
-    ///
-    /// This function will panic if the length of the byte-slice isn't
-    /// equal to the length of the object.
+    /// # Panics
+    /// Panics if the length of the byte-slice isn't equal to the length of the object.
     fn from_slice_unchecked(bytes: &[u8]) -> Self {
         Self::from_slice(bytes).unwrap()
     }

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -8,20 +8,20 @@
 //! # Examples
 //! ## Encryption of messages
 //! ```
-//! # use xain_fl::crypto::generate_encrypt_key_pair;
-//! let (pk, sk) = generate_encrypt_key_pair();
+//! # use xain_fl::crypto::EncryptKeyPair;
+//! let keys = EncryptKeyPair::generate();
 //! let message = b"Hello world!".to_vec();
-//! let cipher = pk.encrypt(&message);
-//! assert_eq!(message, sk.decrypt(&cipher, &pk).unwrap());
+//! let cipher = keys.public.encrypt(&message);
+//! assert_eq!(message, keys.secret.decrypt(&cipher, &keys.public).unwrap());
 //! ```
 //!
 //! ## Signing of messages
 //! ```
-//! # use xain_fl::crypto::generate_signing_key_pair;
-//! let (pk, sk) = generate_signing_key_pair();
+//! # use xain_fl::crypto::SigningKeyPair;
+//! let keys = SigningKeyPair::generate();
 //! let message = b"Hello world!".to_vec();
-//! let signature = sk.sign_detached(&message);
-//! assert!(pk.verify_detached(&signature, &message));
+//! let signature = keys.secret.sign_detached(&message);
+//! assert!(keys.public.verify_detached(&signature, &message));
 //! ```
 //!
 //! [sodiumoxide]: https://docs.rs/sodiumoxide/
@@ -32,23 +32,10 @@ mod prng;
 mod sign;
 
 pub use self::{
-    encrypt::{
-        generate_encrypt_key_pair,
-        EncryptKeySeed,
-        KeyPair,
-        PublicEncryptKey,
-        SecretEncryptKey,
-        SEALBYTES,
-    },
+    encrypt::{EncryptKeyPair, EncryptKeySeed, PublicEncryptKey, SecretEncryptKey, SEALBYTES},
     hash::Sha256,
     prng::generate_integer,
-    sign::{
-        generate_signing_key_pair,
-        PublicSigningKey,
-        SecretSigningKey,
-        Signature,
-        SigningKeySeed,
-    },
+    sign::{PublicSigningKey, SecretSigningKey, Signature, SigningKeyPair, SigningKeySeed},
 };
 
 /// An interface for slicing into cryptographic byte objects.

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -26,10 +26,10 @@
 //!
 //! [sodiumoxide]: https://docs.rs/sodiumoxide/
 
-mod encrypt;
-mod hash;
-mod prng;
-mod sign;
+pub(crate) mod encrypt;
+pub(crate) mod hash;
+pub(crate) mod prng;
+pub(crate) mod sign;
 
 pub use self::{
     encrypt::{EncryptKeyPair, EncryptKeySeed, PublicEncryptKey, SecretEncryptKey, SEALBYTES},

--- a/rust/src/crypto/prng.rs
+++ b/rust/src/crypto/prng.rs
@@ -12,7 +12,7 @@ use rand_chacha::ChaCha20Rng;
 /// Generates a secure pseudo-random integer.
 ///
 /// Draws from a uniform distribution over the integers between zero (included) and
-/// `max_int` (excluded).
+/// `max_int` (excluded). Employs the `ChaCha20` stream cipher as a PRNG.
 pub fn generate_integer(prng: &mut ChaCha20Rng, max_int: &BigUint) -> BigUint {
     if max_int.is_zero() {
         return BigUint::zero();

--- a/rust/src/crypto/prng.rs
+++ b/rust/src/crypto/prng.rs
@@ -1,9 +1,17 @@
+//! PRNG utilities for the crypto primitives.
+//!
+//! See the [crypto module] documentation since this is a private module anyways.
+//!
+//! [sodiumoxide]: https://docs.rs/sodiumoxide/
+//! [crypto module]: ../index.html
+
 use num::{bigint::BigUint, traits::identities::Zero};
 use rand::RngCore;
 use rand_chacha::ChaCha20Rng;
 
-/// Generate a secure pseudo-random integer. Draws from a uniform
-/// distribution over the integers between zero (included) and
+/// Generates a secure pseudo-random integer.
+///
+/// Draws from a uniform distribution over the integers between zero (included) and
 /// `max_int` (excluded).
 pub fn generate_integer(prng: &mut ChaCha20Rng, max_int: &BigUint) -> BigUint {
     if max_int.is_zero() {
@@ -11,7 +19,7 @@ pub fn generate_integer(prng: &mut ChaCha20Rng, max_int: &BigUint) -> BigUint {
     }
     let mut bytes = max_int.to_bytes_le();
     let mut rand_int = max_int.clone();
-    while rand_int >= *max_int {
+    while &rand_int >= max_int {
         prng.fill_bytes(&mut bytes);
         rand_int = BigUint::from_bytes_le(&bytes);
     }

--- a/rust/src/crypto/sign.rs
+++ b/rust/src/crypto/sign.rs
@@ -14,10 +14,24 @@ use sodiumoxide::crypto::{hash::sha256, sign};
 
 use super::ByteObject;
 
-/// Generates a new random `Ed25519` key pair for signing.
-pub fn generate_signing_key_pair() -> (PublicSigningKey, SecretSigningKey) {
-    let (pk, sk) = sign::gen_keypair();
-    (PublicSigningKey(pk), SecretSigningKey(sk))
+#[derive(Debug, Clone)]
+/// A `Ed25519` key pair for signatures.
+pub struct SigningKeyPair {
+    /// The `Ed25519` public key.
+    pub public: PublicSigningKey,
+    /// The `Ed25519` secret key.
+    pub secret: SecretSigningKey,
+}
+
+impl SigningKeyPair {
+    /// Generates a new random `Ed25519` key pair for signing.
+    pub fn generate() -> Self {
+        let (pk, sk) = sign::gen_keypair();
+        Self {
+            public: PublicSigningKey(pk),
+            secret: SecretSigningKey(sk),
+        }
+    }
 }
 
 #[derive(

--- a/rust/src/crypto/sign.rs
+++ b/rust/src/crypto/sign.rs
@@ -14,7 +14,7 @@ use sodiumoxide::crypto::{hash::sha256, sign};
 
 use super::ByteObject;
 
-/// Generates a new random key pair for signing.
+/// Generates a new random `Ed25519` key pair for signing.
 pub fn generate_signing_key_pair() -> (PublicSigningKey, SecretSigningKey) {
     let (pk, sk) = sign::gen_keypair();
     (PublicSigningKey(pk), SecretSigningKey(sk))
@@ -35,11 +35,11 @@ pub fn generate_signing_key_pair() -> (PublicSigningKey, SecretSigningKey) {
     PartialOrd,
     Debug,
 )]
-/// A public key for signatures.
+/// An `Ed25519` public key for signatures.
 pub struct PublicSigningKey(sign::PublicKey);
 
 impl PublicSigningKey {
-    /// Length in bytes of a [`PublicSigningKey`].
+    /// Length in bytes of this public key.
     pub const LENGTH: usize = sign::PUBLICKEYBYTES;
 
     /// Verifies the signature `s` against the message `m` and this public key.
@@ -65,13 +65,13 @@ impl ByteObject for PublicSigningKey {
 }
 
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
-/// A secret key for signatures.
+/// An `Ed25519` secret key for signatures.
 ///
 /// When this goes out of scope, its contents will be zeroed out.
 pub struct SecretSigningKey(sign::SecretKey);
 
 impl SecretSigningKey {
-    /// Length in bytes of a [`SecretSigningKey`].
+    /// Length in bytes of this secret key.
     pub const LENGTH: usize = sign::SECRETKEYBYTES;
 
     /// Signs a message `m` with this secret key.
@@ -114,7 +114,7 @@ impl ByteObject for SecretSigningKey {
     PartialOrd,
     Debug,
 )]
-/// A signature detached from its message.
+/// An `Ed25519` signature detached from its message.
 pub struct Signature(sign::Signature);
 
 impl ByteObject for Signature {
@@ -132,11 +132,11 @@ impl ByteObject for Signature {
 }
 
 impl Signature {
-    /// Length in bytes of a [`Signature`].
+    /// Length in bytes of this signature.
     pub const LENGTH: usize = sign::SIGNATUREBYTES;
 
-    /// Computes the floating point representation of the hashed
-    /// signature and ensure that it is below the given threshold:
+    /// Computes the floating point representation of the hashed signature and ensure that it is
+    /// below the given threshold:
     /// ```no_rust
     /// int(hash(signature)) / (2**hashbits - 1) <= threshold.
     /// ```
@@ -159,13 +159,13 @@ impl Signature {
 }
 
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone)]
-/// A seed that can be used for signing key pair generation.
+/// A seed that can be used for `Ed25519` signing key pair generation.
 ///
 /// When this goes out of scope, its contents will be zeroed out.
 pub struct SigningKeySeed(sign::Seed);
 
 impl SigningKeySeed {
-    /// Length in bytes of a [`SigningKeySeed`].
+    /// Length in bytes of this seed.
     pub const LENGTH: usize = sign::SEEDBYTES;
 
     /// Deterministically derives a new signing key pair from this seed.

--- a/rust/src/crypto/sign.rs
+++ b/rust/src/crypto/sign.rs
@@ -1,4 +1,10 @@
-use super::ByteObject;
+//! Wrappers around some of the [sodiumoxide] signing primitives.
+//!
+//! See the [crypto module] documentation since this is a private module anyways.
+//!
+//! [sodiumoxide]: https://docs.rs/sodiumoxide/
+//! [crypto module]: ../index.html
+
 use derive_more::{AsMut, AsRef, From};
 use num::{
     bigint::{BigUint, ToBigInt},
@@ -6,13 +12,14 @@ use num::{
 };
 use sodiumoxide::crypto::{hash::sha256, sign};
 
-/// Generate a new random signing key pair
+use super::ByteObject;
+
+/// Generates a new random key pair for signing.
 pub fn generate_signing_key_pair() -> (PublicSigningKey, SecretSigningKey) {
     let (pk, sk) = sign::gen_keypair();
     (PublicSigningKey(pk), SecretSigningKey(sk))
 }
 
-/// Public key for signatures
 #[derive(
     AsRef,
     AsMut,
@@ -28,18 +35,16 @@ pub fn generate_signing_key_pair() -> (PublicSigningKey, SecretSigningKey) {
     PartialOrd,
     Debug,
 )]
+/// A public key for signatures.
 pub struct PublicSigningKey(sign::PublicKey);
 
 impl PublicSigningKey {
-    /// Length in bytes of a [`PublicSigningKey`]
+    /// Length in bytes of a [`PublicSigningKey`].
     pub const LENGTH: usize = sign::PUBLICKEYBYTES;
-    /// Verify the signature `s` against the message `m` and the
-    /// signer's public key `&self`.
+
+    /// Verifies the signature `s` against the message `m` and this public key.
     ///
-    /// # Return value
-    ///
-    /// This method returns `true` if the signature is valid, `false`
-    /// otherwise.
+    /// Returns `true` if the signature is valid and `false` otherwise.
     pub fn verify_detached(&self, s: &Signature, m: &[u8]) -> bool {
         sign::verify_detached(s.as_ref(), m, self.as_ref())
     }
@@ -59,19 +64,22 @@ impl ByteObject for PublicSigningKey {
     }
 }
 
-/// Secret key for signatures
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
+/// A secret key for signatures.
+///
+/// When this goes out of scope, its contents will be zeroed out.
 pub struct SecretSigningKey(sign::SecretKey);
 
 impl SecretSigningKey {
-    /// Length in bytes of a [`SecretSigningKey`]
+    /// Length in bytes of a [`SecretSigningKey`].
     pub const LENGTH: usize = sign::SECRETKEYBYTES;
-    /// Sign a message `m`
+
+    /// Signs a message `m` with this secret key.
     pub fn sign_detached(&self, m: &[u8]) -> Signature {
         sign::sign_detached(m, self.as_ref()).into()
     }
 
-    /// Compute the corresponding public key for this secret key
+    /// Computes the corresponding public key for this secret key.
     pub fn public_key(&self) -> PublicSigningKey {
         PublicSigningKey(self.0.public_key())
     }
@@ -91,7 +99,6 @@ impl ByteObject for SecretSigningKey {
     }
 }
 
-/// Detached signature
 #[derive(
     AsRef,
     AsMut,
@@ -107,6 +114,7 @@ impl ByteObject for SecretSigningKey {
     PartialOrd,
     Debug,
 )]
+/// A signature detached from its message.
 pub struct Signature(sign::Signature);
 
 impl ByteObject for Signature {
@@ -124,10 +132,10 @@ impl ByteObject for Signature {
 }
 
 impl Signature {
-    /// Length in bytes of a [`Signature`]
+    /// Length in bytes of a [`Signature`].
     pub const LENGTH: usize = sign::SIGNATUREBYTES;
 
-    /// Compute the floating point representation of the hashed
+    /// Computes the floating point representation of the hashed
     /// signature and ensure that it is below the given threshold:
     /// ```no_rust
     /// int(hash(signature)) / (2**hashbits - 1) <= threshold.
@@ -150,16 +158,17 @@ impl Signature {
     }
 }
 
-/// A seed that can be used for signing key pair generation. When
-/// `KeySeed` goes out of scope, its contents will be zeroed out.
 #[derive(AsRef, AsMut, From, Serialize, Deserialize, Eq, PartialEq, Clone)]
+/// A seed that can be used for signing key pair generation.
+///
+/// When this goes out of scope, its contents will be zeroed out.
 pub struct SigningKeySeed(sign::Seed);
 
 impl SigningKeySeed {
-    /// Length in bytes of a [`SigningKeySeed`]
+    /// Length in bytes of a [`SigningKeySeed`].
     pub const LENGTH: usize = sign::SEEDBYTES;
 
-    /// Deterministically derive a new signing key pair from this seed
+    /// Deterministically derives a new signing key pair from this seed.
     pub fn derive_signing_key_pair(&self) -> (PublicSigningKey, SecretSigningKey) {
         let (pk, sk) = sign::keypair_from_seed(&self.0);
         (PublicSigningKey(pk), SecretSigningKey(sk))

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -29,11 +29,8 @@ use std::collections::HashMap;
 use thiserror::Error;
 
 use self::crypto::{
-    PublicEncryptKey,
-    PublicSigningKey,
-    SecretEncryptKey,
-    SecretSigningKey,
-    Signature,
+    encrypt::{PublicEncryptKey, SecretEncryptKey},
+    sign::{PublicSigningKey, SecretSigningKey, Signature},
 };
 
 #[derive(Error, Debug)]

--- a/rust/src/mask/masking.rs
+++ b/rust/src/mask/masking.rs
@@ -9,7 +9,7 @@ use num::{
 use rand_chacha::ChaCha20Rng;
 
 use crate::{
-    crypto::generate_integer,
+    crypto::prng::generate_integer,
     mask::{MaskConfig, MaskObject, MaskSeed, Model},
 };
 

--- a/rust/src/mask/seed.rs
+++ b/rust/src/mask/seed.rs
@@ -6,7 +6,7 @@ use rand_chacha::ChaCha20Rng;
 use sodiumoxide::{crypto::box_, randombytes::randombytes};
 
 use crate::{
-    crypto::{generate_integer, ByteObject, SEALBYTES},
+    crypto::{encrypt::SEALBYTES, prng::generate_integer, ByteObject},
     mask::{config::MaskConfig, MaskObject},
     PetError,
     SumParticipantEphemeralPublicKey,
@@ -120,7 +120,7 @@ impl EncryptedMaskSeed {
 mod tests {
     use super::*;
     use crate::{
-        crypto::EncryptKeyPair,
+        crypto::encrypt::EncryptKeyPair,
         mask::config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
     };
 

--- a/rust/src/mask/seed.rs
+++ b/rust/src/mask/seed.rs
@@ -120,7 +120,7 @@ impl EncryptedMaskSeed {
 mod tests {
     use super::*;
     use crate::{
-        crypto::generate_encrypt_key_pair,
+        crypto::EncryptKeyPair,
         mask::config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
     };
 
@@ -157,10 +157,10 @@ mod tests {
         let seed = MaskSeed::generate();
         assert_eq!(seed.as_slice().len(), 32);
         assert_ne!(seed, MaskSeed::zeroed());
-        let (pk, sk) = generate_encrypt_key_pair();
-        let encr_seed = seed.encrypt(&pk);
+        let EncryptKeyPair { public, secret } = EncryptKeyPair::generate();
+        let encr_seed = seed.encrypt(&public);
         assert_eq!(encr_seed.as_slice().len(), 80);
-        let decr_seed = encr_seed.decrypt(&pk, &sk).unwrap();
+        let decr_seed = encr_seed.decrypt(&public, &secret).unwrap();
         assert_eq!(seed, decr_seed);
     }
 }

--- a/rust/src/message/message.rs
+++ b/rust/src/message/message.rs
@@ -3,7 +3,11 @@ use std::borrow::Borrow;
 
 use crate::{
     certificate::Certificate,
-    crypto::{ByteObject, PublicEncryptKey, SecretEncryptKey, SecretSigningKey, Signature},
+    crypto::{
+        encrypt::{PublicEncryptKey, SecretEncryptKey},
+        sign::{SecretSigningKey, Signature},
+        ByteObject,
+    },
     mask::MaskObject,
     message::{
         DecodeError,

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -2,7 +2,7 @@ use std::default::Default;
 
 use crate::{
     certificate::Certificate,
-    crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
+    crypto::{encrypt::EncryptKeyPair, sign::SigningKeyPair, ByteObject},
     mask::{
         Aggregation,
         BoundType,
@@ -235,7 +235,7 @@ mod tests {
     use sodiumoxide::randombytes::{randombytes, randombytes_uniform};
 
     use super::*;
-    use crate::{crypto::Signature, SumParticipantPublicKey, UpdateParticipantPublicKey};
+    use crate::{crypto::sign::Signature, SumParticipantPublicKey, UpdateParticipantPublicKey};
 
     #[test]
     fn test_participant() {

--- a/rust/src/participant.rs
+++ b/rust/src/participant.rs
@@ -2,7 +2,7 @@ use std::default::Default;
 
 use crate::{
     certificate::Certificate,
-    crypto::{generate_encrypt_key_pair, generate_signing_key_pair, ByteObject},
+    crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
     mask::{
         Aggregation,
         BoundType,
@@ -82,7 +82,10 @@ impl Participant {
     pub fn new() -> Result<Self, InitError> {
         // crucial: init must be called before anything else in this module
         sodiumoxide::init().or(Err(InitError))?;
-        let (pk, sk) = generate_signing_key_pair();
+        let SigningKeyPair {
+            public: pk,
+            secret: sk,
+        } = SigningKeyPair::generate();
         Ok(Self {
             pk,
             sk,
@@ -172,9 +175,9 @@ impl Participant {
 
     /// Generate an ephemeral encryption key pair.
     fn gen_ephm_keypair(&mut self) {
-        let (ephm_pk, ephm_sk) = generate_encrypt_key_pair();
-        self.ephm_pk = ephm_pk;
-        self.ephm_sk = ephm_sk;
+        let EncryptKeyPair { public, secret } = EncryptKeyPair::generate();
+        self.ephm_pk = public;
+        self.ephm_sk = secret;
     }
 
     /// Generate a mask seed and mask a local model.
@@ -303,10 +306,12 @@ mod tests {
     #[test]
     fn test_create_local_seed_dict() {
         let mask_seed = MaskSeed::generate();
-        let ephm_dict = iter::repeat_with(|| generate_encrypt_key_pair())
-            .take(1 + randombytes_uniform(10) as usize)
-            .collect::<HashMap<SumParticipantEphemeralPublicKey, SumParticipantEphemeralSecretKey>>(
-            );
+        let ephm_dict = iter::repeat_with(|| {
+            let EncryptKeyPair { public, secret } = EncryptKeyPair::generate();
+            (public, secret)
+        })
+        .take(1 + randombytes_uniform(10) as usize)
+        .collect::<HashMap<SumParticipantEphemeralPublicKey, SumParticipantEphemeralSecretKey>>();
         let sum_dict = ephm_dict
             .iter()
             .map(|(ephm_pk, _)| {

--- a/rust/src/services/messages/message_parser.rs
+++ b/rust/src/services/messages/message_parser.rs
@@ -11,7 +11,7 @@ use tokio::sync::oneshot;
 use tower::Service;
 
 use crate::{
-    crypto::{ByteObject, KeyPair},
+    crypto::{ByteObject, EncryptKeyPair},
     message::{
         DecodeError,
         FromBytes,
@@ -38,7 +38,7 @@ pub struct MessageParserService {
     /// A listener to retrieve the latest coordinator keys. These are
     /// necessary for decrypting messages and verifying their
     /// signature.
-    keys_events: EventListener<KeyPair>,
+    keys_events: EventListener<EncryptKeyPair>,
 
     /// A listener to retrieve the current coordinator phase. Messages
     /// that cannot be handled in the current phase will be
@@ -150,7 +150,7 @@ impl Service<Traced<MessageParserRequest>> for MessageParserService {
 /// Handler created by the [`MessageParserService`] for each request.
 struct Handler {
     /// Coordinator keys for the current round
-    keys: KeyPair,
+    keys: EncryptKeyPair,
     /// Current phase of the coordinator
     phase: PhaseEvent,
 }

--- a/rust/src/services/messages/message_parser.rs
+++ b/rust/src/services/messages/message_parser.rs
@@ -11,7 +11,7 @@ use tokio::sync::oneshot;
 use tower::Service;
 
 use crate::{
-    crypto::{ByteObject, EncryptKeyPair},
+    crypto::{encrypt::EncryptKeyPair, ByteObject},
     message::{
         DecodeError,
         FromBytes,

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use sodiumoxide::{self, crypto::box_, randombytes::randombytes};
 
 use crate::{
-    crypto::{ByteObject, KeyPair},
+    crypto::{ByteObject, EncryptKeyPair},
     mask::{MaskConfig, MaskObject},
     settings::{MaskSettings, PetSettings},
     state_machine::events::{EventPublisher, EventSubscriber, PhaseEvent},
@@ -22,7 +22,7 @@ pub struct RoundParameters {
 }
 
 pub struct CoordinatorState {
-    pub keys: KeyPair,
+    pub keys: EncryptKeyPair,
     pub round_params: RoundParameters,
     pub min_sum: usize,
     pub min_update: usize,
@@ -33,7 +33,7 @@ pub struct CoordinatorState {
 
 impl CoordinatorState {
     pub fn new(pet_settings: PetSettings, mask_settings: MaskSettings) -> (Self, EventSubscriber) {
-        let keys = KeyPair::generate();
+        let keys = EncryptKeyPair::generate();
         let round_params = RoundParameters {
             id: 0,
             pk: keys.public,

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use sodiumoxide::{self, crypto::box_, randombytes::randombytes};
 
 use crate::{
-    crypto::{ByteObject, EncryptKeyPair},
+    crypto::{encrypt::EncryptKeyPair, ByteObject},
     mask::{MaskConfig, MaskObject},
     settings::{MaskSettings, PetSettings},
     state_machine::events::{EventPublisher, EventSubscriber, PhaseEvent},

--- a/rust/src/state_machine/events.rs
+++ b/rust/src/state_machine/events.rs
@@ -8,7 +8,7 @@ use futures::Stream;
 use tokio::sync::watch;
 
 use crate::{
-    crypto::KeyPair,
+    crypto::EncryptKeyPair,
     mask::Model,
     state_machine::coordinator::{RoundId, RoundParameters},
     SeedDict,
@@ -65,7 +65,7 @@ pub enum DictionaryUpdate<D> {
 
 /// A convenience type to emit any coordinator event.
 pub struct EventPublisher {
-    keys_tx: EventBroadcaster<KeyPair>,
+    keys_tx: EventBroadcaster<EncryptKeyPair>,
     params_tx: EventBroadcaster<RoundParameters>,
     phase_tx: EventBroadcaster<PhaseEvent>,
     scalar_tx: EventBroadcaster<ScalarUpdate>,
@@ -78,7 +78,7 @@ pub struct EventPublisher {
 /// The `EventSubscriber` hands out `EventListener`s for any
 /// coordinator event.
 pub struct EventSubscriber {
-    keys_rx: EventListener<KeyPair>,
+    keys_rx: EventListener<EncryptKeyPair>,
     params_rx: EventListener<RoundParameters>,
     phase_rx: EventListener<PhaseEvent>,
     scalar_rx: EventListener<ScalarUpdate>,
@@ -91,12 +91,13 @@ pub struct EventSubscriber {
 impl EventPublisher {
     /// Initialize a new event publisher with the given initial events.
     pub fn init(
-        keys: KeyPair,
+        keys: EncryptKeyPair,
         params: RoundParameters,
         phase: PhaseEvent,
     ) -> (Self, EventSubscriber) {
         let round = params.id;
-        let (keys_tx, keys_rx) = watch::channel::<Event<KeyPair>>(Event { round, event: keys });
+        let (keys_tx, keys_rx) =
+            watch::channel::<Event<EncryptKeyPair>>(Event { round, event: keys });
 
         let (phase_tx, phase_rx) = watch::channel::<Event<PhaseEvent>>(Event {
             round,
@@ -161,7 +162,7 @@ impl EventPublisher {
     }
 
     /// Emit a keys event
-    pub fn broadcast_keys(&mut self, round: RoundId, keys: KeyPair) {
+    pub fn broadcast_keys(&mut self, round: RoundId, keys: EncryptKeyPair) {
         let _ = self.keys_tx.broadcast(Event { round, event: keys });
     }
 
@@ -226,7 +227,7 @@ impl EventSubscriber {
     /// Get a listener for keys events. Callers must be careful not to
     /// leak the secret key they receive, since that would compromise
     /// the security of the coordinator.
-    pub fn keys_listener(&self) -> EventListener<KeyPair> {
+    pub fn keys_listener(&self) -> EventListener<EncryptKeyPair> {
         self.keys_rx.clone()
     }
     /// Get a listener for round parameters events

--- a/rust/src/state_machine/events.rs
+++ b/rust/src/state_machine/events.rs
@@ -8,7 +8,7 @@ use futures::Stream;
 use tokio::sync::watch;
 
 use crate::{
-    crypto::EncryptKeyPair,
+    crypto::encrypt::EncryptKeyPair,
     mask::Model,
     state_machine::coordinator::{RoundId, RoundParameters},
     SeedDict,

--- a/rust/src/state_machine/mod.rs
+++ b/rust/src/state_machine/mod.rs
@@ -95,7 +95,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        crypto::{generate_encrypt_key_pair, generate_signing_key_pair, ByteObject},
+        crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
         mask::{
             BoundType,
             DataType,
@@ -131,8 +131,13 @@ mod tests {
         oneshot::Receiver<Result<(), PetError>>,
     ) {
         let (response_tx, response_rx) = oneshot::channel::<Result<(), PetError>>();
-        let (participant_pk, _) = generate_signing_key_pair();
-        let (ephm_pk, _) = generate_encrypt_key_pair();
+        let SigningKeyPair {
+            public: participant_pk,
+            ..
+        } = SigningKeyPair::generate();
+        let EncryptKeyPair {
+            public: ephm_pk, ..
+        } = EncryptKeyPair::generate();
         let req = Request::Sum((
             SumRequest {
                 participant_pk,
@@ -147,7 +152,10 @@ mod tests {
         sum_pk: SumParticipantPublicKey,
     ) -> (Request, oneshot::Receiver<Result<(), PetError>>) {
         let (response_tx, response_rx) = oneshot::channel::<Result<(), PetError>>();
-        let (participant_pk, _) = generate_signing_key_pair();
+        let SigningKeyPair {
+            public: participant_pk,
+            ..
+        } = SigningKeyPair::generate();
         let mut local_seed_dict = LocalSeedDict::new();
         local_seed_dict.insert(sum_pk, EncryptedMaskSeed::zeroed());
         let masked_model = gen_mask();

--- a/rust/src/state_machine/mod.rs
+++ b/rust/src/state_machine/mod.rs
@@ -95,7 +95,7 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        crypto::{ByteObject, EncryptKeyPair, SigningKeyPair},
+        crypto::{encrypt::EncryptKeyPair, sign::SigningKeyPair, ByteObject},
         mask::{
             BoundType,
             DataType,

--- a/rust/src/state_machine/phases/idle.rs
+++ b/rust/src/state_machine/phases/idle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    crypto::{ByteObject, EncryptKeyPair, SigningKeySeed},
+    crypto::{encrypt::EncryptKeyPair, sign::SigningKeySeed, ByteObject},
     state_machine::{
         coordinator::{CoordinatorState, RoundSeed},
         events::{DictionaryUpdate, MaskLengthUpdate, PhaseEvent, ScalarUpdate},

--- a/rust/src/state_machine/phases/idle.rs
+++ b/rust/src/state_machine/phases/idle.rs
@@ -1,5 +1,5 @@
 use crate::{
-    crypto::{ByteObject, KeyPair, SigningKeySeed},
+    crypto::{ByteObject, EncryptKeyPair, SigningKeySeed},
     state_machine::{
         coordinator::{CoordinatorState, RoundSeed},
         events::{DictionaryUpdate, MaskLengthUpdate, PhaseEvent, ScalarUpdate},
@@ -100,7 +100,7 @@ impl<R> PhaseState<R, Idle> {
 
     /// Generate fresh round credentials.
     fn gen_round_keypair(&mut self) {
-        self.coordinator_state.keys = KeyPair::generate();
+        self.coordinator_state.keys = EncryptKeyPair::generate();
         self.coordinator_state.round_params.pk = self.coordinator_state.keys.public;
     }
 }


### PR DESCRIPTION
**References**
- [PB-875](https://xainag.atlassian.net/browse/PB-875)

**Summary**
- add module level documentation
- update struct and method documentation
- unravel import indirections
- consistify naming and usage of the newly introduced `KeyPair`

note that this requires `cargo +nightly doc` to generate proper internal links, which is not an issue since this is supported by the hosted rust docs as well.