### PR TITLE
Add missing PhaseEvent in error and shutdown state

### DIFF
--- a/configs/config.toml
+++ b/configs/config.toml
@@ -1,5 +1,5 @@
 [log]
-filter = "xain_fl=debug,info"
+filter = "xain_fl=debug,http=warn,info"
 
 [api]
 bind_address = "127.0.0.1:8081"

--- a/configs/docker-dev.toml
+++ b/configs/docker-dev.toml
@@ -1,5 +1,5 @@
 [log]
-filter = "xain_fl=debug,info"
+filter = "xain_fl=debug,http=warn,info"
 
 [api]
 bind_address = "0.0.0.0:8081"

--- a/rust/src/state_machine/phases/error.rs
+++ b/rust/src/state_machine/phases/error.rs
@@ -1,5 +1,6 @@
 use crate::state_machine::{
     coordinator::CoordinatorState,
+    events::PhaseEvent,
     phases::{Idle, Phase, PhaseState, Shutdown},
     requests::RequestReceiver,
     RoundFailed,
@@ -40,8 +41,15 @@ where
     /// Moves from the error state to the next state.
     ///
     /// See the [module level documentation](../index.html) for more details.
-    async fn next(self) -> Option<StateMachine<R>> {
+    async fn next(mut self) -> Option<StateMachine<R>> {
         error!("state transition failed! error: {:?}", self.inner);
+
+        info!("broadcasting error phase event");
+        self.coordinator_state.events.broadcast_phase(
+            self.coordinator_state.round_params.seed.clone(),
+            PhaseEvent::Error,
+        );
+
         let next_state = match self.inner {
             StateError::ChannelError(_) => {
                 PhaseState::<R, Shutdown>::new(self.coordinator_state, self.request_rx).into()

--- a/rust/src/state_machine/phases/shutdown.rs
+++ b/rust/src/state_machine/phases/shutdown.rs
@@ -1,5 +1,6 @@
 use crate::state_machine::{
     coordinator::CoordinatorState,
+    events::PhaseEvent,
     phases::{Phase, PhaseState},
     requests::RequestReceiver,
     StateMachine,
@@ -19,6 +20,12 @@ where
     /// See the [module level documentation](../index.html) for more details.
     async fn next(mut self) -> Option<StateMachine<R>> {
         warn!("shutdown state machine");
+
+        info!("broadcasting shutdown phase event");
+        self.coordinator_state.events.broadcast_phase(
+            self.coordinator_state.round_params.seed.clone(),
+            PhaseEvent::Shutdown,
+        );
 
         // clear the request channel
         self.request_rx.close();


### PR DESCRIPTION
**Summary**
- added the broadcasting of PhaseEvent in error and shutdown state 
- set the filter of  `http` to `warn` because each http request creates an info log entry