### PR TITLE
PB-870 document mask module

### DIFF
--- a/rust/src/crypto/sign.rs
+++ b/rust/src/crypto/sign.rs
@@ -149,7 +149,7 @@ impl Signature {
     /// Length in bytes of this signature.
     pub const LENGTH: usize = sign::SIGNATUREBYTES;
 
-    /// Computes the floating point representation of the hashed signature and ensure that it is
+    /// Computes the floating point representation of the hashed signature and ensures that it is
     /// below the given threshold:
     /// ```no_rust
     /// int(hash(signature)) / (2**hashbits - 1) <= threshold.

--- a/rust/src/mask/config/mod.rs
+++ b/rust/src/mask/config/mod.rs
@@ -84,6 +84,9 @@ impl TryFrom<u8> for DataType {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
 /// The bounds of the numerical values.
+///
+/// For a value `v` to be absolutely bounded by another value `b`, it has to hold that
+/// `-b <= v <= b` or equivalently `|v| <= b`.
 pub enum BoundType {
     /// Numerical values absolutely bounded by 1.
     B0 = 0,
@@ -115,7 +118,7 @@ impl TryFrom<u8> for BoundType {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
-/// The number of models to be aggregated at most.
+/// The maximum number of models to be aggregated at most.
 pub enum ModelType {
     /// At most 1_000 models to be aggregated.
     M3 = 3,
@@ -129,7 +132,7 @@ pub enum ModelType {
 
 impl ModelType {
     /// Gets the maximum number of models that can be aggregated for this model type.
-    pub fn nb_models_max(&self) -> usize {
+    pub fn max_nb_models(&self) -> usize {
         10_usize.pow(*self as u8 as u32)
     }
 }
@@ -151,20 +154,20 @@ impl TryFrom<u8> for ModelType {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// A masking configuration.
 ///
-/// Consists of the following parts:
-/// - the order of the finite group
-/// - the data type of the numbers to be masked
-/// - the bounds of the numbers to be masked
-/// - the number of models to be aggregated at most
+/// This configuration is applied for masking, aggregation and unmasking of models.
 pub struct MaskConfig {
+    /// The order of the finite group.
     pub group_type: GroupType,
+    /// The original primitive data type of the numerical values to be masked.
     pub data_type: DataType,
+    /// The bounds of the numerical values.
     pub bound_type: BoundType,
+    /// The maximum number of models to be aggregated at most.
     pub model_type: ModelType,
 }
 
 impl MaskConfig {
-    /// Returns the number of bytes needed for an element of a mask or masked model.
+    /// Returns the number of bytes needed for an element of a mask object.
     pub(crate) fn bytes_per_number(&self) -> usize {
         let max_number = self.order() - BigUint::from(1_u8);
         (max_number.bits() + 7) / 8

--- a/rust/src/mask/config/mod.rs
+++ b/rust/src/mask/config/mod.rs
@@ -1,4 +1,4 @@
-//! Mask configuration parameters.
+//! Masking configuration parameters.
 //!
 //! See the [mask module] documentation since this is a private module anyways.
 //!
@@ -16,7 +16,7 @@ use num::{
 use thiserror::Error;
 
 #[derive(Debug, Error)]
-/// Errors related to invalid mask configurations.
+/// Errors related to invalid masking configurations.
 pub enum InvalidMaskConfigError {
     #[error("invalid group type")]
     GroupType,
@@ -55,7 +55,7 @@ impl TryFrom<u8> for GroupType {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u8)]
-/// The original primitive data type of the numerical values.
+/// The original primitive data type of the numerical values to be masked.
 pub enum DataType {
     /// Numbers of type f32.
     F32 = 0,
@@ -128,7 +128,7 @@ pub enum ModelType {
 }
 
 impl ModelType {
-    /// Gets the number of models to be aggregated at most for this model type.
+    /// Gets the maximum number of models that can be aggregated for this model type.
     pub fn nb_models_max(&self) -> usize {
         10_usize.pow(*self as u8 as u32)
     }
@@ -149,7 +149,7 @@ impl TryFrom<u8> for ModelType {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-/// A mask configuration.
+/// A masking configuration.
 ///
 /// Consists of the following parts:
 /// - the order of the finite group
@@ -164,14 +164,13 @@ pub struct MaskConfig {
 }
 
 impl MaskConfig {
-    /// Returns the number of bytes needed for an element of a mask or masked model wrt this mask
-    /// configuration.
-    pub fn bytes_per_number(&self) -> usize {
+    /// Returns the number of bytes needed for an element of a mask or masked model.
+    pub(crate) fn bytes_per_number(&self) -> usize {
         let max_number = self.order() - BigUint::from(1_u8);
         (max_number.bits() + 7) / 8
     }
 
-    /// Gets the additional shift value for masking/unmasking wrt this mask configuration.
+    /// Gets the additional shift value for masking/unmasking.
     pub fn add_shift(&self) -> Ratio<BigInt> {
         use BoundType::{Bmax, B0, B2, B4, B6};
         use DataType::{F32, F64, I32, I64};
@@ -191,7 +190,7 @@ impl MaskConfig {
         }
     }
 
-    /// Gets the exponential shift value for masking/unmasking wrt this mask configuration.
+    /// Gets the exponential shift value for masking/unmasking.
     pub fn exp_shift(&self) -> BigInt {
         use BoundType::{Bmax, B0, B2, B4, B6};
         use DataType::{F32, F64, I32, I64};
@@ -209,7 +208,7 @@ impl MaskConfig {
         }
     }
 
-    /// Gets the finite group order value for masking/unmasking wrt this mask configuration.
+    /// Gets the finite group order value for masking/unmasking.
     pub fn order(&self) -> BigUint {
         use BoundType::{Bmax, B0, B2, B4, B6};
         use DataType::{F32, F64, I32, I64};

--- a/rust/src/mask/config/mod.rs
+++ b/rust/src/mask/config/mod.rs
@@ -157,10 +157,10 @@ impl TryFrom<u8> for ModelType {
 /// - the bounds of the numbers to be masked
 /// - the number of models to be aggregated at most
 pub struct MaskConfig {
-    pub(crate) group_type: GroupType,
-    pub(crate) data_type: DataType,
-    pub(crate) bound_type: BoundType,
-    pub(crate) model_type: ModelType,
+    pub group_type: GroupType,
+    pub data_type: DataType,
+    pub bound_type: BoundType,
+    pub model_type: ModelType,
 }
 
 impl MaskConfig {

--- a/rust/src/mask/config/mod.rs
+++ b/rust/src/mask/config/mod.rs
@@ -93,7 +93,7 @@ pub enum BoundType {
     B4 = 4,
     /// Numerical values absolutely bounded by 1_000_000.
     B6 = 6,
-    /// Numerical values absolutely bounded by their original primitve data types' maximum absolute
+    /// Numerical values absolutely bounded by their original primitive data type's maximum absolute
     /// value.
     Bmax = 255,
 }

--- a/rust/src/mask/config/serialization.rs
+++ b/rust/src/mask/config/serialization.rs
@@ -1,4 +1,4 @@
-//! Serialization of mask configurations.
+//! Serialization of masking configurations.
 //!
 //! See the [mask module] documentation since this is a private module anyways.
 //!
@@ -19,7 +19,7 @@ const BOUND_TYPE_FIELD: usize = 2;
 const MODEL_TYPE_FIELD: usize = 3;
 pub(crate) const MASK_CONFIG_BUFFER_LEN: usize = 4;
 
-/// A buffer for serialized mask configurations.
+/// A buffer for serialized masking configurations.
 pub struct MaskConfigBuffer<T> {
     inner: T,
 }
@@ -28,7 +28,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
     /// Creates a new buffer from `bytes`.
     ///
     /// # Errors
-    /// Fails if the `bytes` don't conform to the required buffer length for mask configurations.
+    /// Fails if the `bytes` don't conform to the required buffer length for masking configurations.
     pub fn new(bytes: T) -> Result<Self, DecodeError> {
         let buffer = Self { inner: bytes };
         buffer
@@ -42,7 +42,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         Self { inner: bytes }
     }
 
-    /// Checks if this buffer conforms to the required buffer length for mask configurations.
+    /// Checks if this buffer conforms to the required buffer length for masking configurations.
     ///
     /// # Errors
     /// Fails if the buffer is to small.
@@ -58,7 +58,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         Ok(())
     }
 
-    /// Gets the serialized group type of the mask configuration.
+    /// Gets the serialized group type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -66,7 +66,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_ref()[GROUP_TYPE_FIELD]
     }
 
-    /// Gets the serialized data type of the mask configuration.
+    /// Gets the serialized data type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -74,7 +74,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_ref()[DATA_TYPE_FIELD]
     }
 
-    /// Gets the serialized bound type of the mask configuration.
+    /// Gets the serialized bound type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -82,7 +82,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_ref()[BOUND_TYPE_FIELD]
     }
 
-    /// Gets the serialized model type of the mask configuration.
+    /// Gets the serialized model type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -92,7 +92,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
 }
 
 impl<T: AsMut<[u8]>> MaskConfigBuffer<T> {
-    /// Sets the serialized group type of the mask configuration.
+    /// Sets the serialized group type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -100,7 +100,7 @@ impl<T: AsMut<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_mut()[GROUP_TYPE_FIELD] = value;
     }
 
-    /// Sets the serialized data type of the mask configuration.
+    /// Sets the serialized data type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -108,7 +108,7 @@ impl<T: AsMut<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_mut()[DATA_TYPE_FIELD] = value;
     }
 
-    /// Sets the serialized bound type of the mask configuration.
+    /// Sets the serialized bound type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -116,7 +116,7 @@ impl<T: AsMut<[u8]>> MaskConfigBuffer<T> {
         self.inner.as_mut()[BOUND_TYPE_FIELD] = value;
     }
 
-    /// Sets the serialized model type of the mask configuration.
+    /// Sets the serialized model type of the masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.

--- a/rust/src/mask/config/serialization.rs
+++ b/rust/src/mask/config/serialization.rs
@@ -1,5 +1,12 @@
-use anyhow::{anyhow, Context};
+//! Serialization of mask configurations.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
 use std::convert::TryInto;
+
+use anyhow::{anyhow, Context};
 
 use crate::{
     mask::MaskConfig,
@@ -12,11 +19,16 @@ const BOUND_TYPE_FIELD: usize = 2;
 const MODEL_TYPE_FIELD: usize = 3;
 pub(crate) const MASK_CONFIG_BUFFER_LEN: usize = 4;
 
-struct MaskConfigBuffer<T> {
+/// A buffer for serialized mask configurations.
+pub struct MaskConfigBuffer<T> {
     inner: T,
 }
 
 impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
+    /// Creates a new buffer from `bytes`.
+    ///
+    /// # Errors
+    /// Fails if the `bytes` don't conform to the required buffer length for mask configurations.
     pub fn new(bytes: T) -> Result<Self, DecodeError> {
         let buffer = Self { inner: bytes };
         buffer
@@ -25,10 +37,15 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         Ok(buffer)
     }
 
+    /// Creates a new buffer from `bytes`.
     pub fn new_unchecked(bytes: T) -> Self {
         Self { inner: bytes }
     }
 
+    /// Checks if this buffer conforms to the required buffer length for mask configurations.
+    ///
+    /// # Errors
+    /// Fails if the buffer is to small.
     pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.inner.as_ref().len();
         if len < MASK_CONFIG_BUFFER_LEN {
@@ -41,32 +58,68 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
         Ok(())
     }
 
+    /// Gets the serialized group type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn group_type(&self) -> u8 {
         self.inner.as_ref()[GROUP_TYPE_FIELD]
     }
 
+    /// Gets the serialized data type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn data_type(&self) -> u8 {
         self.inner.as_ref()[DATA_TYPE_FIELD]
     }
+
+    /// Gets the serialized bound type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn bound_type(&self) -> u8 {
         self.inner.as_ref()[BOUND_TYPE_FIELD]
     }
+
+    /// Gets the serialized model type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn model_type(&self) -> u8 {
         self.inner.as_ref()[MODEL_TYPE_FIELD]
     }
 }
 
 impl<T: AsMut<[u8]>> MaskConfigBuffer<T> {
+    /// Sets the serialized group type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn set_group_type(&mut self, value: u8) {
         self.inner.as_mut()[GROUP_TYPE_FIELD] = value;
     }
 
+    /// Sets the serialized data type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn set_data_type(&mut self, value: u8) {
         self.inner.as_mut()[DATA_TYPE_FIELD] = value;
     }
+
+    /// Sets the serialized bound type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn set_bound_type(&mut self, value: u8) {
         self.inner.as_mut()[BOUND_TYPE_FIELD] = value;
     }
+
+    /// Sets the serialized model type of the mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn set_model_type(&mut self, value: u8) {
         self.inner.as_mut()[MODEL_TYPE_FIELD] = value;
     }

--- a/rust/src/mask/config/serialization.rs
+++ b/rust/src/mask/config/serialization.rs
@@ -45,7 +45,7 @@ impl<T: AsRef<[u8]>> MaskConfigBuffer<T> {
     /// Checks if this buffer conforms to the required buffer length for masking configurations.
     ///
     /// # Errors
-    /// Fails if the buffer is to small.
+    /// Fails if the buffer is too small.
     pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.inner.as_ref().len();
         if len < MASK_CONFIG_BUFFER_LEN {

--- a/rust/src/mask/masking.rs
+++ b/rust/src/mask/masking.rs
@@ -86,12 +86,12 @@ impl Aggregation {
         self.object.data.len()
     }
 
-    /// Gets the mask configuration of the aggregator.
+    /// Gets the masking configuration of the aggregator.
     pub fn config(&self) -> MaskConfig {
         self.object.config
     }
 
-    /// Validates if unmasking of the aggregated, masked model with the given `mask` may be
+    /// Validates if unmasking of the aggregated masked model with the given `mask` may be
     /// safely performed.
     ///
     /// This should be checked before calling [`unmask()`], since unmasking may return garbage
@@ -100,9 +100,9 @@ impl Aggregation {
     /// # Errors
     /// Fails in one of the following cases:
     /// - The aggregator has not yet aggregated any models.
-    /// - The number of aggregated masked models is larger than the chosen mask configuration
+    /// - The number of aggregated masked models is larger than the chosen masking configuration
     ///   allows.
-    /// - The mask configuration of the aggregator and of the `mask` don't coincide.
+    /// - The masking configuration of the aggregator and of the `mask` don't coincide.
     /// - The length of the aggregated masked model and the `mask` don't coincide.
     /// - The `mask` itself is invalid.
     ///
@@ -131,7 +131,7 @@ impl Aggregation {
         Ok(())
     }
 
-    /// Unmasks the aggregated, masked model with the given `mask`.
+    /// Unmasks the aggregated masked model with the given `mask`.
     ///
     /// It should be checked that [`validate_unmasking()`] returns `true` before calling this, since
     /// unmasking may return garbage values otherwise. The unmasking is performed in opposite order
@@ -180,11 +180,11 @@ impl Aggregation {
     ///
     /// # Errors
     /// Fails in one of the following cases:
-    /// - The mask configuration of the aggregator and of the `object` don't coincide.
+    /// - The masking configuration of the aggregator and of the `object` don't coincide.
     /// - The length of the aggregated masks or masked model and the `object` don't coincide. If the
     ///   aggregator is empty, then an `object` of any length may be aggregated.
     /// - The new number of aggregated masks or masked models would exceed the number that the
-    ///   chosen mask configuration allows.
+    ///   chosen masking configuration allows.
     /// - The `object` itself is invalid.
     ///
     /// Even though it does not produce any meaningful values, it may be validated that
@@ -245,7 +245,7 @@ pub struct Masker {
 }
 
 impl Masker {
-    /// Creates a new masker with the given mask `config`uration with a randomly generated seed.
+    /// Creates a new masker with the given masking `config`uration with a randomly generated seed.
     pub fn new(config: MaskConfig) -> Self {
         Self {
             config,
@@ -253,17 +253,17 @@ impl Masker {
         }
     }
 
-    /// Creates a new masker with the given mask `config`uration and `seed`.
+    /// Creates a new masker with the given masking `config`uration and `seed`.
     pub fn with_seed(config: MaskConfig, seed: MaskSeed) -> Self {
         Self { config, seed }
     }
 }
 
 impl Masker {
-    /// Masks the model wrt the mask configuration. Enforces bounds on the scalar and weights.
+    /// Masks the model wrt the masking configuration. Enforces bounds on the scalar and weights.
     ///
     /// The masking proceeds in the following steps:
-    /// - Clamp the scalar and the weights according to the mask configuration.
+    /// - Clamp the scalar and the weights according to the masking configuration.
     /// - Shift the weights into the non-negative reals.
     /// - Shift the weights into the non-negative integers.
     /// - Shift the weights into the finite group.
@@ -302,7 +302,7 @@ impl Masker {
         (seed, masked_model)
     }
 
-    /// Creates an iterator that yields randomly generated integers wrt the mask configuration.
+    /// Creates an iterator that yields randomly generated integers wrt the masking configuration.
     fn random_ints(&self) -> impl Iterator<Item = BigUint> {
         let order = self.config.order();
         let mut prng = ChaCha20Rng::from_seed(self.seed.as_array());

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -1,4 +1,184 @@
-//! Masking of models according to the PET protocol.
+//! Masking, aggregation and unmasking of models.
+//!
+//! # Models
+//! A [`Model`] is a collection of weights/parameters which are represented as finite numerical
+//! values (i.e. rational numbers) of arbitrary precision. Particularly, a model in itself is not
+//! bound to a primitive data type, but it can be created from those and converted back into those.
+//!
+//! Currently, the primitive data types [`f32`], [`f64`], [`i32`] and [`i64`] are supported and
+//! this might be extended in the future.
+//!
+//! ```
+//! # use xain_fl::mask::{FromPrimitives, IntoPrimitives, Model};
+//! let weights = vec![0_f32; 10];
+//! let model = Model::from_primitives_bounded(weights.into_iter());
+//! assert_eq!(
+//!     model.into_primitives_unchecked().collect::<Vec<f32>>(),
+//!     vec![0_f32; 10],
+//! );
+//! ```
+//!
+//! # Mask configurations
+//! The masking, aggregation and unmasking of models requires certain information about the models
+//! to guarantee that no information is lost during the process, which is configured via the
+//! [`MaskConfig`]. Each mask configuration consists of the group type, data type, bound type and
+//! model type. Usually, a mask configuration is decided on and configured depending on the specific
+//! machine learning use case as part of the setup for the XayNet federated learning platform.
+//!
+//! Currently, those choices are catalogued for certain fixed variants for each type, but we aim
+//! to generalize this in the future to more flexible mask configurations to allow for a more
+//! fine-grained tradeoff between representability and performance.
+//!
+//! ## Group type
+//! The [`GroupType`] describes the order of the finite group in which the masked model weights are
+//! embedded. The smaller the gap between the maximum possible embedded weights and the group order
+//! is, the less theoretically possible information flow about the masks may be observed. Specific
+//! group orders provide potentially higher performance on the other hand, which always makes this
+//! a tradeoff between security and performance. The group type variants are:
+//! - Integer: no gap but potentially slowest performance.
+//! - Prime: usually small gap with higher performance.
+//! - Power2: usually higher gap with potentially highest performance.
+//!
+//! ## Data type
+//! The [`DataType`] describes the original primitives data type of the model weights. This
+//! influences in combination with the bound type the preserved decimal places of the model weights
+//! during the masking, aggregation and unmasking process, which are:
+//! - F32: 10 decimal places for bounded model weights and 45 decimal places for unbounded.
+//! - F64: 20 decimal places for bounded model weights and 324 decimal places for unbounded.
+//! - I32 and I64: 10 decimal places (required for scaled aggregation).
+//!
+//! Currently the primitive data types [`f32`], [`f64`], [`i32`] and [`i64`] are supported via the
+//! data type variants.
+//!
+//! ## Bound type
+//! The [`BoundType`] describes the absolute bounds on all model weights. The smaller the bounds of
+//! the model weights, the less bytes are required to represent the masked model weights. These
+//! bounds are enforced on the model weights before masking them to prevent information loss during
+//! the masking, aggregation and unmasking process. The bound type variants are:
+//! - B0: all model weights are absolutely bounded by 1.
+//! - B2: all model weights are absolutely bounded by 100.
+//! - B4: all model weights are absolutely bounded by 10,000.
+//! - B6: all model weights are absolutely bounded by 1,000,000.
+//! - Bmax: all model weights are absolutely bounded by their primitive data type's absolute
+//!   maximum value.
+//!
+//! ## Model type
+//! The [`ModelType`] describes the maximum number of masked models that can be aggregated without
+//! information loss. The smaller the number of masked models, the less bytes are required to
+//! represent masked model weights. The model type variants are:
+//! - M3: at most 1,000 masked models may be aggregated.
+//! - M6: at most 1,000,000 masked models may be aggregated.
+//! - M9: at most 1,000,000,000 masked models may be aggregated.
+//! - M12: at most 1,000,000,000,000 masked models may be aggregated.
+//!
+//! # Masking, aggregation and unmasking
+//! Local models should be masked (i.e. encrypted) before they are communicated somewhere else to
+//! protect the possibly sensitive information learned from local data. The masking should allow
+//! for masked models to be aggregated while they are still masked (i.e. homomorphic encryption).
+//! Then the aggregated masked model can safely be unmasked without jeopardizing the secrecy of
+//! personal information if the model is generalized enough.
+//!
+//! ## Masking
+//! A [`Model`] can be masked with a [`Masker`], which requires a [`MaskConfig`]. During the
+//! masking the model weights are scaled, then embedded as elements of the chosen finite group and
+//! finally masked by randomly generated elements from that very same finite group. The scalar
+//! provides the necessary means to perform different aggregation strategies, for example federated
+//! averaging. The masked model is returned as a [`MaskObject`] and the mask used to mask the model
+//! can be generated via the additionally returned [`MaskSeed`].
+//!
+//! ```
+//! # use xain_fl::mask::{BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, Model, ModelType};
+//! // create local models and a fitting mask configuration
+//! let number_weights = 10;
+//! let scalar = 0.5;
+//! let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
+//! let local_model_2 = Model::from_primitives_bounded(vec![1_f32; number_weights].into_iter());
+//! let config = MaskConfig {
+//!     group_type: GroupType::Prime,
+//!     data_type: DataType::F32,
+//!     bound_type: BoundType::B0,
+//!     model_type: ModelType::M3,
+//! };
+//!
+//! // mask the local models
+//! let (local_mask_seed_1, masked_local_model_1) = Masker::new(config).mask(scalar, local_model_1);
+//! let (local_mask_seed_2, masked_local_model_2) = Masker::new(config).mask(scalar, local_model_2);
+//!
+//! // derive the masks of the local masked models
+//! let local_mask_1 = local_mask_seed_1.derive_mask(number_weights, config);
+//! let local_mask_2 = local_mask_seed_2.derive_mask(number_weights, config);
+//! ```
+//!
+//! ## Aggregation
+//! Masked models can be aggregated via an [`Aggregation`]. Masks can be aggregated via an
+//! [`Aggregation`] as well, since an aggregated, masked model can only be unmasked by the
+//! aggregated masks belonging to the masked models. It should always be validated that the
+//! aggregation may be safely performed wrt the chosen mask configuration before actually
+//! aggregating to avoid the possible loss of information.
+//!
+//! ```
+//! # use xain_fl::mask::{Aggregation, BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, MaskObject, Model, ModelType};
+//! # let number_weights = 10;
+//! # let scalar = 0.5;
+//! # let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
+//! # let local_model_2 = Model::from_primitives_bounded(vec![1_f32; number_weights].into_iter());
+//! # let config = MaskConfig { group_type: GroupType::Prime, data_type: DataType::F32, bound_type: BoundType::B0, model_type: ModelType::M3};
+//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config).mask(scalar, local_model_1);
+//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config).mask(scalar, local_model_2);
+//! # let local_mask_1 = local_mask_seed_1.derive_mask(number_weights, config);
+//! # let local_mask_2 = local_mask_seed_2.derive_mask(number_weights, config);
+//! // aggregate the local masks
+//! let mut mask_aggregator = Aggregation::new(config);
+//! if let Ok(_) = mask_aggregator.validate_aggregation(&local_mask_1) {
+//!     mask_aggregator.aggregate(local_mask_1);
+//! };
+//! if let Ok(_) = mask_aggregator.validate_aggregation(&local_mask_2) {
+//!     mask_aggregator.aggregate(local_mask_2);
+//! };
+//! let global_mask: MaskObject = mask_aggregator.into();
+//!
+//! // aggregate the local masked models
+//! let mut model_aggregator = Aggregation::new(config);
+//! if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_1) {
+//!     model_aggregator.aggregate(masked_local_model_1);
+//! };
+//! if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_2) {
+//!     model_aggregator.aggregate(masked_local_model_2);
+//! };
+//! ```
+//!
+//! ## Unmasking
+//! A masked model can be unmasked by the corresponding mask via an [`Aggregation`] in the end. It
+//! should always be validated that the unmasking may be safely performed wrt the chosen mask
+//! configuration before actually unmasking to avoid the possible loss of information.
+//!
+//! ```
+//! # use xain_fl::mask::{Aggregation, BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, MaskObject, Model, ModelType};
+//! # let number_weights = 10;
+//! # let scalar = 0.5;
+//! # let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
+//! # let local_model_2 = Model::from_primitives_bounded(vec![1_f32; number_weights].into_iter());
+//! # let config = MaskConfig { group_type: GroupType::Prime, data_type: DataType::F32, bound_type: BoundType::B0, model_type: ModelType::M3};
+//! # let (local_mask_seed_1, masked_local_model_1) = Masker::new(config).mask(scalar, local_model_1);
+//! # let (local_mask_seed_2, masked_local_model_2) = Masker::new(config).mask(scalar, local_model_2);
+//! # let local_mask_1 = local_mask_seed_1.derive_mask(number_weights, config);
+//! # let local_mask_2 = local_mask_seed_2.derive_mask(number_weights, config);
+//! # let mut mask_aggregator = Aggregation::new(config);
+//! # if let Ok(_) = mask_aggregator.validate_aggregation(&local_mask_1) { mask_aggregator.aggregate(local_mask_1); };
+//! # if let Ok(_) = mask_aggregator.validate_aggregation(&local_mask_2) { mask_aggregator.aggregate(local_mask_2); };
+//! # let global_mask: MaskObject = mask_aggregator.into();
+//! # let mut model_aggregator = Aggregation::new(config);
+//! # if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_1) { model_aggregator.aggregate(masked_local_model_1); };
+//! # if let Ok(_) = model_aggregator.validate_aggregation(&masked_local_model_2) { model_aggregator.aggregate(masked_local_model_2); };
+//! // unmask the aggregated masked model with the aggregated mask
+//! if let Ok(_) = model_aggregator.validate_unmasking(&global_mask) {
+//!     let global_model = model_aggregator.unmask(global_mask);
+//!     assert_eq!(
+//!         global_model,
+//!         Model::from_primitives_bounded(vec![0.5_f32; number_weights].into_iter()),
+//!     );
+//! };
+//! ```
 
 pub(crate) mod config;
 mod masking;

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -1,13 +1,23 @@
+//! Masking of models according to the PET protocol.
+
 pub(crate) mod config;
 mod masking;
 pub(crate) mod model;
-pub(crate) mod object; //
+pub(crate) mod object;
 mod seed;
 
 pub use self::{
-    config::{BoundType, DataType, GroupType, MaskConfig, ModelType},
+    config::{
+        serialization::MaskConfigBuffer,
+        BoundType,
+        DataType,
+        GroupType,
+        InvalidMaskConfigError,
+        MaskConfig,
+        ModelType,
+    },
     masking::{Aggregation, AggregationError, Masker, UnmaskingError},
-    model::{FromPrimitives, IntoPrimitives, Model},
-    object::{serialization::MaskObjectBuffer, MaskObject},
+    model::{FromPrimitives, IntoPrimitives, Model, ModelCastError, PrimitiveCastError},
+    object::{serialization::MaskObjectBuffer, InvalidMaskObjectError, MaskObject},
     seed::{EncryptedMaskSeed, MaskSeed},
 };

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! # Models
 //! A [`Model`] is a collection of weights/parameters which are represented as finite numerical
-//! values (i.e. rational numbers) of arbitrary precision. Particularly, a model in itself is not
-//! bound to a primitive data type, but it can be created from those and converted back into those.
+//! values (i.e. rational numbers) of arbitrary precision. As such, a model in itself is not bound
+//! to any particular primitive data type, but it can be created from those and converted back into
+//! them.
 //!
 //! Currently, the primitive data types [`f32`], [`f64`], [`i32`] and [`i64`] are supported and
 //! this might be extended in the future.
@@ -41,8 +42,8 @@
 //! - Power2: usually higher gap with potentially highest performance.
 //!
 //! ## Data type
-//! The [`DataType`] describes the original primitives data type of the model weights. This
-//! influences in combination with the bound type the preserved decimal places of the model weights
+//! The [`DataType`] describes the original primitive data type of the model weights. This in
+//! combination with the bound type influences the preserved decimal places of the model weights
 //! during the masking, aggregation and unmasking process, which are:
 //! - F32: 10 decimal places for bounded model weights and 45 decimal places for unbounded.
 //! - F64: 20 decimal places for bounded model weights and 324 decimal places for unbounded.
@@ -81,7 +82,7 @@
 //!
 //! ## Masking
 //! A [`Model`] can be masked with a [`Masker`], which requires a [`MaskConfig`]. During the
-//! masking the model weights are scaled, then embedded as elements of the chosen finite group and
+//! masking, the model weights are scaled, then embedded as elements of the chosen finite group and
 //! finally masked by randomly generated elements from that very same finite group. The scalar
 //! provides the necessary means to perform different aggregation strategies, for example federated
 //! averaging. The masked model is returned as a [`MaskObject`] and the mask used to mask the model
@@ -111,11 +112,10 @@
 //! ```
 //!
 //! ## Aggregation
-//! Masked models can be aggregated via an [`Aggregation`]. Masks can be aggregated via an
-//! [`Aggregation`] as well, since an aggregated masked model can only be unmasked by the
-//! aggregated masks belonging to the masked models. It should always be validated that the
-//! aggregation may be safely performed wrt the chosen masking configuration before actually
-//! aggregating to avoid the possible loss of information.
+//! Masked models can be aggregated via an [`Aggregation`]. Masks themselves can be aggregated via
+//! an [`Aggregation`] as well. An aggregated masked model can only be unmasked by the aggregation
+//! of masks for each model. Aggregation should always be validated beforehand so that it may be
+//! safely performed wrt the chosen masking configuration without possible loss of information.
 //!
 //! ```
 //! # use xain_fl::mask::{Aggregation, BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, MaskObject, Model, ModelType};
@@ -149,9 +149,9 @@
 //! ```
 //!
 //! ## Unmasking
-//! A masked model can be unmasked by the corresponding mask via an [`Aggregation`] in the end. It
-//! should always be validated that the unmasking may be safely performed wrt the chosen mask
-//! configuration before actually unmasking to avoid the possible loss of information.
+//! A masked model can be unmasked by the corresponding mask via an [`Aggregation`]. Unmasking
+//! should always be validated beforehand so that it may be safely performed wrt the chosen mask
+//! configuration without possible loss of information.
 //!
 //! ```
 //! # use xain_fl::mask::{Aggregation, BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, MaskObject, Model, ModelType};

--- a/rust/src/mask/mod.rs
+++ b/rust/src/mask/mod.rs
@@ -18,15 +18,16 @@
 //! );
 //! ```
 //!
-//! # Mask configurations
+//! # Masking configurations
 //! The masking, aggregation and unmasking of models requires certain information about the models
 //! to guarantee that no information is lost during the process, which is configured via the
-//! [`MaskConfig`]. Each mask configuration consists of the group type, data type, bound type and
-//! model type. Usually, a mask configuration is decided on and configured depending on the specific
-//! machine learning use case as part of the setup for the XayNet federated learning platform.
+//! [`MaskConfig`]. Each masking configuration consists of the group type, data type, bound type and
+//! model type. Usually, a masking configuration is decided on and configured depending on the
+//! specific machine learning use case as part of the setup for the XayNet federated learning
+//! platform.
 //!
 //! Currently, those choices are catalogued for certain fixed variants for each type, but we aim
-//! to generalize this in the future to more flexible mask configurations to allow for a more
+//! to generalize this in the future to more flexible masking configurations to allow for a more
 //! fine-grained tradeoff between representability and performance.
 //!
 //! ## Group type
@@ -88,7 +89,7 @@
 //!
 //! ```
 //! # use xain_fl::mask::{BoundType, DataType, FromPrimitives, GroupType, MaskConfig, Masker, Model, ModelType};
-//! // create local models and a fitting mask configuration
+//! // create local models and a fitting masking configuration
 //! let number_weights = 10;
 //! let scalar = 0.5;
 //! let local_model_1 = Model::from_primitives_bounded(vec![0_f32; number_weights].into_iter());
@@ -111,9 +112,9 @@
 //!
 //! ## Aggregation
 //! Masked models can be aggregated via an [`Aggregation`]. Masks can be aggregated via an
-//! [`Aggregation`] as well, since an aggregated, masked model can only be unmasked by the
+//! [`Aggregation`] as well, since an aggregated masked model can only be unmasked by the
 //! aggregated masks belonging to the masked models. It should always be validated that the
-//! aggregation may be safely performed wrt the chosen mask configuration before actually
+//! aggregation may be safely performed wrt the chosen masking configuration before actually
 //! aggregating to avoid the possible loss of information.
 //!
 //! ```

--- a/rust/src/mask/model.rs
+++ b/rust/src/mask/model.rs
@@ -79,10 +79,10 @@ pub struct ModelCastError {
 /// Errors related to model conversion from primitives.
 pub struct PrimitiveCastError<P: Debug>(P);
 
-/// An interface to convert a collection of numerical values into a an iterator of primitive values.
+/// An interface to convert a collection of numerical values into an iterator of primitive values.
 ///
 /// This trait is used to convert a [`Model`], which has its own internal representation of the
-/// weights, into primitive types ([`f32`], [`f64`], [`i32`], [`i64`]). The opposed trait is
+/// weights, into primitive types ([`f32`], [`f64`], [`i32`], [`i64`]). The opposite trait is
 /// [`FromPrimitives`].
 pub trait IntoPrimitives<P: 'static>: Sized {
     /// Creates an iterator from numerical values that yields converted primitive values.
@@ -103,10 +103,10 @@ pub trait IntoPrimitives<P: 'static>: Sized {
     }
 }
 
-/// An interface to convert a collection of primitive values into a an iterator of numerical values.
+/// An interface to convert a collection of primitive values into an iterator of numerical values.
 ///
 /// This trait is used to convert primitive types ([`f32`], [`f64`], [`i32`], [`i64`]) into a
-/// [`Model`], which has its own internal representation of the weights. The opposed trait is
+/// [`Model`], which has its own internal representation of the weights. The opposite trait is
 /// [`IntoPrimitives`].
 pub trait FromPrimitives<P: Debug>: Sized {
     /// Creates an iterator from primitive values that yields converted numerical values.

--- a/rust/src/mask/model.rs
+++ b/rust/src/mask/model.rs
@@ -1,3 +1,9 @@
+//! Model representation and conversion.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
 use std::{
     fmt::Debug,
     iter::{FromIterator, IntoIterator},
@@ -13,20 +19,23 @@ use num::{
 };
 use thiserror::Error;
 
-/// Represent a model.
 #[derive(Debug, Clone, PartialEq, Hash, From, Index, IndexMut, Into, Serialize, Deserialize)]
+/// A numerical representation of a machine learning model.
 pub struct Model(Vec<Ratio<BigInt>>);
 
 #[allow(clippy::len_without_is_empty)]
 impl Model {
+    /// Gets the number of weights/parameters of this model.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Creates an iterator that yields references to the weights/parameters of this model.
     pub fn iter(&self) -> Iter<Ratio<BigInt>> {
         self.0.iter()
     }
 
+    /// Creates an iterator that yields mutable references to the weights/parameters of this model.
     pub fn iter_mut(&mut self) -> IterMut<Ratio<BigInt>> {
         self.0.iter_mut()
     }
@@ -49,6 +58,7 @@ impl IntoIterator for Model {
 }
 
 #[derive(Debug, Display)]
+/// A primitive data type as a target for model conversion.
 enum PrimitiveType {
     F32,
     F64,
@@ -58,6 +68,7 @@ enum PrimitiveType {
 
 #[derive(Error, Debug)]
 #[error("Could not convert weight {weight} to primitive type {target}")]
+/// Errors related to model conversion into primitives.
 pub struct ModelCastError {
     weight: Ratio<BigInt>,
     target: PrimitiveType,
@@ -65,25 +76,25 @@ pub struct ModelCastError {
 
 #[derive(Error, Debug)]
 #[error("Could not convert primitive type {0:?} to model weight")]
+/// Errors related to model conversion from primitives.
 pub struct PrimitiveCastError<P: Debug>(P);
 
-/// Convert this type into a an iterator of type `P`. This trait is
-/// used to convert a [`Model`], which has its own internal
-/// representation of the weights into primitive types (`f64`, `f32`,
-/// `i32` `i64`).
+/// An interface to convert a collection of numerical values into a an iterator of primitive values.
+///
+/// This trait is used to convert a [`Model`], which has its own internal representation of the
+/// weights, into primitive types ([`f32`], [`f64`], [`i32`], [`i64`]). The opposed trait is
+/// [`FromPrimitives`].
 pub trait IntoPrimitives<P: 'static>: Sized {
-    /// Consume this model and into an iterator that yields `Ok(P)`
-    /// for each model weight that can be converted to `P`, and
-    /// `Err(ModelCastError)` for each weight that cannot be converted
-    /// to `P`.
+    /// Creates an iterator from numerical values that yields converted primitive values.
+    ///
+    /// # Errors
+    /// Yields an error for each numerical value that can't be converted into a primitive value.
     fn into_primitives(self) -> Box<dyn Iterator<Item = Result<P, ModelCastError>>>;
 
-    /// Consume this model and into an iterator that yields `P` values.
+    /// Creates an iterator from numerical values that yields converted primitive values.
     ///
     /// # Panics
-    ///
-    /// This method panics if a model weight cannot be converted into
-    /// `P`.
+    /// Panics if a numerical value can't be converted into a primitive value.
     fn into_primitives_unchecked(self) -> Box<dyn Iterator<Item = P>> {
         Box::new(
             self.into_primitives()
@@ -92,15 +103,22 @@ pub trait IntoPrimitives<P: 'static>: Sized {
     }
 }
 
-/// Convert a stream of numerical primitive types (`i32`, `i64`,
-/// `f32`, `f64`) into this type.
+/// An interface to convert a collection of primitive values into a an iterator of numerical values.
+///
+/// This trait is used to convert primitive types ([`f32`], [`f64`], [`i32`], [`i64`]) into a
+/// [`Model`], which has its own internal representation of the weights. The opposed trait is
+/// [`IntoPrimitives`].
 pub trait FromPrimitives<P: Debug>: Sized {
-    /// Consume an iterator that yields `P`, into a model. If a `P`
-    /// cannot be converted to a model weight, this method fails.
+    /// Creates an iterator from primitive values that yields converted numerical values.
+    ///
+    /// # Errors
+    /// Yields an error for each primitive value that can't be converted into a numerical value.
     fn from_primitives<I: Iterator<Item = P>>(iter: I) -> Result<Self, PrimitiveCastError<P>>;
 
-    /// Consume an iterator that yields `P` values into a model. If a
-    /// `P` cannot be directly converted into a model weight because it is not finite, it is clamped.
+    /// Creates an iterator from primitive values that yields converted numerical values.
+    ///
+    /// If a primitive value cannot be directly converted into a numerical value due to not being
+    /// finite, it is clamped.
     fn from_primitives_bounded<I: Iterator<Item = P>>(iter: I) -> Self;
 }
 
@@ -192,6 +210,10 @@ impl FromPrimitives<f64> for Model {
     }
 }
 
+/// Converts a numerical value into a primitive floating point value.
+///
+/// # Errors
+/// Fails if the numerical value is not representable in the primitive data type.
 fn ratio_to_float<F: FloatCore>(ratio: &Ratio<BigInt>) -> Option<F> {
     let min_value = Ratio::from_float(F::min_value()).unwrap();
     let max_value = Ratio::from_float(F::max_value()).unwrap();
@@ -219,8 +241,9 @@ fn ratio_to_float<F: FloatCore>(ratio: &Ratio<BigInt>) -> Option<F> {
     }
 }
 
-/// Cast the given float to a ratio. Positive/negative infinity is
-/// mapped to max/min and NaN to zero.
+/// Converts the primitive floating point value into a numerical value.
+///
+/// Maps positive/negative infinity to max/min of the primitive data type and NaN to zero.
 fn float_to_ratio_bounded<F: FloatCore>(f: F) -> Ratio<BigInt> {
     if f.is_nan() {
         Ratio::<BigInt>::zero()

--- a/rust/src/mask/model.rs
+++ b/rust/src/mask/model.rs
@@ -112,7 +112,8 @@ pub trait FromPrimitives<P: Debug>: Sized {
     /// Creates an iterator from primitive values that yields converted numerical values.
     ///
     /// # Errors
-    /// Yields an error for each primitive value that can't be converted into a numerical value.
+    /// Yields an error for the first encountered primitive value that can't be converted into a
+    /// numerical value due to not being finite.
     fn from_primitives<I: Iterator<Item = P>>(iter: I) -> Result<Self, PrimitiveCastError<P>>;
 
     /// Creates an iterator from primitive values that yields converted numerical values.

--- a/rust/src/mask/object/mod.rs
+++ b/rust/src/mask/object/mod.rs
@@ -26,17 +26,17 @@ pub struct MaskObject {
 }
 
 impl MaskObject {
-    /// Creates a new mask object from the given mask configuration and the elements of the mask
+    /// Creates a new mask object from the given masking configuration and the elements of the mask
     /// or masked model.
     pub fn new(config: MaskConfig, data: Vec<BigUint>) -> Self {
         Self { data, config }
     }
 
-    /// Creates a new mask object from the given mask configuration and the elements of the mask
+    /// Creates a new mask object from the given masking configuration and the elements of the mask
     /// or masked model.
     ///
     /// # Errors
-    /// Fails if the elements of the mask object don't conform to the given mask configuration.
+    /// Fails if the elements of the mask object don't conform to the given masking configuration.
     pub fn new_checked(
         config: MaskConfig,
         data: Vec<BigUint>,
@@ -49,7 +49,7 @@ impl MaskObject {
         }
     }
 
-    /// Checks if the elements of this mask object conform to the given mask configuration.
+    /// Checks if the elements of this mask object conform to the given masking configuration.
     pub fn is_valid(&self) -> bool {
         let order = self.config.order();
         self.data.iter().all(|i| i < &order)

--- a/rust/src/mask/object/mod.rs
+++ b/rust/src/mask/object/mod.rs
@@ -1,4 +1,10 @@
-pub(crate) mod serialization;
+//! Masked objects.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
+pub mod serialization;
 
 use std::iter::Iterator;
 
@@ -9,28 +15,41 @@ use crate::mask::MaskConfig;
 
 #[derive(Error, Debug)]
 #[error("the mask object is invalid: data is incompatible with the masking configuration")]
-pub struct InvalidMaskObject;
+/// Errors related to invalid mask objects.
+pub struct InvalidMaskObjectError;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
+/// A mask or masked model.
 pub struct MaskObject {
     pub(crate) data: Vec<BigUint>,
     pub(crate) config: MaskConfig,
 }
 
 impl MaskObject {
+    /// Creates a new mask object from the given mask configuration and the elements of the mask
+    /// or masked model.
     pub fn new(config: MaskConfig, data: Vec<BigUint>) -> Self {
         Self { data, config }
     }
 
-    pub fn new_checked(config: MaskConfig, data: Vec<BigUint>) -> Result<Self, InvalidMaskObject> {
+    /// Creates a new mask object from the given mask configuration and the elements of the mask
+    /// or masked model.
+    ///
+    /// # Errors
+    /// Fails if the elements of the mask object don't conform to the given mask configuration.
+    pub fn new_checked(
+        config: MaskConfig,
+        data: Vec<BigUint>,
+    ) -> Result<Self, InvalidMaskObjectError> {
         let obj = Self::new(config, data);
         if obj.is_valid() {
             Ok(obj)
         } else {
-            Err(InvalidMaskObject)
+            Err(InvalidMaskObjectError)
         }
     }
 
+    /// Checks if the elements of this mask object conform to the given mask configuration.
     pub fn is_valid(&self) -> bool {
         let order = self.config.order();
         self.data.iter().all(|i| i < &order)

--- a/rust/src/mask/object/mod.rs
+++ b/rust/src/mask/object/mod.rs
@@ -19,7 +19,7 @@ use crate::mask::MaskConfig;
 pub struct InvalidMaskObjectError;
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
-/// A mask or masked model.
+/// A mask object which represents either a mask or a masked model.
 pub struct MaskObject {
     pub(crate) data: Vec<BigUint>,
     pub(crate) config: MaskConfig,

--- a/rust/src/mask/object/serialization.rs
+++ b/rust/src/mask/object/serialization.rs
@@ -44,7 +44,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
     /// Checks if this buffer conforms to the required buffer length for mask objects.
     ///
     /// # Errors
-    /// Fails if the buffer is to small.
+    /// Fails if the buffer is too small.
     pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.inner.as_ref().len();
         if len < NUMBERS_FIELD.end {

--- a/rust/src/mask/object/serialization.rs
+++ b/rust/src/mask/object/serialization.rs
@@ -1,23 +1,33 @@
-use anyhow::{anyhow, Context};
+//! Serialization of masked objects.
+//!
+//! See the [mask module] documentation since this is a private module anyways.
+//!
+//! [mask module]: ../index.html
+
 use std::{convert::TryInto, ops::Range};
 
+use anyhow::{anyhow, Context};
 use num::bigint::BigUint;
 
-use super::MaskObject;
 use crate::{
-    mask::{config::serialization::MASK_CONFIG_BUFFER_LEN, MaskConfig},
+    mask::{config::serialization::MASK_CONFIG_BUFFER_LEN, object::MaskObject, MaskConfig},
     message::{utils::range, DecodeError, FromBytes, ToBytes},
 };
 
 const MASK_CONFIG_FIELD: Range<usize> = range(0, MASK_CONFIG_BUFFER_LEN);
-const DIGITS_FIELD: Range<usize> = range(MASK_CONFIG_FIELD.end, 4);
+const NUMBERS_FIELD: Range<usize> = range(MASK_CONFIG_FIELD.end, 4);
 
+/// A buffer for serialized mask objects.
 pub struct MaskObjectBuffer<T> {
     inner: T,
 }
 
 #[allow(clippy::len_without_is_empty)]
 impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
+    /// Creates a new buffer from `bytes`.
+    ///
+    /// # Errors
+    /// Fails if the `bytes` don't conform to the required buffer length for mask objects.
     pub fn new(bytes: T) -> Result<Self, DecodeError> {
         let buffer = Self { inner: bytes };
         buffer
@@ -26,29 +36,34 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         Ok(buffer)
     }
 
+    /// Creates a new buffer from `bytes`.
     pub fn new_unchecked(bytes: T) -> Self {
         Self { inner: bytes }
     }
 
+    /// Checks if this buffer conforms to the required buffer length for mask objects.
+    ///
+    /// # Errors
+    /// Fails if the buffer is to small.
     pub fn check_buffer_length(&self) -> Result<(), DecodeError> {
         let len = self.inner.as_ref().len();
-        if len < DIGITS_FIELD.end {
+        if len < NUMBERS_FIELD.end {
             return Err(anyhow!(
                 "invalid buffer length: {} < {}",
                 len,
-                DIGITS_FIELD.end
+                NUMBERS_FIELD.end
             ));
         }
 
         let config = MaskConfig::from_bytes(&self.config()).context("invalid MaskObject buffer")?;
-        let bytes_per_digit = config.bytes_per_digit();
-        let (data_length, overflows) = (self.digits() as usize).overflowing_mul(bytes_per_digit);
+        let bytes_per_number = config.bytes_per_number();
+        let (data_length, overflows) = (self.numbers() as usize).overflowing_mul(bytes_per_number);
         if overflows {
             return Err(anyhow!(
-                "invalid MaskObject buffer: invalid mask config or digits field"
+                "invalid MaskObject buffer: invalid mask config or numbers field"
             ));
         }
-        let total_expected_length = DIGITS_FIELD.end + data_length;
+        let total_expected_length = NUMBERS_FIELD.end + data_length;
         if len < total_expected_length {
             return Err(anyhow!(
                 "invalid buffer length: expected {} bytes but buffer has only {} bytes",
@@ -59,53 +74,82 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         Ok(())
     }
 
+    /// Gets the expected number of bytes of this buffer wrt to the mask configuration.
+    ///
+    /// # Panics
+    /// Panics if the serialized mask configuration is invalid.
     pub fn len(&self) -> usize {
         let config = MaskConfig::from_bytes(&self.config()).unwrap();
-        let bytes_per_digit = config.bytes_per_digit();
-        let data_length = self.digits() as usize * bytes_per_digit;
-        DIGITS_FIELD.end + data_length
+        let bytes_per_number = config.bytes_per_number();
+        let data_length = self.numbers() as usize * bytes_per_number;
+        NUMBERS_FIELD.end + data_length
     }
 
-    pub fn digits(&self) -> u32 {
+    /// Gets the number of serialized mask object elements.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn numbers(&self) -> u32 {
         // UNWRAP SAFE: the slice is exactly 4 bytes long
-        u32::from_be_bytes(self.inner.as_ref()[DIGITS_FIELD].try_into().unwrap())
+        u32::from_be_bytes(self.inner.as_ref()[NUMBERS_FIELD].try_into().unwrap())
     }
 
+    /// Gets the serialized mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn config(&self) -> &[u8] {
         &self.inner.as_ref()[MASK_CONFIG_FIELD]
     }
 
+    /// Gets the serialized mask object elements.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn data(&self) -> &[u8] {
-        &self.inner.as_ref()[DIGITS_FIELD.end..self.len()]
+        &self.inner.as_ref()[NUMBERS_FIELD.end..self.len()]
     }
 }
 
 impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskObjectBuffer<T> {
-    pub fn set_digits(&mut self, value: u32) {
-        self.inner.as_mut()[DIGITS_FIELD].copy_from_slice(&value.to_be_bytes());
+    /// Sets the number of serialized mask object elements.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
+    pub fn set_numbers(&mut self, value: u32) {
+        self.inner.as_mut()[NUMBERS_FIELD].copy_from_slice(&value.to_be_bytes());
     }
+
+    /// Gets the serialized mask configuration.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn config_mut(&mut self) -> &mut [u8] {
         &mut self.inner.as_mut()[MASK_CONFIG_FIELD]
     }
 
+    /// Gets the serialized mask object elements.
+    ///
+    /// # Panics
+    /// May panic if this buffer is unchecked.
     pub fn data_mut(&mut self) -> &mut [u8] {
         let end = self.len();
-        &mut self.inner.as_mut()[DIGITS_FIELD.end..end]
+        &mut self.inner.as_mut()[NUMBERS_FIELD.end..end]
     }
 }
 
 impl ToBytes for MaskObject {
     fn buffer_length(&self) -> usize {
-        DIGITS_FIELD.end + self.config.bytes_per_digit() * self.data.len()
+        NUMBERS_FIELD.end + self.config.bytes_per_number() * self.data.len()
     }
 
     fn to_bytes<T: AsMut<[u8]>>(&self, buffer: &mut T) {
         let mut writer = MaskObjectBuffer::new_unchecked(buffer.as_mut());
         self.config.to_bytes(&mut writer.config_mut());
-        writer.set_digits(self.data.len() as u32);
+        writer.set_numbers(self.data.len() as u32);
 
         let mut data = writer.data_mut();
-        let bytes_per_digit = self.config.bytes_per_digit();
+        let bytes_per_number = self.config.bytes_per_number();
 
         for int in self.data.iter() {
             // FIXME: this allocates a vec which is sub-optimal. See
@@ -116,10 +160,10 @@ impl ToBytes for MaskObject {
             // configuration.
             data[..bytes.len()].copy_from_slice(&bytes[..]);
             // padding
-            for b in data.iter_mut().take(bytes_per_digit).skip(bytes.len()) {
+            for b in data.iter_mut().take(bytes_per_number).skip(bytes.len()) {
                 *b = 0;
             }
-            data = &mut data[bytes_per_digit..];
+            data = &mut data[bytes_per_number..];
         }
     }
 }
@@ -129,9 +173,9 @@ impl FromBytes for MaskObject {
         let reader = MaskObjectBuffer::new(buffer.as_ref())?;
 
         let config = MaskConfig::from_bytes(&reader.config())?;
-        let mut data = Vec::with_capacity(reader.digits() as usize);
-        let bytes_per_digit = config.bytes_per_digit();
-        for chunk in reader.data().chunks(bytes_per_digit) {
+        let mut data = Vec::with_capacity(reader.numbers() as usize);
+        let bytes_per_number = config.bytes_per_number();
+        for chunk in reader.data().chunks(bytes_per_number) {
             data.push(BigUint::from_bytes_le(chunk));
         }
 

--- a/rust/src/mask/object/serialization.rs
+++ b/rust/src/mask/object/serialization.rs
@@ -60,7 +60,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         let (data_length, overflows) = (self.numbers() as usize).overflowing_mul(bytes_per_number);
         if overflows {
             return Err(anyhow!(
-                "invalid MaskObject buffer: invalid mask config or numbers field"
+                "invalid MaskObject buffer: invalid masking config or numbers field"
             ));
         }
         let total_expected_length = NUMBERS_FIELD.end + data_length;
@@ -74,10 +74,10 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         Ok(())
     }
 
-    /// Gets the expected number of bytes of this buffer wrt to the mask configuration.
+    /// Gets the expected number of bytes of this buffer wrt to the masking configuration.
     ///
     /// # Panics
-    /// Panics if the serialized mask configuration is invalid.
+    /// Panics if the serialized masking configuration is invalid.
     pub fn len(&self) -> usize {
         let config = MaskConfig::from_bytes(&self.config()).unwrap();
         let bytes_per_number = config.bytes_per_number();
@@ -94,7 +94,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         u32::from_be_bytes(self.inner.as_ref()[NUMBERS_FIELD].try_into().unwrap())
     }
 
-    /// Gets the serialized mask configuration.
+    /// Gets the serialized masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.
@@ -120,7 +120,7 @@ impl<T: AsRef<[u8]> + AsMut<[u8]>> MaskObjectBuffer<T> {
         self.inner.as_mut()[NUMBERS_FIELD].copy_from_slice(&value.to_be_bytes());
     }
 
-    /// Gets the serialized mask configuration.
+    /// Gets the serialized masking configuration.
     ///
     /// # Panics
     /// May panic if this buffer is unchecked.

--- a/rust/src/mask/seed.rs
+++ b/rust/src/mask/seed.rs
@@ -60,7 +60,7 @@ impl MaskSeed {
         EncryptedMaskSeed::from_slice_unchecked(pk.encrypt(self.as_slice()).as_slice())
     }
 
-    /// Derives a mask of given length from this seed wrt the mask configuration.
+    /// Derives a mask of given length from this seed wrt the masking configuration.
     pub fn derive_mask(&self, len: usize, config: MaskConfig) -> MaskObject {
         let mut prng = ChaCha20Rng::from_seed(self.as_array());
         let data = iter::repeat_with(|| generate_integer(&mut prng, &config.order()))


### PR DESCRIPTION
**References**
- [PB-870](https://xainag.atlassian.net/browse/PB-870)

**Summary**
- add module level documentation
- update struct and method documentation

note that this requires `cargo +nightly doc` to generate proper internal links, which is not an issue since this is supported by the hosted rust docs as well.