### PR TITLE
Test the `crate::services::fetchers` module

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -21,7 +21,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
 
 [[package]]
 name = "cfg-if"
@@ -186,9 +186,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits 0.2.12",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.8"
+version = "0.99.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc655351f820d774679da6cdc23355a93de496867d8203496675162e17b1d671"
+checksum = "298998b1cf6b5b2c8a7b023dfd45821825ce3ba8a8af55c921a0e734e4653f76"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -388,7 +388,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -539,7 +539,7 @@ dependencies = [
  "libc",
  "log 0.4.8",
  "rustc_version",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9586eedd4ce6b3c498bc3b4dd92fc9f11166aa908a914071953768066c67909"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
 dependencies = [
  "libc",
 ]
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
+checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
  "bytes 0.5.5",
  "hyper",
@@ -751,9 +751,9 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce10c23ad2ea25ceca0093bd3192229da4c5b3c0f2de499c1ecac0d98d452177"
+checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -789,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.71"
+version = "0.2.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
 name = "libflate"
@@ -893,9 +893,9 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
+checksum = "c198b026e1bbf08a937e94c6c60f9ec4a2267f5b0d2eec9c1b21b061ce2be55f"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -1023,7 +1023,7 @@ checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1149,9 +1149,9 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.29"
+version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee6d85f4cb4c4f59a6a85d5b68a233d280c82e29e822913b9c8b129fbf20bdd"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1290,9 +1290,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-error"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+checksum = "fc175e9777c3116627248584e8f8b3e2987405cabe1c0adf7d1dd28f09dc7880"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
+checksum = "3cc9795ca17eb581285ec44936da7fc2335a3f34f2ddd13118b6f4d515435c50"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1366,7 +1366,7 @@ dependencies = [
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1461,7 +1461,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1475,7 +1475,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1571,7 +1571,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1648,7 +1648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1748,9 +1748,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.55"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "itoa",
  "ryu",
@@ -1823,9 +1823,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "socket2"
@@ -1836,7 +1836,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1937,7 +1937,7 @@ dependencies = [
  "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1985,7 +1985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2014,7 +2014,7 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "tokio-macros",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2026,6 +2026,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
+dependencies = [
+ "bytes 0.5.5",
+ "futures-core",
+ "tokio",
 ]
 
 [[package]]
@@ -2052,7 +2063,7 @@ dependencies = [
  "tokio",
  "tower-load",
  "tower-service",
- "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2120,7 +2131,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2209,6 +2220,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
+name = "tower-test"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
+dependencies = [
+ "futures-util",
+ "pin-project",
+ "tokio",
+ "tokio-test",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-timeout"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2234,30 +2259,30 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+version = "0.1.16"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "cfg-if",
- "tracing-attributes 0.1.8 (git+https://github.com/tokio-rs/tracing)",
- "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-attributes 0.1.9 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.11 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
 dependencies = [
  "cfg-if",
  "log 0.4.8",
- "tracing-attributes 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-attributes 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+version = "0.1.9"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2266,9 +2291,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2277,17 +2302,17 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+version = "0.1.11"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
 dependencies = [
  "lazy_static",
 ]
@@ -2295,35 +2320,35 @@ dependencies = [
 [[package]]
 name = "tracing-futures"
 version = "0.2.6"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "pin-project",
- "tracing 0.1.15 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.1.16 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-log"
 version = "0.1.1"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "lazy_static",
  "log 0.4.8",
- "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.11 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-serde"
 version = "0.1.1"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "serde 1.0.114",
- "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.11 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.6"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+version = "0.2.7"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2334,7 +2359,7 @@ dependencies = [
  "serde_json",
  "sharded-slab",
  "smallvec",
- "tracing-core 0.1.10 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.11 (git+https://github.com/tokio-rs/tracing)",
  "tracing-log",
  "tracing-serde",
 ]
@@ -2342,7 +2367,7 @@ dependencies = [
 [[package]]
 name = "tracing-tower"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#7bc225a5e9eef119ae4165a851a5d116a7e94539"
+source = "git+https://github.com/tokio-rs/tracing#7dc37dda8fe6c217d6ba2200db13d0d45b9530e4"
 dependencies = [
  "futures",
  "http 0.1.21",
@@ -2350,7 +2375,7 @@ dependencies = [
  "tower-layer",
  "tower-make",
  "tower-service",
- "tracing 0.1.15 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.1.16 (git+https://github.com/tokio-rs/tracing)",
  "tracing-futures",
 ]
 
@@ -2438,9 +2463,9 @@ checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"
@@ -2578,9 +2603,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
+checksum = "6a634620115e4a229108b71bde263bb4220c483b3f07f5ba514ee8d15064c4c2"
 dependencies = [
  "cfg-if",
  "serde 1.0.114",
@@ -2590,9 +2615,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded84f06e0ed21499f6184df0e0cb3494727b0c5da89534e0fcc55c51d812101"
+checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2605,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
+checksum = "dba48d66049d2a6cc8488702e7259ab7afc9043ad0dc5448444f46f2a453b362"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2617,9 +2642,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838e423688dac18d73e31edce74ddfac468e37b1506ad163ffaf0a46f703ffe3"
+checksum = "3fcfd5ef6eec85623b4c6e844293d4516470d8f19cd72d0d12246017eb9060b8"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2627,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3156052d8ec77142051a533cdd686cba889537b213f948cd1d20869926e68e92"
+checksum = "9adff9ee0e94b926ca81b57f57f86d5545cdcb1d259e21ec9bdd95b901754c75"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2640,15 +2665,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.63"
+version = "0.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ba19973a58daf4db6f352eda73dc0e289493cd29fb2632eb172085b6521acd"
+checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "web-sys"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b72fe77fd39e4bd3eaa4412fd299a0be6b3dfe9d2597e2f1c20beb968f41d17"
+checksum = "863539788676619aac1a23e2df3655e96b32b0e05eb72ca34ba045ad573c625d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2662,9 +2687,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -2694,7 +2719,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2730,9 +2755,11 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio",
+ "tokio-test",
  "tokio-tower",
  "tower",
- "tracing 0.1.15 (git+https://github.com/tokio-rs/tracing)",
+ "tower-test",
+ "tracing 0.1.16 (git+https://github.com/tokio-rs/tracing)",
  "tracing-futures",
  "tracing-subscriber",
  "tracing-tower",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,6 +40,10 @@ uuid = { version = "0.8.1", features = ["v4"]}
 rayon = "1.3.0"
 async-trait = "0.1.35"
 
+[dev-dependencies]
+tower-test = "0.3.0"
+tokio-test = "0.2.1"
+
 [[bin]]
 name = "coordinator"
 path = "src/bin/main.rs"

--- a/rust/src/crypto/encrypt.rs
+++ b/rust/src/crypto/encrypt.rs
@@ -52,6 +52,8 @@ impl EncryptKeyPair {
 pub struct PublicEncryptKey(box_::PublicKey);
 
 impl ByteObject for PublicEncryptKey {
+    const LENGTH: usize = box_::PUBLICKEYBYTES;
+
     fn zeroed() -> Self {
         Self(box_::PublicKey([0_u8; box_::PUBLICKEYBYTES]))
     }
@@ -66,9 +68,6 @@ impl ByteObject for PublicEncryptKey {
 }
 
 impl PublicEncryptKey {
-    /// Length in bytes of this public key.
-    pub const LENGTH: usize = box_::PUBLICKEYBYTES;
-
     /// Encrypts a message `m` with this public key.
     ///
     /// The resulting ciphertext length is [`SEALBYTES`]` + m.len()`.
@@ -88,9 +87,6 @@ impl PublicEncryptKey {
 pub struct SecretEncryptKey(box_::SecretKey);
 
 impl SecretEncryptKey {
-    /// Length in bytes of this secret key.
-    pub const LENGTH: usize = box_::SECRETKEYBYTES;
-
     /// Decrypts the ciphertext `c` using this secret key and the associated public key, and returns
     /// the decrypted message.
     ///
@@ -107,6 +103,8 @@ impl SecretEncryptKey {
 }
 
 impl ByteObject for SecretEncryptKey {
+    const LENGTH: usize = box_::SECRETKEYBYTES;
+
     fn zeroed() -> Self {
         Self(box_::SecretKey([0_u8; box_::SECRETKEYBYTES]))
     }
@@ -127,9 +125,6 @@ impl ByteObject for SecretEncryptKey {
 pub struct EncryptKeySeed(box_::Seed);
 
 impl EncryptKeySeed {
-    /// Length in bytes of this seed.
-    pub const LENGTH: usize = box_::SEEDBYTES;
-
     /// Deterministically derives a new key pair from this seed.
     pub fn derive_encrypt_key_pair(&self) -> (PublicEncryptKey, SecretEncryptKey) {
         let (pk, sk) = box_::keypair_from_seed(self.as_ref());
@@ -138,6 +133,8 @@ impl EncryptKeySeed {
 }
 
 impl ByteObject for EncryptKeySeed {
+    const LENGTH: usize = box_::SEEDBYTES;
+
     fn from_slice(bytes: &[u8]) -> Option<Self> {
         box_::Seed::from_slice(bytes).map(Self)
     }

--- a/rust/src/crypto/hash.rs
+++ b/rust/src/crypto/hash.rs
@@ -30,6 +30,8 @@ use derive_more::{AsMut, AsRef, From};
 pub struct Sha256(sha256::Digest);
 
 impl ByteObject for Sha256 {
+    const LENGTH: usize = sha256::DIGESTBYTES;
+
     fn zeroed() -> Self {
         Self(sha256::Digest([0_u8; sha256::DIGESTBYTES]))
     }
@@ -44,9 +46,6 @@ impl ByteObject for Sha256 {
 }
 
 impl Sha256 {
-    /// Length in bytes of this digest.
-    pub const LENGTH: usize = sha256::DIGESTBYTES;
-
     /// Computes the digest of the message `m`.
     pub fn hash(m: &[u8]) -> Self {
         Self(sha256::hash(m))

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -70,4 +70,10 @@ pub trait ByteObject: Sized {
         // safe unwrap: length of slice is guaranteed by constants
         Self::from_slice_unchecked(randombytes(Self::LENGTH).as_slice())
     }
+
+    #[cfg(test)]
+    /// A helper for instantiating an object filled with the given value
+    fn fill_with(value: u8) -> Self {
+        Self::from_slice_unchecked(&vec![value; Self::LENGTH])
+    }
 }

--- a/rust/src/crypto/mod.rs
+++ b/rust/src/crypto/mod.rs
@@ -31,6 +31,8 @@ pub(crate) mod hash;
 pub(crate) mod prng;
 pub(crate) mod sign;
 
+use sodiumoxide::randombytes::randombytes;
+
 pub use self::{
     encrypt::{EncryptKeyPair, EncryptKeySeed, PublicEncryptKey, SecretEncryptKey, SEALBYTES},
     hash::Sha256,
@@ -40,6 +42,9 @@ pub use self::{
 
 /// An interface for slicing into cryptographic byte objects.
 pub trait ByteObject: Sized {
+    /// Length in bytes of this object
+    const LENGTH: usize;
+
     /// Creates a new object with all the bytes initialized to `0`.
     fn zeroed() -> Self;
 
@@ -58,5 +63,11 @@ pub trait ByteObject: Sized {
     /// Panics if the length of the byte-slice isn't equal to the length of the object.
     fn from_slice_unchecked(bytes: &[u8]) -> Self {
         Self::from_slice(bytes).unwrap()
+    }
+
+    /// Generates an object with random bytes
+    fn generate() -> Self {
+        // safe unwrap: length of slice is guaranteed by constants
+        Self::from_slice_unchecked(randombytes(Self::LENGTH).as_slice())
     }
 }

--- a/rust/src/crypto/sign.rs
+++ b/rust/src/crypto/sign.rs
@@ -53,9 +53,6 @@ impl SigningKeyPair {
 pub struct PublicSigningKey(sign::PublicKey);
 
 impl PublicSigningKey {
-    /// Length in bytes of this public key.
-    pub const LENGTH: usize = sign::PUBLICKEYBYTES;
-
     /// Verifies the signature `s` against the message `m` and this public key.
     ///
     /// Returns `true` if the signature is valid and `false` otherwise.
@@ -65,6 +62,8 @@ impl PublicSigningKey {
 }
 
 impl ByteObject for PublicSigningKey {
+    const LENGTH: usize = sign::PUBLICKEYBYTES;
+
     fn zeroed() -> Self {
         Self(sign::PublicKey([0_u8; sign::PUBLICKEYBYTES]))
     }
@@ -85,9 +84,6 @@ impl ByteObject for PublicSigningKey {
 pub struct SecretSigningKey(sign::SecretKey);
 
 impl SecretSigningKey {
-    /// Length in bytes of this secret key.
-    pub const LENGTH: usize = sign::SECRETKEYBYTES;
-
     /// Signs a message `m` with this secret key.
     pub fn sign_detached(&self, m: &[u8]) -> Signature {
         sign::sign_detached(m, self.as_ref()).into()
@@ -100,8 +96,10 @@ impl SecretSigningKey {
 }
 
 impl ByteObject for SecretSigningKey {
+    const LENGTH: usize = sign::SECRETKEYBYTES;
+
     fn zeroed() -> Self {
-        Self(sign::SecretKey([0_u8; sign::SECRETKEYBYTES]))
+        Self(sign::SecretKey([0_u8; Self::LENGTH]))
     }
 
     fn as_slice(&self) -> &[u8] {
@@ -132,6 +130,8 @@ impl ByteObject for SecretSigningKey {
 pub struct Signature(sign::Signature);
 
 impl ByteObject for Signature {
+    const LENGTH: usize = sign::SIGNATUREBYTES;
+
     fn zeroed() -> Self {
         Self(sign::Signature([0_u8; sign::SIGNATUREBYTES]))
     }
@@ -146,9 +146,6 @@ impl ByteObject for Signature {
 }
 
 impl Signature {
-    /// Length in bytes of this signature.
-    pub const LENGTH: usize = sign::SIGNATUREBYTES;
-
     /// Computes the floating point representation of the hashed signature and ensures that it is
     /// below the given threshold:
     /// ```no_rust
@@ -179,9 +176,6 @@ impl Signature {
 pub struct SigningKeySeed(sign::Seed);
 
 impl SigningKeySeed {
-    /// Length in bytes of this seed.
-    pub const LENGTH: usize = sign::SEEDBYTES;
-
     /// Deterministically derives a new signing key pair from this seed.
     pub fn derive_signing_key_pair(&self) -> (PublicSigningKey, SecretSigningKey) {
         let (pk, sk) = sign::keypair_from_seed(&self.0);
@@ -190,6 +184,8 @@ impl SigningKeySeed {
 }
 
 impl ByteObject for SigningKeySeed {
+    const LENGTH: usize = sign::SEEDBYTES;
+
     fn from_slice(bytes: &[u8]) -> Option<Self> {
         sign::Seed::from_slice(bytes).map(Self)
     }

--- a/rust/src/mask/masking.rs
+++ b/rust/src/mask/masking.rs
@@ -16,7 +16,7 @@ use rand_chacha::ChaCha20Rng;
 use thiserror::Error;
 
 use crate::{
-    crypto::prng::generate_integer,
+    crypto::{prng::generate_integer, ByteObject},
     mask::{config::MaskConfig, model::Model, object::MaskObject, seed::MaskSeed},
 };
 

--- a/rust/src/message/buffer.rs
+++ b/rust/src/message/buffer.rs
@@ -9,6 +9,7 @@ use std::ops::{Range, RangeFrom};
 use anyhow::{anyhow, Context};
 
 use crate::{
+    crypto::ByteObject,
     message::{header::Flags, traits::LengthValueBuffer, utils::range, DecodeError},
     CoordinatorPublicKey,
     ParticipantPublicKey,

--- a/rust/src/message/payload/sum.rs
+++ b/rust/src/message/payload/sum.rs
@@ -9,6 +9,7 @@ use std::ops::Range;
 use anyhow::{anyhow, Context};
 
 use crate::{
+    crypto::ByteObject,
     message::{
         traits::{FromBytes, ToBytes},
         utils::range,

--- a/rust/src/message/payload/sum2.rs
+++ b/rust/src/message/payload/sum2.rs
@@ -9,6 +9,7 @@ use std::{borrow::Borrow, ops::Range};
 use anyhow::{anyhow, Context};
 
 use crate::{
+    crypto::ByteObject,
     mask::object::{serialization::MaskObjectBuffer, MaskObject},
     message::{
         traits::{FromBytes, ToBytes},

--- a/rust/src/message/payload/update.rs
+++ b/rust/src/message/payload/update.rs
@@ -9,6 +9,7 @@ use std::{borrow::Borrow, ops::Range};
 use anyhow::{anyhow, Context};
 
 use crate::{
+    crypto::ByteObject,
     mask::object::{serialization::MaskObjectBuffer, MaskObject},
     message::{
         traits::{FromBytes, LengthValueBuffer, ToBytes},

--- a/rust/src/services/mod.rs
+++ b/rust/src/services/mod.rs
@@ -22,6 +22,8 @@
 //! an interface for the second category of services.
 pub mod fetchers;
 pub mod messages;
+#[cfg(test)]
+mod tests;
 
 pub use self::{
     fetchers::{FetchError, Fetcher},

--- a/rust/src/services/tests/fetchers/mod.rs
+++ b/rust/src/services/tests/fetchers/mod.rs
@@ -82,10 +82,10 @@ async fn test_round_params_svc() {
     assert_eq!(resp, Ok(initial_params));
 
     let params = RoundParameters {
-        pk: PublicEncryptKey::from_slice(&vec![0x11; PublicEncryptKey::LENGTH]).unwrap(),
+        pk: PublicEncryptKey::fill_with(0x11),
         sum: 0.42,
         update: 0.42,
-        seed: RoundSeed::from_slice(&vec![0x11; RoundSeed::LENGTH]).unwrap(),
+        seed: RoundSeed::fill_with(0x11),
     };
     publisher.broadcast_params(params.clone());
     assert_ready!(task.poll_ready()).unwrap();

--- a/rust/src/services/tests/fetchers/mod.rs
+++ b/rust/src/services/tests/fetchers/mod.rs
@@ -1,0 +1,32 @@
+use tokio_test::assert_ready;
+use tower_test::mock::Spawn;
+
+use crate::{
+    services::{
+        fetchers::{MaskLengthRequest, MaskLengthService},
+        tests::utils::new_event_channels,
+    },
+    state_machine::events::MaskLengthUpdate,
+};
+
+#[tokio::test]
+async fn test_mask_length_svc() {
+    let (mut publisher, subscriber) = new_event_channels();
+
+    let mut task = Spawn::new(MaskLengthService::new(&subscriber));
+    assert_ready!(task.poll_ready()).unwrap();
+
+    let resp = task.call(MaskLengthRequest).await;
+    assert_eq!(resp, Ok(None));
+
+    let round_id = subscriber.params_listener().get_latest().round_id;
+    publisher.broadcast_mask_length(round_id.clone(), MaskLengthUpdate::New(42));
+    assert_ready!(task.poll_ready()).unwrap();
+    let resp = task.call(MaskLengthRequest).await;
+    assert_eq!(resp, Ok(Some(42)));
+
+    publisher.broadcast_mask_length(round_id, MaskLengthUpdate::Invalidate);
+    assert_ready!(task.poll_ready()).unwrap();
+    let resp = task.call(MaskLengthRequest).await;
+    assert_eq!(resp, Ok(None));
+}

--- a/rust/src/services/tests/fetchers/mod.rs
+++ b/rust/src/services/tests/fetchers/mod.rs
@@ -4,12 +4,23 @@ use tokio_test::assert_ready;
 use tower_test::mock::Spawn;
 
 use crate::{
+    crypto::{ByteObject, PublicEncryptKey},
     mask::Model,
     services::{
-        fetchers::{MaskLengthRequest, MaskLengthService, ModelRequest, ModelService},
+        fetchers::{
+            MaskLengthRequest,
+            MaskLengthService,
+            ModelRequest,
+            ModelService,
+            RoundParamsRequest,
+            RoundParamsService,
+        },
         tests::utils::new_event_channels,
     },
-    state_machine::events::{MaskLengthUpdate, ModelUpdate},
+    state_machine::{
+        coordinator::{RoundParameters, RoundSeed},
+        events::{MaskLengthUpdate, ModelUpdate},
+    },
 };
 
 #[tokio::test]
@@ -55,4 +66,27 @@ async fn test_model_svc() {
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(ModelRequest).await;
     assert_eq!(resp, Ok(None));
+}
+
+#[tokio::test]
+async fn test_round_params_svc() {
+    let (mut publisher, subscriber) = new_event_channels();
+    let initial_params = subscriber.params_listener().get_latest().event;
+
+    let mut task = Spawn::new(RoundParamsService::new(&subscriber));
+    assert_ready!(task.poll_ready()).unwrap();
+
+    let resp = task.call(RoundParamsRequest).await;
+    assert_eq!(resp, Ok(initial_params));
+
+    let params = RoundParameters {
+        pk: PublicEncryptKey::from_slice(&vec![0x11; PublicEncryptKey::LENGTH]).unwrap(),
+        sum: 0.42,
+        update: 0.42,
+        seed: RoundSeed::from_slice(&vec![0x11; RoundSeed::LENGTH]).unwrap(),
+    };
+    publisher.broadcast_params(params.clone());
+    assert_ready!(task.poll_ready()).unwrap();
+    let resp = task.call(RoundParamsRequest).await;
+    assert_eq!(resp, Ok(params));
 }

--- a/rust/src/services/tests/fetchers/mod.rs
+++ b/rust/src/services/tests/fetchers/mod.rs
@@ -1,12 +1,15 @@
+use std::sync::Arc;
+
 use tokio_test::assert_ready;
 use tower_test::mock::Spawn;
 
 use crate::{
+    mask::Model,
     services::{
-        fetchers::{MaskLengthRequest, MaskLengthService},
+        fetchers::{MaskLengthRequest, MaskLengthService, ModelRequest, ModelService},
         tests::utils::new_event_channels,
     },
-    state_machine::events::MaskLengthUpdate,
+    state_machine::events::{MaskLengthUpdate, ModelUpdate},
 };
 
 #[tokio::test]
@@ -28,5 +31,28 @@ async fn test_mask_length_svc() {
     publisher.broadcast_mask_length(round_id, MaskLengthUpdate::Invalidate);
     assert_ready!(task.poll_ready()).unwrap();
     let resp = task.call(MaskLengthRequest).await;
+    assert_eq!(resp, Ok(None));
+}
+
+#[tokio::test]
+async fn test_model_svc() {
+    let (mut publisher, subscriber) = new_event_channels();
+
+    let mut task = Spawn::new(ModelService::new(&subscriber));
+    assert_ready!(task.poll_ready()).unwrap();
+
+    let resp = task.call(ModelRequest).await;
+    assert_eq!(resp, Ok(None));
+
+    let round_id = subscriber.params_listener().get_latest().round_id;
+    let model = Arc::new(Model::from(vec![]));
+    publisher.broadcast_model(round_id.clone(), ModelUpdate::New(model.clone()));
+    assert_ready!(task.poll_ready()).unwrap();
+    let resp = task.call(ModelRequest).await;
+    assert_eq!(resp, Ok(Some(model)));
+
+    publisher.broadcast_model(round_id, ModelUpdate::Invalidate);
+    assert_ready!(task.poll_ready()).unwrap();
+    let resp = task.call(ModelRequest).await;
     assert_eq!(resp, Ok(None));
 }

--- a/rust/src/services/tests/mod.rs
+++ b/rust/src/services/tests/mod.rs
@@ -1,0 +1,2 @@
+mod fetchers;
+mod utils;

--- a/rust/src/services/tests/utils.rs
+++ b/rust/src/services/tests/utils.rs
@@ -1,0 +1,23 @@
+use crate::{
+    crypto::{ByteObject, EncryptKeyPair, PublicEncryptKey, SecretEncryptKey},
+    state_machine::{
+        coordinator::{RoundParameters, RoundSeed},
+        events::{EventPublisher, EventSubscriber, PhaseEvent},
+    },
+    CoordinatorPublicKey,
+};
+
+pub fn new_event_channels() -> (EventPublisher, EventSubscriber) {
+    let keys = EncryptKeyPair {
+        public: PublicEncryptKey::zeroed(),
+        secret: SecretEncryptKey::zeroed(),
+    };
+    let params = RoundParameters {
+        pk: CoordinatorPublicKey::zeroed(),
+        sum: 0.0,
+        update: 0.0,
+        seed: RoundSeed::zeroed(),
+    };
+    let phase = PhaseEvent::Idle;
+    EventPublisher::init(keys, params, phase)
+}

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -1,7 +1,7 @@
 //! Coordinator state and round parameter types.
 use std::collections::HashMap;
 
-use sodiumoxide::{self, crypto::box_, randombytes::randombytes};
+use sodiumoxide::{self, crypto::box_};
 
 use crate::{
     crypto::{encrypt::EncryptKeyPair, ByteObject},
@@ -74,6 +74,8 @@ impl CoordinatorState {
 pub struct RoundSeed(box_::Seed);
 
 impl ByteObject for RoundSeed {
+    const LENGTH: usize = box_::SEEDBYTES;
+
     /// Creates a round seed from a slice of bytes.
     ///
     /// # Errors
@@ -90,17 +92,6 @@ impl ByteObject for RoundSeed {
     /// Gets the round seed as a slice.
     fn as_slice(&self) -> &[u8] {
         self.0.as_ref()
-    }
-}
-
-impl RoundSeed {
-    /// Gets the number of bytes of a round seed.
-    pub const LENGTH: usize = box_::SEEDBYTES;
-
-    /// Generates a random round seed.
-    pub fn generate() -> Self {
-        // Safe unwrap: length of slice is guaranteed by constants
-        Self::from_slice_unchecked(randombytes(Self::LENGTH).as_slice())
     }
 }
 

--- a/rust/src/state_machine/coordinator.rs
+++ b/rust/src/state_machine/coordinator.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 /// The round parameters.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RoundParameters {
     /// The public key of the coordinator used for encryption.
     pub pk: CoordinatorPublicKey,


### PR DESCRIPTION
- add two new dev dependencies: `tokio-test` and `tower-test`.
- add a `LENGTH` associated constant to the `ByteObject` trait (see: https://github.com/xainag/xain-fl/pull/457/commits/fa1160f617e96e928f1bb04085346fe8b56dc3f3). This was necessary to implement the very convenient helper `ByteObject::fill_with` (see: https://github.com/xainag/xain-fl/pull/457/commits/372acd144ab7e8b7d0ec49378a2dacda5e907549)

The rest is just boring test boilerplate in `rust/src/services/tests/fetchers/mod.rs`.

Commits are independent and can be reviewed separately.