### PR TITLE
PB-927 update num dependency and add target checks

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1039,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "ab3e176191bc4faad357e3122c4747aa098ac880e88b168f106386128736cf4a"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -1053,9 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -1065,11 +1065,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "b05ad05bd8977050b171b3f6b48175fea6e0565b7981059b486075e1026a9fb5"
 dependencies = [
- "autocfg 1.0.0",
  "num-traits 0.2.12",
  "serde 1.0.114",
 ]
@@ -1097,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "a5b4d7360f362cfb50dde8143501e6940b22f644be75a4cc90b2d81968908138"
 dependencies = [
  "autocfg 1.0.0",
  "num-bigint",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = "0.2.2"
 serde = { version = "1.0.111", features = [ "derive" ] }
 bytes = "0.5.4"
 sodiumoxide = "0.2.5"
-num = { version = "0.2.1", features = ["serde"] }
+num = { version = "0.3.0", features = ["serde"] }
 bincode = "1.2.1"
 thiserror = "1.0.19"
 anyhow = "1.0.31"

--- a/rust/src/mask/config/mod.rs
+++ b/rust/src/mask/config/mod.rs
@@ -186,7 +186,7 @@ impl MaskConfig {
             // the largest bpn from the masking configuration catalogue is currently 173, hence
             // this is almost impossible on 32 bits targets and smaller targets are currently not
             // of interest for us
-            unimplemented!("the employed masking config is not supported on the target")
+            panic!("the employed masking config is not supported on the target")
         } else {
             bpn as usize
         }

--- a/rust/src/mask/object/serialization.rs
+++ b/rust/src/mask/object/serialization.rs
@@ -109,7 +109,7 @@ impl<T: AsRef<[u8]>> MaskObjectBuffer<T> {
         let nb = u32::from_be_bytes(self.inner.as_ref()[NUMBERS_FIELD].try_into().unwrap());
         if nb > MAX_NB {
             // smaller targets than 32 bits are currently not of interest for us
-            unimplemented!("16 bit targets or smaller are currently not fully supported")
+            panic!("16 bit targets or smaller are currently not fully supported")
         } else {
             nb as usize
         }


### PR DESCRIPTION
**References**
- [PB-927](https://xainag.atlassian.net/browse/PB-927)

**Summary**
- update the `num` dependency to `0.3.0`
- fix a breaking change in byte counting for the mask serialization
- add some target checks for the mask serialization