### PR TITLE
Fix typos in state machine docs

### DIFF
--- a/rust/src/state_machine/events.rs
+++ b/rust/src/state_machine/events.rs
@@ -23,14 +23,14 @@ use crate::{
 /// An event emitted by the coordinator.
 #[derive(Debug, Clone)]
 pub struct Event<E> {
-    /// Metadata that associate this event to the round in which it is
+    /// Metadata that associates this event to the round in which it is
     /// emitted.
     pub round_id: RoundSeed,
     /// The event itself
     pub event: E,
 }
 
-/// Event that is emitted when the state machine transition to a new
+/// Event that is emitted when the state machine transitions to a new
 /// phase.
 #[derive(Debug, Clone, Copy)]
 pub enum PhaseEvent {

--- a/rust/src/state_machine/mod.rs
+++ b/rust/src/state_machine/mod.rs
@@ -17,42 +17,42 @@
 //!
 //! **Idle**
 //!
-//! Publishes the [`PhaseEvent::Idle`], increments the `round id` by `1`, invalidates the
+//! Publishes [`PhaseEvent::Idle`], increments the `round id` by `1`, invalidates the
 //! [`SumDict`], [`SeedDict`], `scalar` and `mask length`, updates the [`EncryptKeyPair`],
 //! `thresholds` as well as the `seed` and publishes the [`EncryptKeyPair`] and the
 //! [`RoundParameters`].
 //!
 //! **Sum**
 //!
-//! Publishes the [`PhaseEvent::Sum`], builds and publishes the [`SumDict`], ensures that enough sum
+//! Publishes [`PhaseEvent::Sum`], builds and publishes the [`SumDict`], ensures that enough sum
 //! messages have been submitted and initializes the [`SeedDict`].
 //!
 //! **Update**
 //!
-//! Publishes the [`PhaseEvent::Update`], publishes the `scalar`, builds and publishes the
+//! Publishes [`PhaseEvent::Update`], publishes the `scalar`, builds and publishes the
 //! [`SeedDict`], ensures that enough update messages have been submitted and aggregates the
 //! masked model.
 //!
 //! **Sum2**
 //!
-//! Publishes the [`PhaseEvent::Sum2`], builds the [`MaskDict`], ensures that enough sum2
+//! Publishes [`PhaseEvent::Sum2`], builds the [`MaskDict`], ensures that enough sum2
 //! messages have been submitted and determines the applicable mask for unmasking the global
 //! masked model.
 //!
 //! **Unmask**
 //!
-//! Publishes the [`PhaseEvent::Unmask`], unmasks the global masked model and publishes the global
+//! Publishes [`PhaseEvent::Unmask`], unmasks the global masked model and publishes the global
 //! model.
 //!
 //! **Error**
 //!
-//! Publishes the [`PhaseEvent::Error`] and handles [`StateError`]s that can occur during the
+//! Publishes [`PhaseEvent::Error`] and handles [`StateError`]s that can occur during the
 //! execution of the [`StateMachine`]. In most cases, the error is handled by restarting the round.
 //! However, if a [`StateError::ChannelError`] occurs, the [`StateMachine`] will shut down.
 //!
 //! **Shutdown**
 //!
-//! Publishes the [`PhaseEvent::Shutdown`] and shuts down the [`StateMachine`]. During the shutdown,
+//! Publishes [`PhaseEvent::Shutdown`] and shuts down the [`StateMachine`]. During the shutdown,
 //! the [`StateMachine`] performs a clean shutdown of the [Request][requests_idx] channel by
 //! closing it and consuming all remaining messages.
 //!

--- a/rust/src/state_machine/phases/mod.rs
+++ b/rust/src/state_machine/phases/mod.rs
@@ -31,14 +31,14 @@ use crate::{
 use futures::StreamExt;
 use tokio::sync::oneshot;
 
-/// A trait that must be implement by a state in order to move to a next state.
+/// A trait that must be implemented by a state in order to move to a next state.
 #[async_trait]
 pub trait Phase<R> {
     /// Moves from this state to the next state.
     async fn next(mut self) -> Option<StateMachine<R>>;
 }
 
-/// A trait that must be implement by a state to handle a request.
+/// A trait that must be implemented by a state to handle a request.
 pub trait Handler<R> {
     /// Handles a request.
     fn handle_request(&mut self, req: R);


### PR DESCRIPTION
Follow up ticket of #442 