### PR TITLE
PB-797 Replace/update coordinator in Kubernetes

### DIFF
--- a/k8s/coordinator/base/deployment.yaml
+++ b/k8s/coordinator/base/deployment.yaml
@@ -23,4 +23,3 @@ spec:
           ports:
             - containerPort: 8081
               protocol: TCP
-

--- a/k8s/coordinator/base/deployment.yaml
+++ b/k8s/coordinator/base/deployment.yaml
@@ -15,8 +15,12 @@ spec:
       containers:
         - name: coordinator
           image: coordinator
+          env:
+            - name: RUST_LOG
+              value: "DEBUG"
           command: ["/app/coordinator"]
           args: ["-c", "/app/config.toml"]
           ports:
             - containerPort: 8081
               protocol: TCP
+

--- a/k8s/coordinator/base/deployment.yaml
+++ b/k8s/coordinator/base/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       containers:
         - name: coordinator
           image: coordinator
+          imagePullPolicy: Always
           env:
             - name: RUST_LOG
               value: "DEBUG"

--- a/k8s/coordinator/development/kustomization.yaml
+++ b/k8s/coordinator/development/kustomization.yaml
@@ -4,18 +4,20 @@ kind: Kustomization
 namespace: development
 
 images:
-- name: coordinator
-  newName: xain/xain-fl
-  newTag: development
+  - name: coordinator
+    newName: xain/xain-fl
+    newTag: development
 
 configMapGenerator:
-- name: config-toml
-  files:
-  - config.toml
+  - name: config-toml
+    files:
+    - config.toml
+
+bases:
+  - ../base
 
 patchesStrategicMerge:
-- history-limit.yaml
-- config-volume-mount.yaml
+  - history-limit.yaml
+  - config-volume-mount.yaml
 resources:
-- ../base
-- ingress.yaml
+  - ingress.yaml


### PR DESCRIPTION
I'm opening this as a "Draft PR" as I still want to wait for https://github.com/xainag/xain-fl/pull/430 to be merged first, due to changes on the Dockerfile.
I will then rebase this one and mark it as ready for review.

---

For the time being, so I could move forward and update the `coordinator` in our development Kubernetes Cluster, I did local changes to the Dockerfile on my own branch, just so I could build and push the updated `xain/xain-fl:development` to Docker Hub.